### PR TITLE
新增暗黑模式與雛形頁面

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,5 +1,9 @@
 <script setup>
-// 根應用，僅負責渲染 <router-view/>
+import { onMounted } from 'vue'
+import { useThemeStore } from './stores/theme'
+
+const theme = useThemeStore()
+onMounted(() => theme.init())
 </script>
 
 <template>

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { useAuthStore } from '../stores/auth'
 import { useRouter } from 'vue-router'
+import ThemeToggle from './ThemeToggle.vue'
 
 const store = useAuthStore()
 const router = useRouter()
@@ -51,6 +52,9 @@ const navItems = computed(() => menus[store.role] ?? [])
         >
           登出
         </button>
+      </li>
+      <li>
+        <ThemeToggle />
       </li>
     </ul>
   </aside>

--- a/client/src/components/ThemeToggle.vue
+++ b/client/src/components/ThemeToggle.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { computed } from 'vue'
+import { useThemeStore } from '../stores/theme'
+
+const theme = useThemeStore()
+
+const label = computed(() => (theme.dark ? '切換為白天模式' : '切換為黑夜模式'))
+const icon = computed(() => (theme.dark ? '🌞' : '🌙'))
+</script>
+
+<template>
+  <button @click="theme.toggle()" class="w-full py-2 mt-4 rounded bg-blue-600 hover:bg-blue-700 text-white">
+    {{ icon }} {{ label }}
+  </button>
+</template>

--- a/client/src/stores/theme.js
+++ b/client/src/stores/theme.js
@@ -1,0 +1,17 @@
+import { defineStore } from 'pinia'
+
+export const useThemeStore = defineStore('theme', {
+  state: () => ({
+    dark: localStorage.getItem('theme') === 'dark'
+  }),
+  actions: {
+    toggle() {
+      this.dark = !this.dark
+      localStorage.setItem('theme', this.dark ? 'dark' : 'light')
+      document.body.classList.toggle('dark', this.dark)
+    },
+    init() {
+      document.body.classList.toggle('dark', this.dark)
+    }
+  }
+})

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -11,6 +11,13 @@
   font-family: 'Noto Sans TC', 'Helvetica Neue', Arial, sans-serif;
 }
 
+body.dark {
+  --bg-color: #1f2937;
+  --text-color: #f8fafc;
+  --sidebar-bg: #1e293b;
+  --sidebar-hover: #334155;
+}
+
 body {
   margin: 0;
   background-color: var(--bg-color);

--- a/client/src/views/Account.vue
+++ b/client/src/views/Account.vue
@@ -2,5 +2,6 @@
 </script>
 
 <template>
-  <h1 class="text-2xl font-bold">這裡是 XXX 頁面，待實作</h1>
+  <h1 class="text-2xl font-bold mb-4">帳號資訊</h1>
+  <p>此處將提供使用者更新個人資料。</p>
 </template>

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -2,5 +2,6 @@
 </script>
 
 <template>
-  <h1 class="text-2xl font-bold">這裡是 XXX 頁面，待實作</h1>
+  <h1 class="text-2xl font-bold mb-4">素材庫</h1>
+  <p>後續將在此列出上傳的素材列表。</p>
 </template>

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -2,5 +2,6 @@
 </script>
 
 <template>
-  <h1 class="text-2xl font-bold">這裡是 XXX 頁面，待實作</h1>
+  <h1 class="text-2xl font-bold mb-4">儀表板</h1>
+  <p>這裡將顯示專案總覽與統計資訊。</p>
 </template>

--- a/client/src/views/Progress.vue
+++ b/client/src/views/Progress.vue
@@ -2,5 +2,6 @@
 </script>
 
 <template>
-  <h1 class="text-2xl font-bold">這裡是 XXX 頁面，待實作</h1>
+  <h1 class="text-2xl font-bold mb-4">進度追蹤</h1>
+  <p>後續將在此顯示各項任務的進度。</p>
 </template>


### PR DESCRIPTION
## Summary
- 加入可切換白天/黑夜模式的功能
- 更新 Sidebar 以放入切換按鈕
- 增加 ThemeToggle 元件與 Pinia store
- 調整全域 CSS 以支援深色主題
- 完成 Dashboard、Account、AssetLibrary、Progress 四個頁面雛形

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e1b99c948329bc46abdc04a60d8f