### PR TITLE
Handle roleId references for user model

### DIFF
--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -25,7 +25,7 @@ export const uploadFile = async (req, res) => {
 
 /* ---------- GET /api/assets ---------- */
 export const getAssets = async (req, res) => {
-  const query = { allowRoles: req.user.role }
+  const query = { allowRoles: req.user.roleId?.name }
   query.folderId = req.query.folderId ? req.query.folderId : null
 
   const assets = await Asset.find(query)
@@ -66,7 +66,7 @@ export const deleteAsset = async (req, res) => {
 /* ---------- 依 limit 取得最新素材 ---------- */
 export const getRecentAssets = async (req, res) => {
   const limit = Number(req.query.limit) || 5
-  const query = { allowRoles: req.user.role }
+  const query = { allowRoles: req.user.roleId?.name }
   const assets = await Asset.find(query)
     .sort({ createdAt: -1 })
     .limit(limit)

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -1,17 +1,24 @@
 import User from '../models/user.model.js'
+import Role from '../models/role.model.js'
 import { generateToken } from '../utils/generateToken.js'
 
 /* ---------- POST /api/auth/login ---------- */
 export const login = async (req, res) => {
   const { username, password } = req.body
-  const user = await User.findOne({ username }).select('+password')
+  const user = await User.findOne({ username })
+    .select('+password')
+    .populate('roleId')
   if (!user || !(await user.matchPassword(password))) {
     return res.status(401).json({ message: '\u5e33\u865f\u6216\u5bc6\u78bc\u932f\u8aa4' })
   }
   const token = generateToken(user._id)
   res.json({
     token,
-    user: { id: user._id, username: user.username, role: user.role }
+    user: {
+      id: user._id,
+      username: user.username,
+      role: user.roleId?.name
+    }
   })
 }
 
@@ -20,8 +27,18 @@ export const register = async (req, res) => {
   const { username, password, email, role } = req.body
   const exists = await User.findOne({ username })
   if (exists) return res.status(400).json({ message: '\u4f7f\u7528\u8005\u5df2\u5b58\u5728' })
-  const newUser = await User.create({ username, password, email, role })
+  const roleDoc = await Role.findOne({ name: role })
+  const newUser = await User.create({
+    username,
+    password,
+    email,
+    roleId: roleDoc?._id
+  })
   res.status(201).json({
-    user: { id: newUser._id, username: newUser.username, role: newUser.role }
+    user: {
+      id: newUser._id,
+      username: newUser.username,
+      role: roleDoc?.name
+    }
   })
 }

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -1,8 +1,9 @@
 import User from '../models/user.model.js'
+import Role from '../models/role.model.js'
 import bcrypt from 'bcryptjs'
 
 const managerOnly = (req,res) => {
-  if (req.user.role !== 'manager') {
+  if (req.user.roleId?.name !== 'manager') {
     res.status(403).json({ message:'僅限 Manager 操作' })
     return true
   }
@@ -12,8 +13,14 @@ const managerOnly = (req,res) => {
 /* 取得所有使用者 */
 export const getAllUsers = async (req,res) => {
   if (!req.query.role && managerOnly(req,res)) return
-  const filter = req.query.role ? { role: req.query.role } : {}
-  const users = await User.find(filter).select('-password')
+  let filter = {}
+  if (req.query.role) {
+    const roleDoc = await Role.findOne({ name: req.query.role })
+    if (roleDoc) filter.roleId = roleDoc._id
+  }
+  const users = await User.find(filter)
+    .select('-password')
+    .populate('roleId')
   res.json(users)
 }
 
@@ -23,8 +30,10 @@ export const createUser = async (req,res) => {
   const { name,email,role,password } = req.body
   if (await User.findOne({ email })) return res.status(400).json({ message:'Email 已存在' })
   const hash = await bcrypt.hash(password,12)
-  const u = await User.create({ name,email,role,password:hash })
-  res.status(201).json(u)
+  const roleDoc = await Role.findOne({ name: role })
+  const u = await User.create({ name,email,roleId: roleDoc?._id,password:hash })
+  const populated = await u.populate('roleId')
+  res.status(201).json(populated)
 }
 
 /* 更新 */
@@ -37,10 +46,14 @@ export const updateUser = async (req,res) => {
     return res.status(400).json({ message:'Email 已存在' })
   if (name)  u.name  = name
   if (email) u.email = email
-  if (role)  u.role  = role
+  if (role) {
+    const roleDoc = await Role.findOne({ name: role })
+    u.roleId = roleDoc?._id
+  }
   if (password) u.password = await bcrypt.hash(password,12)
   await u.save()
-  res.json(u)
+  const populated = await u.populate('roleId')
+  res.json(populated)
 }
 
 /* 刪除 */
@@ -52,7 +65,8 @@ export const deleteUser = async (req,res) => {
 
 /* 取得個人資料 */
 export const getProfile = async (req,res) => {
-  res.json(req.user)
+  const user = await req.user.populate('roleId')
+  res.json(user)
 }
 
 /* 更新個人資料 */
@@ -68,5 +82,6 @@ export const updateProfile = async (req,res) => {
   if (email)    u.email    = email
   if (password) u.password = await bcrypt.hash(password,12)
   await u.save()
-  res.json(u)
+  const populated = await u.populate('roleId')
+  res.json(populated)
 }

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -18,7 +18,9 @@ export const protect = async (req, res, next) => {
     const token = authHeader.split(' ')[1];
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
-    const user = await User.findById(decoded.id).select('-password');
+    const user = await User.findById(decoded.id)
+      .select('-password')
+      .populate('roleId');
     if (!user) {
       return res.status(404).json({ message: '使用者不存在' });
     }

--- a/server/src/middleware/roleGuard.js
+++ b/server/src/middleware/roleGuard.js
@@ -4,7 +4,7 @@
 export const authorize =
   (...roles) =>
   (req, res, next) => {
-    if (!roles.includes(req.user.role)) {
+    if (!roles.includes(req.user.roleId?.name)) {
       return res.status(403).json({ message: '\u6b0a\u9650\u4e0d\u8db3' })
     }
     next()

--- a/server/src/models/role.model.js
+++ b/server/src/models/role.model.js
@@ -1,0 +1,7 @@
+import mongoose from 'mongoose'
+
+const roleSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true }
+})
+
+export default mongoose.model('Role', roleSchema)

--- a/server/src/models/user.model.js
+++ b/server/src/models/user.model.js
@@ -3,18 +3,16 @@
  */
 import mongoose from 'mongoose'
 import bcrypt from 'bcryptjs'
-import { ROLES } from '../config/roles.js'
+// 角色模型
+import Role from './role.model.js'
 
 const userSchema = new mongoose.Schema(
   {
     username: { type: String, required: true, unique: true },
     password: { type: String, required: true, select: false },
     email: { type: String, required: true, unique: true },
-    role: {
-      type: String,
-      enum: Object.values(ROLES),
-      default: ROLES.EMPLOYEE
-    }
+    // 角色參照 Role 集合
+    roleId: { type: mongoose.Schema.Types.ObjectId, ref: 'Role' }
   },
   { timestamps: true }
 )

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -2,6 +2,7 @@ import dotenv from 'dotenv'
 import mongoose from 'mongoose'
 import bcrypt from 'bcryptjs'
 import User from '../models/user.model.js'
+import Role from '../models/role.model.js'
 import { ROLES } from '../config/roles.js'
 
 dotenv.config()
@@ -18,9 +19,19 @@ const seed = async () => {
     console.log('✅ MongoDB 已連線')
 
     await User.deleteMany({})
+    await Role.deleteMany({})
+
+    // 建立角色資料
+    const roleDocs = await Role.insertMany(
+      Object.values(ROLES).map((name) => ({ name }))
+    )
+    const roleMap = {}
+    for (const r of roleDocs) roleMap[r.name] = r._id
 
     for (const user of users) {
       user.password = await bcrypt.hash(user.password, 10)
+      user.roleId = roleMap[user.role]
+      delete user.role
     }
 
     await User.insertMany(users)

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -4,6 +4,7 @@ import mongoose from 'mongoose'
 import { MongoMemoryServer } from 'mongodb-memory-server'
 import authRoutes from '../src/routes/auth.routes.js'
 import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
 import dotenv from 'dotenv'
 
 dotenv.config({ override: true })
@@ -19,11 +20,12 @@ beforeAll(async () => {
   app.use(express.json())
   app.use('/api/auth', authRoutes)
 
+  const role = await Role.create({ name: 'manager' })
   await User.create({
     username: 'admin',
     password: 'mypwd',
     email: 'admin@example.com',
-    role: 'manager'
+    roleId: role._id
   })
 })
 


### PR DESCRIPTION
## Summary
- reference Role in user model instead of role string
- populate role information in auth and user controllers
- adjust middleware and asset controller to work with roleId
- seed roles when seeding users
- update login test setup for new structure

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845073d73608329a7178da730dfd41e