### PR TITLE
新增側邊欄收合功能

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useAuthStore } from '../stores/auth'
 import { useRouter } from 'vue-router'
 import ThemeToggle from './ThemeToggle.vue'
@@ -30,11 +30,16 @@ const menus = {
 
 /* ---------- 目前使用者可見選單 ---------- */
 const navItems = computed(() => menus[store.role] ?? [])
+const isCollapsed = ref(false)
 </script>
 
 <template>
-  <aside class="w-60 bg-slate-800 text-white h-screen p-4">
-    <h2 class="text-xl font-bold mb-6">系統選單</h2>
+  <aside :class="[isCollapsed ? 'w-16' : 'w-60', 'bg-slate-800 text-white h-screen p-4 transition-all']">
+    <button @click="isCollapsed = !isCollapsed" class="mb-4 w-full text-right">
+      <span v-if="isCollapsed">➡️</span>
+      <span v-else>⬅️</span>
+    </button>
+    <h2 v-if="!isCollapsed" class="text-xl font-bold mb-6">系統選單</h2>
     <ul>
       <li v-for="item in navItems" :key="item.path" class="mb-3">
         <a
@@ -42,19 +47,20 @@ const navItems = computed(() => menus[store.role] ?? [])
           class="flex items-center gap-2 hover:text-amber-300 transition"
         >
           <span>{{ item.icon }}</span>
-          <span>{{ item.label }}</span>
+          <span v-if="!isCollapsed">{{ item.label }}</span>
         </a>
       </li>
       <li class="mt-10">
         <button
           @click="store.logout(); router.push('/login')"
-          class="w-full bg-red-600 hover:bg-red-700 py-2 rounded"
+          class="w-full bg-red-600 hover:bg-red-700 py-2 rounded flex items-center justify-center gap-2"
         >
-          登出
+          <span>🚪</span>
+          <span v-if="!isCollapsed">登出</span>
         </button>
       </li>
       <li>
-        <ThemeToggle />
+        <ThemeToggle :collapsed="isCollapsed" />
       </li>
     </ul>
   </aside>

--- a/client/src/components/ThemeToggle.vue
+++ b/client/src/components/ThemeToggle.vue
@@ -2,6 +2,10 @@
 import { computed } from 'vue'
 import { useThemeStore } from '../stores/theme'
 
+const props = defineProps({
+  collapsed: Boolean
+})
+
 const theme = useThemeStore()
 
 const label = computed(() => (theme.dark ? '切換為白天模式' : '切換為黑夜模式'))
@@ -9,7 +13,8 @@ const icon = computed(() => (theme.dark ? '🌞' : '🌙'))
 </script>
 
 <template>
-  <button @click="theme.toggle()" class="w-full py-2 mt-4 rounded bg-blue-600 hover:bg-blue-700 text-white">
-    {{ icon }} {{ label }}
+  <button @click="theme.toggle()" class="w-full py-2 mt-4 rounded bg-blue-600 hover:bg-blue-700 text-white flex items-center justify-center">
+    <span>{{ icon }}</span>
+    <span v-if="!props.collapsed" class="ml-2">{{ label }}</span>
   </button>
 </template>


### PR DESCRIPTION
## Summary
- Sidebar 加入 `isCollapsed` 狀態，可在寬版與縮起之間切換
- 登出與主題切換按鈕在收合後仍顯示圖示
- ThemeToggle 新增 `collapsed` prop，依狀態隱藏文字

## Testing
- `npm --prefix server test` *(失敗：jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684337ac96788329847e91aa6701d77d