### PR TITLE
新增近期紀錄及素材 API

### DIFF
--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -62,3 +62,13 @@ export const deleteAsset = async (req, res) => {
   await Asset.findByIdAndDelete(req.params.id)
   res.json({ message: '素材已刪除' })
 }
+
+/* ---------- 依 limit 取得最新素材 ---------- */
+export const getRecentAssets = async (req, res) => {
+  const limit = Number(req.query.limit) || 5
+  const query = { allowRoles: req.user.role }
+  const assets = await Asset.find(query)
+    .sort({ createdAt: -1 })
+    .limit(limit)
+  res.json(assets)
+}

--- a/server/src/controllers/progress.controller.js
+++ b/server/src/controllers/progress.controller.js
@@ -36,3 +36,12 @@ export const deleteTemplate = async (req, res) => {
   await tpl.deleteOne()
   res.json({ message: '已刪除' })
 }
+
+/* ---------- 依 limit 取得最新紀錄 ---------- */
+export const getRecentRecords = async (req, res) => {
+  const limit = Number(req.query.limit) || 5
+  const recs = await ProgressRecord.find()
+    .sort({ createdAt: -1 })
+    .limit(limit)
+  res.json(recs)
+}

--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -6,7 +6,8 @@ import {
     getAssets,
     addComment,
     updateAsset,
-    deleteAsset      // ★ 新增
+    deleteAsset,      // ★ 新增
+    getRecentAssets
 } from '../controllers/asset.controller.js'
 
 const router = Router()
@@ -14,6 +15,7 @@ const router = Router()
 router.post('/upload', protect, upload.single('file'), uploadFile)
 router.get('/', protect, getAssets)
 router.post('/:id/comment', protect, addComment)
+router.get('/recent', protect, getRecentAssets)
 
 /* ★ 新增：更新檔名／描述 */
 router.put('/:id', protect, updateAsset)

--- a/server/src/routes/progress.routes.js
+++ b/server/src/routes/progress.routes.js
@@ -3,7 +3,8 @@ import { protect } from '../middleware/auth.js'
 import {
   createTemplate,  getTemplates,
   updateTemplate,  deleteTemplate,   // ← 新增
-  createRecord,    getRecords
+  createRecord,    getRecords,
+  getRecentRecords
 } from '../controllers/progress.controller.js'
 
 const router = Router()
@@ -15,6 +16,7 @@ router.delete('/templates/:id', protect, deleteTemplate) // ★
 
 router.get ('/records/:tplId', protect, getRecords)
 router.post('/records',       protect, createRecord)
+router.get ('/recent', protect, getRecentRecords)
 
 export default router
 


### PR DESCRIPTION
## Summary
- 新增 `getRecentRecords` 取得近期進度紀錄
- 新增 `getRecentAssets` 取得近期素材
- 路由 `/progress/recent`、`/assets/recent` 對應上述 API

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684463aa6e388329b7f2794732cda11a