### PR TITLE
Add permission middleware and update task routes

### DIFF
--- a/server/src/middleware/permissionGuard.js
+++ b/server/src/middleware/permissionGuard.js
@@ -1,0 +1,8 @@
+import Role from '../models/role.model.js'
+
+export const requirePerm = (...perms) => async (req, res, next) => {
+  const role = await Role.findById(req.user.roleId)
+  const allowed = perms.every(p => role.permissions.includes(p))
+  if (!allowed) return res.status(403).json({ message: '權限不足' })
+  next()
+}

--- a/server/src/models/role.model.js
+++ b/server/src/models/role.model.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose'
+
+const roleSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  permissions: [{ type: String, required: true }]
+})
+
+export default mongoose.model('Role', roleSchema)

--- a/server/src/routes/task.routes.js
+++ b/server/src/routes/task.routes.js
@@ -1,13 +1,12 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
-import { authorize } from '../middleware/roleGuard.js'
+import { requirePerm } from '../middleware/permissionGuard.js'
 import { createTask, getTasks, updateTask } from '../controllers/task.controller.js'
-import { ROLES } from '../config/roles.js'
 
 const router = Router()
 
 router.get('/', protect, getTasks)
-router.post('/', protect, authorize(ROLES.MANAGER, ROLES.EMPLOYEE), createTask)
-router.put('/:id', protect, authorize(ROLES.MANAGER, ROLES.EMPLOYEE), updateTask)
+router.post('/', protect, requirePerm('task:create'), createTask)
+router.put('/:id', protect, requirePerm('task:update'), updateTask)
 
 export default router


### PR DESCRIPTION
## Summary
- add permission-based middleware and Role model
- update task routes to use permission guard

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845073e20ec8329ab2c339f76b3d087