### PR TITLE
新增使用者種子腳本

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -9,6 +9,16 @@ npm install
 npm start                 # 啟動伺服器
 ```
 
+執行 `npm run seed` 可建立預設帳號，方便初次測試。
+
+預設登入資訊如下：
+
+| 帳號 | 密碼  | 角色 |
+|------|-------|------|
+| employee  | 123456 | employee |
+| manager   | 123456 | manager  |
+| outsource | 123456 | outsource |
+
 啟動後，可透過 `/static/<檔名>` 存取上傳檔案，API 根路徑為 `/api/*`。
 
 ---

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon src/server.js",
-    "start": "node src/server.js"
+    "start": "node src/server.js",
+    "seed": "node src/scripts/seedUsers.js"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -1,0 +1,35 @@
+import dotenv from 'dotenv'
+import mongoose from 'mongoose'
+import bcrypt from 'bcryptjs'
+import User from '../models/user.model.js'
+import { ROLES } from '../config/roles.js'
+
+dotenv.config()
+
+const users = [
+  { username: 'employee', password: '123456', email: 'employee@example.com', role: ROLES.EMPLOYEE },
+  { username: 'manager', password: '123456', email: 'manager@example.com', role: ROLES.MANAGER },
+  { username: 'outsource', password: '123456', email: 'outsource@example.com', role: ROLES.OUTSOURCE }
+]
+
+const seed = async () => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI)
+    console.log('✅ MongoDB 已連線')
+
+    await User.deleteMany({})
+
+    for (const user of users) {
+      user.password = await bcrypt.hash(user.password, 10)
+    }
+
+    await User.insertMany(users)
+    console.log('📌 預設帳號建立完成')
+  } catch (err) {
+    console.error('❌ 建立帳號失敗：', err.message)
+  } finally {
+    await mongoose.disconnect()
+  }
+}
+
+seed()


### PR DESCRIPTION
## Summary
- 新增 `seedUsers.js` 腳本，連線至資料庫並建立三種角色帳號
- `server/package.json` 增加 `seed` 指令
- `server/README.md` 說明如何執行種子腳本並列出預設帳號資訊

## Testing
- `npm --prefix server run seed` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6841c64cd1888329baa8ae55430d1aee