### PR TITLE
新增資料夾管理功能

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -1,0 +1,16 @@
+import api from './api'
+
+export const fetchAssets = (folderId = null) => {
+  const params = {}
+  if (folderId) params.folderId = folderId
+  return api.get('/assets', { params }).then((res) => res.data)
+}
+
+export const uploadAsset = (file, folderId) => {
+  const formData = new FormData()
+  formData.append('file', file)
+  if (folderId) formData.append('folderId', folderId)
+  return api.post('/assets/upload', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  }).then((res) => res.data)
+}

--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -1,0 +1,19 @@
+import api from './api'
+
+export const fetchFolders = (parentId = null) => {
+  const params = {}
+  if (parentId) params.parentId = parentId
+  return api.get('/folders', { params }).then((res) => res.data)
+}
+
+export const createFolder = (data) => {
+  return api.post('/folders', data).then((res) => res.data)
+}
+
+export const getFolder = (id) => {
+  return api.get(`/folders/${id}`).then((res) => res.data)
+}
+
+export const updateFolder = (id, data) => {
+  return api.put(`/folders/${id}`, data).then((res) => res.data)
+}

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -1,7 +1,96 @@
 <script setup>
+import { ref, onMounted } from 'vue'
+import { fetchFolders, createFolder, updateFolder, getFolder } from '../services/folders'
+import { fetchAssets, uploadAsset } from '../services/assets'
+
+const folders = ref([])
+const assets = ref([])
+const currentFolder = ref(null)
+const detail = ref({ description: '', script: '' })
+const showDetail = ref(false)
+const newFolderName = ref('')
+
+const loadData = async (id = null) => {
+  folders.value = await fetchFolders(id)
+  assets.value = await fetchAssets(id)
+  currentFolder.value = id ? await getFolder(id) : null
+}
+
+onMounted(() => loadData())
+
+const openFolder = (f) => {
+  loadData(f._id)
+}
+
+const goUp = () => {
+  loadData(currentFolder.value?.parentId || null)
+}
+
+const saveDetail = async () => {
+  if (!currentFolder.value) return
+  await updateFolder(currentFolder.value._id, detail.value)
+  showDetail.value = false
+  loadData(currentFolder.value._id)
+}
+
+const showDetailFor = (f) => {
+  currentFolder.value = f
+  detail.value.description = f.description || ''
+  detail.value.script = f.script || ''
+  showDetail.value = true
+}
+
+const createNewFolder = async () => {
+  if (!newFolderName.value) return
+  await createFolder({ name: newFolderName.value, parentId: currentFolder.value?._id })
+  newFolderName.value = ''
+  loadData(currentFolder.value?._id)
+}
+
+const onFileChange = async (e) => {
+  const file = e.target.files[0]
+  if (!file) return
+  await uploadAsset(file, currentFolder.value?._id)
+  loadData(currentFolder.value?._id)
+}
 </script>
 
 <template>
   <h1 class="text-2xl font-bold mb-4">素材庫</h1>
-  <p>後續將在此列出上傳的素材列表。</p>
+  <div class="mb-4 flex gap-2">
+    <el-button @click="goUp" :disabled="!currentFolder">返回上層</el-button>
+    <el-input v-model="newFolderName" placeholder="新增資料夾名稱" class="w-40" />
+    <el-button type="primary" @click="createNewFolder">新增資料夾</el-button>
+    <input type="file" @change="onFileChange" />
+  </div>
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <el-card v-for="f in folders" :key="f._id" class="cursor-pointer">
+      <template #header>
+        <div class="flex justify-between items-center">
+          <span @click="openFolder(f)">📁 {{ f.name }}</span>
+          <el-button size="small" @click.stop="showDetailFor(f)">詳細</el-button>
+        </div>
+      </template>
+    </el-card>
+    <el-card v-for="a in assets" :key="a._id">
+      {{ a.filename }}
+    </el-card>
+  </div>
+  <el-dialog v-model="showDetail" title="資料夾資訊">
+    <el-form @submit.prevent>
+      <el-form-item label="描述">
+        <el-input v-model="detail.description" type="textarea" />
+      </el-form-item>
+      <el-form-item label="腳本需求">
+        <el-input v-model="detail.script" type="textarea" />
+      </el-form-item>
+    </el-form>
+    <template #footer>
+      <el-button @click="showDetail = false">取消</el-button>
+      <el-button type="primary" @click="saveDetail">儲存</el-button>
+    </template>
+  </el-dialog>
 </template>
