### PR TITLE
Add employee manager route

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -71,6 +71,7 @@ const menus = {
     { path: '/', icon: '🏠', label: '首頁' },
     { path: '/progress', icon: '📈', label: '進度追踪' },
     { path: '/assets', icon: '🎞️', label: '素材庫' },
+    { path: '/employees', icon: '👥', label: '人員管理' },
     { path: '/account', icon: '👤', label: '帳號資訊' }
   ],
   outsource: [

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -7,6 +7,7 @@ import Dashboard from '../views/Dashboard.vue'
 import Account from '../views/Account.vue'
 import Progress from '../views/Progress.vue'
 import AssetLibrary from '../views/AssetLibrary.vue'
+import EmployeeManager from '../views/EmployeeManager.vue'
 
 const routes = [
   {
@@ -22,7 +23,8 @@ const routes = [
       { path: '', name: 'Dashboard', component: Dashboard },
       { path: 'account', name: 'Account', component: Account },
       { path: 'progress', name: 'Progress', component: Progress },
-      { path: 'assets', name: 'Assets', component: AssetLibrary }
+      { path: 'assets', name: 'Assets', component: AssetLibrary },
+      { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { role: 'manager' } }
     ]
   },
   // 404
@@ -41,6 +43,7 @@ router.beforeEach((to) => {
 
   // 若尚未登入，導向 login
   if (!store.isAuthenticated) return '/login'
+  if (to.meta.role && store.role !== to.meta.role) return '/'
   return true
 })
 


### PR DESCRIPTION
## Summary
- add EmployeeManager route for managers only
- show new link in sidebar for manager role

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844665ae3fc832989d05ff6bdedd437