### PR TITLE
Add auth service and refactor login action

### DIFF
--- a/client/src/services/auth.js
+++ b/client/src/services/auth.js
@@ -1,0 +1,7 @@
+import api from './api'
+
+export const login = credentials =>
+  api.post('/auth/login', credentials).then(res => res.data)
+
+export const register = data =>
+  api.post('/auth/register', data).then(res => res.data)

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import Cookies from 'js-cookie'
 import api from '../services/api'
+import { login as loginService } from '../services/auth'
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
@@ -14,7 +15,7 @@ export const useAuthStore = defineStore('auth', {
   actions: {
     /* ---------- 登入 ---------- */
     async login(username, password) {
-      const { data } = await api.post('/auth/login', { username, password })
+      const data = await loginService({ username, password })
       this.token = data.token
       Cookies.set('token', data.token, { secure: true })
       this.user = data.user


### PR DESCRIPTION
## Summary
- implement `login` and `register` helpers in auth service
- refactor auth store to use the new service

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684463a6713c83298f046c7a1fc43233