### PR TITLE
Implement role-based select options

### DIFF
--- a/client/src/services/user.js
+++ b/client/src/services/user.js
@@ -1,8 +1,8 @@
 // src/services/users.js
 import api from './api'
 
-export const fetchUsers = () =>
-  api.get('/user').then(r => r.data)          // GET /api/user   (全部)
+export const fetchUsers = (params = {}) =>
+  api.get('/user', { params }).then(r => r.data)          // GET /api/user
 
 export const createUser = data =>
   api.post('/user', data).then(r => r.data)   // POST /api/user

--- a/server/src/models/progressTemplate.model.js
+++ b/server/src/models/progressTemplate.model.js
@@ -2,11 +2,17 @@
  * \u81ea\u5b9a\u7fa9\u9032\u5ea6\u8ffd\u8e64\u300c\u6b04\u4f4d\u6a21\u677f\u300d
  */
 import mongoose from 'mongoose'
+import { ROLES } from '../config/roles.js'
 
 const fieldSchema = new mongoose.Schema(
   {
     fieldName: { type: String, required: true },
-    fieldType: { type: String, enum: ['string', 'date', 'number'], default: 'string' }
+    fieldType: {
+      type: String,
+      enum: ['string', 'date', 'number', 'select'],
+      default: 'string'
+    },
+    optionsRole: { type: String, enum: Object.values(ROLES) }
   },
   { _id: false }
 )


### PR DESCRIPTION
## Summary
- add optional `role` filtering for `GET /api/user`
- allow storing `select` fields with `optionsRole` in progress templates
- fetch users by role for dropdowns in progress page
- update frontend to configure dropdown role source

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446c0710b48329a1f418164c52db85