### PR TITLE
新增帳號個人資料路由

### DIFF
--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -45,3 +45,24 @@ export const deleteUser = async (req,res) => {
   await User.findByIdAndDelete(req.params.id)
   res.json({ message:'已刪除' })
 }
+
+/* 取得個人資料 */
+export const getProfile = async (req,res) => {
+  res.json(req.user)
+}
+
+/* 更新個人資料 */
+export const updateProfile = async (req,res) => {
+  const { username,email,password } = req.body
+  const u = await User.findById(req.user._id)
+  if (!u) return res.status(404).json({ message:'找不到使用者' })
+  if (username && username!==u.username && await User.findOne({ username }))
+    return res.status(400).json({ message:'使用者已存在' })
+  if (email && email!==u.email && await User.findOne({ email }))
+    return res.status(400).json({ message:'Email 已存在' })
+  if (username) u.username = username
+  if (email)    u.email    = email
+  if (password) u.password = await bcrypt.hash(password,12)
+  await u.save()
+  res.json(u)
+}

--- a/server/src/routes/user.routes.js
+++ b/server/src/routes/user.routes.js
@@ -1,12 +1,19 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
 import {
-  getAllUsers, createUser, updateUser, deleteUser
+  getAllUsers,
+  createUser,
+  updateUser,
+  deleteUser,
+  getProfile,
+  updateProfile
 } from '../controllers/user.controller.js'
 
 const router = Router()
 
 router.use(protect)               // 登入保護
+router.get('/profile', getProfile)
+router.put('/profile', updateProfile)
 
 router
   .route('/')


### PR DESCRIPTION
## Summary
- 新增 `getProfile`、`updateProfile` 控制器
- `/api/user/profile` 增加 GET 及 PUT 路由

## Testing
- `npm test --prefix server` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684463ac1e0c832993026ee2b8b964fe