### PR TITLE
Integrate Element Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 影片素材與進度追蹤系統
 
 此專案包含前端與後端兩個部分，分別位於 `client/` 與 `server/` 目錄。
-前端採用 **Vue 3 + Vite**，後端則使用 **Node.js + Express** 搭配 **MongoDB**。
+前端採用 **Vue 3 + Vite** 並整合 **Element Plus**，後端則使用 **Node.js + Express** 搭配 **MongoDB**。
 
 ## 前端 (client)
 1. 進入 `client` 目錄安裝依賴：

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,8 @@
     "js-cookie": "^3.0.5",
     "pinia": "^3.0.3",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "element-plus": "^2.7.2"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -3,8 +3,11 @@ import { createPinia } from 'pinia'
 import router from './router'
 import App from './App.vue'
 import './style.css'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
 
 const app = createApp(App)
 app.use(createPinia())
+app.use(ElementPlus)
 app.use(router)
 app.mount('#app')

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -20,28 +20,17 @@ const onSubmit = async () => {
 
 <template>
   <div class="h-screen flex items-center justify-center bg-gray-100">
-    <form
+    <el-form
       @submit.prevent="onSubmit"
       class="w-80 bg-white rounded-2xl shadow-xl p-8 space-y-6"
     >
       <h1 class="text-2xl text-center font-bold">系統登入</h1>
-      <input v-model="username" placeholder="使用者名稱" class="input" required />
-      <input
-        v-model="password"
-        type="password"
-        placeholder="密碼"
-        class="input"
-        required
-      />
-      <button class="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded">
-        登入
-      </button>
-    </form>
+      <el-input v-model="username" placeholder="使用者名稱" clearable />
+      <el-input v-model="password" type="password" placeholder="密碼" show-password />
+      <el-button type="primary" class="w-full" native-type="submit">登入</el-button>
+    </el-form>
   </div>
 </template>
 
 <style scoped>
-.input {
-  @apply w-full border rounded px-3 py-2 focus:outline-none focus:ring;
-}
 </style>


### PR DESCRIPTION
## Summary
- update README to mention Element Plus
- install Element Plus on frontend
- set up Element Plus in `main.js`
- convert login page to use Element Plus components

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e69c68f8832988b2d4c5adb8629b