### PR TITLE
Add permission-based access control

### DIFF
--- a/server/src/config/permissions.js
+++ b/server/src/config/permissions.js
@@ -1,0 +1,11 @@
+export const PERMISSIONS = Object.freeze({
+  ASSET_CREATE: 'asset:create',
+  ASSET_READ: 'asset:read',
+  ASSET_UPDATE: 'asset:update',
+  ASSET_DELETE: 'asset:delete',
+  FOLDER_MANAGE: 'folder:manage',
+  PROGRESS_MANAGE: 'progress:manage',
+  USER_MANAGE: 'user:manage',
+  TASK_MANAGE: 'task:manage',
+  ANALYTICS_VIEW: 'analytics:view'
+})

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -1,17 +1,8 @@
 import User from '../models/user.model.js'
 import bcrypt from 'bcryptjs'
 
-const managerOnly = (req,res) => {
-  if (req.user.role !== 'manager') {
-    res.status(403).json({ message:'僅限 Manager 操作' })
-    return true
-  }
-  return false
-}
-
 /* 取得所有使用者 */
 export const getAllUsers = async (req,res) => {
-  if (!req.query.role && managerOnly(req,res)) return
   const filter = req.query.role ? { role: req.query.role } : {}
   const users = await User.find(filter).select('-password')
   res.json(users)
@@ -19,7 +10,6 @@ export const getAllUsers = async (req,res) => {
 
 /* 新增 */
 export const createUser = async (req,res) => {
-  if (managerOnly(req,res)) return
   const { name,email,role,password } = req.body
   if (await User.findOne({ email })) return res.status(400).json({ message:'Email 已存在' })
   const hash = await bcrypt.hash(password,12)
@@ -29,7 +19,6 @@ export const createUser = async (req,res) => {
 
 /* 更新 */
 export const updateUser = async (req,res) => {
-  if (managerOnly(req,res)) return
   const { name,email,role,password } = req.body
   const u = await User.findById(req.params.id)
   if (!u) return res.status(404).json({ message:'找不到使用者' })
@@ -45,7 +34,6 @@ export const updateUser = async (req,res) => {
 
 /* 刪除 */
 export const deleteUser = async (req,res) => {
-  if (managerOnly(req,res)) return
   await User.findByIdAndDelete(req.params.id)
   res.json({ message:'已刪除' })
 }

--- a/server/src/middleware/permission.js
+++ b/server/src/middleware/permission.js
@@ -1,0 +1,9 @@
+import Role from '../models/role.model.js'
+
+export const requirePerm = (perm) => async (req, res, next) => {
+  const role = await Role.findOne({ name: req.user.role })
+  if (!role || !role.permissions.includes(perm)) {
+    return res.status(403).json({ message: '\u6b0a\u9650\u4e0d\u8db3' })
+  }
+  next()
+}

--- a/server/src/models/role.model.js
+++ b/server/src/models/role.model.js
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose'
+import { PERMISSIONS } from '../config/permissions.js'
+
+const roleSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, unique: true },
+    permissions: {
+      type: [String],
+      validate: {
+        validator: (arr) => arr.every((p) => Object.values(PERMISSIONS).includes(p)),
+        message: 'Invalid permission'
+      },
+      default: []
+    }
+  },
+  { timestamps: true }
+)
+
+export default mongoose.model('Role', roleSchema)

--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -1,6 +1,8 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
 import { upload } from '../middleware/upload.js'
+import { requirePerm } from '../middleware/permission.js'
+import { PERMISSIONS } from '../config/permissions.js'
 import {
     uploadFile,
     getAssets,
@@ -12,12 +14,33 @@ import {
 
 const router = Router()
 
-router.post('/upload', protect, upload.single('file'), uploadFile)
-router.get('/', protect, getAssets)
-router.post('/:id/comment', protect, addComment)
-router.get('/recent', protect, getRecentAssets)
+router.post(
+  '/upload',
+  protect,
+  requirePerm(PERMISSIONS.ASSET_CREATE),
+  upload.single('file'),
+  uploadFile
+)
+router.get('/', protect, requirePerm(PERMISSIONS.ASSET_READ), getAssets)
+router.post(
+  '/:id/comment',
+  protect,
+  requirePerm(PERMISSIONS.ASSET_UPDATE),
+  addComment
+)
+router.get('/recent', protect, requirePerm(PERMISSIONS.ASSET_READ), getRecentAssets)
 
 /* ★ 新增：更新檔名／描述 */
-router.put('/:id', protect, updateAsset)
-router.delete('/:id', protect, deleteAsset)    // assets
+router.put(
+  '/:id',
+  protect,
+  requirePerm(PERMISSIONS.ASSET_UPDATE),
+  updateAsset
+)
+router.delete(
+  '/:id',
+  protect,
+  requirePerm(PERMISSIONS.ASSET_DELETE),
+  deleteAsset
+) // assets
 export default router

--- a/server/src/routes/folder.routes.js
+++ b/server/src/routes/folder.routes.js
@@ -1,5 +1,7 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
+import { requirePerm } from '../middleware/permission.js'
+import { PERMISSIONS } from '../config/permissions.js'
 import {
   createFolder,
   getFolders,
@@ -10,10 +12,15 @@ import {
 
 const router = Router()
 
-router.post('/', protect, createFolder)
-router.get('/', protect, getFolders)
-router.get('/:id', protect, getFolder)
-router.put('/:id', protect, updateFolder)
-router.delete('/:id', protect, deleteFolder)   // folders
+router.post('/', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), createFolder)
+router.get('/', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), getFolders)
+router.get('/:id', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), getFolder)
+router.put('/:id', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), updateFolder)
+router.delete(
+  '/:id',
+  protect,
+  requirePerm(PERMISSIONS.FOLDER_MANAGE),
+  deleteFolder
+)   // folders
 
 export default router

--- a/server/src/routes/progress.routes.js
+++ b/server/src/routes/progress.routes.js
@@ -1,5 +1,7 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
+import { requirePerm } from '../middleware/permission.js'
+import { PERMISSIONS } from '../config/permissions.js'
 import {
   createTemplate,  getTemplates,
   updateTemplate,  deleteTemplate,   // ← 新增
@@ -9,14 +11,49 @@ import {
 
 const router = Router()
 
-router.get ('/templates', protect, getTemplates)
-router.post('/templates', protect, createTemplate)
-router.put ('/templates/:id', protect, updateTemplate)   // ★
-router.delete('/templates/:id', protect, deleteTemplate) // ★
+router.get(
+  '/templates',
+  protect,
+  requirePerm(PERMISSIONS.PROGRESS_MANAGE),
+  getTemplates
+)
+router.post(
+  '/templates',
+  protect,
+  requirePerm(PERMISSIONS.PROGRESS_MANAGE),
+  createTemplate
+)
+router.put(
+  '/templates/:id',
+  protect,
+  requirePerm(PERMISSIONS.PROGRESS_MANAGE),
+  updateTemplate
+)   // ★
+router.delete(
+  '/templates/:id',
+  protect,
+  requirePerm(PERMISSIONS.PROGRESS_MANAGE),
+  deleteTemplate
+) // ★
 
-router.get ('/records/:tplId', protect, getRecords)
-router.post('/records',       protect, createRecord)
-router.get ('/recent', protect, getRecentRecords)
+router.get(
+  '/records/:tplId',
+  protect,
+  requirePerm(PERMISSIONS.PROGRESS_MANAGE),
+  getRecords
+)
+router.post(
+  '/records',
+  protect,
+  requirePerm(PERMISSIONS.PROGRESS_MANAGE),
+  createRecord
+)
+router.get(
+  '/recent',
+  protect,
+  requirePerm(PERMISSIONS.PROGRESS_MANAGE),
+  getRecentRecords
+)
 
 export default router
 

--- a/server/src/routes/task.routes.js
+++ b/server/src/routes/task.routes.js
@@ -1,13 +1,23 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
-import { authorize } from '../middleware/roleGuard.js'
+import { requirePerm } from '../middleware/permission.js'
 import { createTask, getTasks, updateTask } from '../controllers/task.controller.js'
-import { ROLES } from '../config/roles.js'
+import { PERMISSIONS } from '../config/permissions.js'
 
 const router = Router()
 
-router.get('/', protect, getTasks)
-router.post('/', protect, authorize(ROLES.MANAGER, ROLES.EMPLOYEE), createTask)
-router.put('/:id', protect, authorize(ROLES.MANAGER, ROLES.EMPLOYEE), updateTask)
+router.get('/', protect, requirePerm(PERMISSIONS.TASK_MANAGE), getTasks)
+router.post(
+  '/',
+  protect,
+  requirePerm(PERMISSIONS.TASK_MANAGE),
+  createTask
+)
+router.put(
+  '/:id',
+  protect,
+  requirePerm(PERMISSIONS.TASK_MANAGE),
+  updateTask
+)
 
 export default router

--- a/server/src/routes/user.routes.js
+++ b/server/src/routes/user.routes.js
@@ -1,5 +1,7 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
+import { requirePerm } from '../middleware/permission.js'
+import { PERMISSIONS } from '../config/permissions.js'
 import {
   getAllUsers,
   createUser,
@@ -17,12 +19,12 @@ router.put('/profile', updateProfile)
 
 router
   .route('/')
-  .get(getAllUsers)               // GET  /api/user
-  .post(createUser)               // POST /api/user
+  .get(requirePerm(PERMISSIONS.USER_MANAGE), getAllUsers)               // GET  /api/user
+  .post(requirePerm(PERMISSIONS.USER_MANAGE), createUser)               // POST /api/user
 
 router
   .route('/:id')
-  .put(updateUser)                // PUT    /api/user/:id
-  .delete(deleteUser)             // DELETE /api/user/:id
+  .put(requirePerm(PERMISSIONS.USER_MANAGE), updateUser)                // PUT    /api/user/:id
+  .delete(requirePerm(PERMISSIONS.USER_MANAGE), deleteUser)             // DELETE /api/user/:id
 
 export default router


### PR DESCRIPTION
## Summary
- define permissions in `config/permissions.js`
- create Role model with permission validation
- add middleware `requirePerm`
- remove obsolete manager check
- secure asset, folder, progress, user and task routes with permissions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845073ef30c8329918b99c810dbc5d4