+
+<style scoped>
+</style>

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -7,14 +7,18 @@ export const uploadFile = async (req, res) => {
     filename: req.file.filename,
     path: req.file.path,
     type: req.body.type || 'raw',
-    uploadedBy: req.user._id
+    uploadedBy: req.user._id,
+    folderId: req.body.folderId || null
   })
   res.status(201).json(asset)
 }
 
 /* ---------- GET /api/assets ---------- */
 export const getAssets = async (req, res) => {
-  const assets = await Asset.find({ allowRoles: req.user.role })
+  const query = { allowRoles: req.user.role }
+  if (req.query.folderId) query.folderId = req.query.folderId
+  else query.folderId = null
+  const assets = await Asset.find(query)
   res.json(assets)
 }
 

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -1,0 +1,29 @@
+import Folder from '../models/folder.model.js'
+
+export const createFolder = async (req, res) => {
+  const folder = await Folder.create({
+    name: req.body.name,
+    parentId: req.body.parentId || null,
+    description: req.body.description,
+    script: req.body.script
+  })
+  res.status(201).json(folder)
+}
+
+export const getFolders = async (req, res) => {
+  const parentId = req.query.parentId || null
+  const folders = await Folder.find({ parentId })
+  res.json(folders)
+}
+
+export const getFolder = async (req, res) => {
+  const folder = await Folder.findById(req.params.id)
+  if (!folder) return res.status(404).json({ message: '找不到資料夾' })
+  res.json(folder)
+}
+
+export const updateFolder = async (req, res) => {
+  const folder = await Folder.findByIdAndUpdate(req.params.id, req.body, { new: true })
+  if (!folder) return res.status(404).json({ message: '資料夾不存在' })
+  res.json(folder)
+}

--- a/server/src/models/asset.model.js
+++ b/server/src/models/asset.model.js
@@ -18,6 +18,7 @@ const assetSchema = new mongoose.Schema(
     path: { type: String, required: true },
     type: { type: String, enum: ['raw', 'edited'], default: 'raw' },
     uploadedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    folderId: { type: mongoose.Schema.Types.ObjectId, ref: 'Folder', default: null },
     allowRoles: {
       type: [String],
       enum: Object.values(ROLES),

--- a/server/src/models/folder.model.js
+++ b/server/src/models/folder.model.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose'
+
+const folderSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    parentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Folder', default: null },
+    description: { type: String },
+    script: { type: String }
+  },
+  { timestamps: true }
+)
+
+export default mongoose.model('Folder', folderSchema)

--- a/server/src/routes/folder.routes.js
+++ b/server/src/routes/folder.routes.js
@@ -1,0 +1,17 @@
+import { Router } from 'express'
+import { protect } from '../middleware/auth.js'
+import {
+  createFolder,
+  getFolders,
+  getFolder,
+  updateFolder
+} from '../controllers/folder.controller.js'
+
+const router = Router()
+
+router.post('/', protect, createFolder)
+router.get('/', protect, getFolders)
+router.get('/:id', protect, getFolder)
+router.put('/:id', protect, updateFolder)
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -30,6 +30,7 @@ app.use('/static', express.static(path.resolve(uploadDir)))
 import authRoutes from './routes/auth.routes.js'
 import userRoutes from './routes/user.routes.js'
 import assetRoutes from './routes/asset.routes.js'
+import folderRoutes from './routes/folder.routes.js'
 import taskRoutes from './routes/task.routes.js'
 import progressRoutes from './routes/progress.routes.js'
 import analyticsRoutes from './routes/analytics.routes.js'
@@ -38,6 +39,7 @@ import healthRoutes from './routes/health.routes.js'
 app.use('/api/auth', authRoutes)
 app.use('/api/user', userRoutes)
 app.use('/api/assets', assetRoutes)
+app.use('/api/folders', folderRoutes)
 app.use('/api/tasks', taskRoutes)
 app.use('/api/progress', progressRoutes)
 app.use('/api/analytics', analyticsRoutes)


### PR DESCRIPTION
## Summary
- 後端新增 `Folder` model 與 CRUD API
- `Asset` model 支援 `folderId`，並調整 controller
- 前端 `AssetLibrary` 加入資料夾瀏覽與上傳/編輯介面
- 新增 `assets.js`、`folders.js` service

## Testing
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684337b0f01883299839dd976efa29f8