### PR TITLE
Add login test with Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@
    ```
    伺服器啟動後，API 根路徑為 `http://localhost:3000/api`，
    靜態檔案可自 `/static/<檔名>` 存取。
+3. 進行登入測試：
+   ```bash
+   npm test
+   ```
+   這會在 `server` 目錄執行 Jest 測試，模擬 POST `/api/auth/login`。
 
 ## 根目錄一鍵啟動
 根目錄已新增 `package.json`，安裝相依套件後即可同時啟動前後端：

--- a/server/README.md
+++ b/server/README.md
@@ -22,5 +22,10 @@ npm start                 # 啟動伺服器
    # 登入
    curl -X POST http://localhost:3000/api/auth/login \
      -H "Content-Type: application/json" \
-     -d '{"username":"admin","password":"mypwd"}'
+   -d '{"username":"admin","password":"mypwd"}'
    ```
+5. 執行自動化測試：
+   ```bash
+   npm test
+   ```
+   透過 Jest 與 Supertest 模擬登入，確認回傳資料包含 `token` 與 `user.role`。

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon src/server.js",
-    "start": "node src/server.js"
+    "start": "node src/server.js",
+    "test": "jest --experimental-vm-modules"
   },
   "dependencies": {
     "express": "^4.19.2",
@@ -17,6 +18,12 @@
     "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.0"
+    "nodemon": "^3.1.0",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3",
+    "mongodb-memory-server": "^8.12.1"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,0 +1,45 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import authRoutes from '../src/routes/auth.routes.js'
+import User from '../src/models/user.model.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+
+let mongo
+let app
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+
+  await User.create({
+    username: 'admin',
+    password: 'mypwd',
+    email: 'admin@example.com',
+    role: 'manager'
+  })
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+describe('POST /api/auth/login', () => {
+  it('should return token and user role when credentials are correct', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: 'admin', password: 'mypwd' })
+      .expect(200)
+
+    expect(res.body).toHaveProperty('token')
+    expect(res.body).toHaveProperty('user.role')
+  })
+})


### PR DESCRIPTION
## Summary
- add supertest login test under `server/tests/`
- update backend package.json with Jest configuration
- document how to run `npm test` in README files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c64fa4d0832997f72ee6b7411bbd