### PR TITLE
Add role settings management page

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -72,6 +72,7 @@ const menus = {
     { path: '/progress', icon: '📈', label: '進度追踪' },
     { path: '/assets', icon: '🎞️', label: '素材庫' },
     { path: '/employees', icon: '👥', label: '人員管理' },
+    { path: '/roles', icon: '🛡️', label: '角色設定' },
     { path: '/account', icon: '👤', label: '帳號資訊' }
   ],
   outsource: [

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -8,6 +8,7 @@ import Account from '../views/Account.vue'
 import Progress from '../views/Progress.vue'
 import AssetLibrary from '../views/AssetLibrary.vue'
 import EmployeeManager from '../views/EmployeeManager.vue'
+import RoleSettings from '../views/RoleSettings.vue'
 
 const routes = [
   {
@@ -24,7 +25,8 @@ const routes = [
       { path: 'account', name: 'Account', component: Account },
       { path: 'progress', name: 'Progress', component: Progress },
       { path: 'assets', name: 'Assets', component: AssetLibrary },
-      { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { role: 'manager' } }
+      { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { role: 'manager' } },
+      { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { role: 'manager' } }
     ]
   },
   // 404

--- a/client/src/services/roles.js
+++ b/client/src/services/roles.js
@@ -1,0 +1,13 @@
+import api from './api'
+
+export const fetchRoles = () =>
+  api.get('/roles').then(r => r.data)
+
+export const createRole = data =>
+  api.post('/roles', data).then(r => r.data)
+
+export const updateRole = (id, data) =>
+  api.put(`/roles/${id}`, data).then(r => r.data)
+
+export const deleteRole = id =>
+  api.delete(`/roles/${id}`).then(r => r.data)

--- a/client/src/views/RoleSettings.vue
+++ b/client/src/views/RoleSettings.vue
@@ -1,0 +1,104 @@
+<!-- RoleSettings.vue -->
+<script setup>
+import { ref, onMounted } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { fetchRoles, createRole, updateRole, deleteRole } from '../services/roles'
+import { useAuthStore } from '../stores/auth'
+
+const store = useAuthStore()
+if (store.role !== 'manager') {
+  window.location.href = '/'
+}
+
+const roles = ref([])
+const dialog = ref(false)
+const editing = ref(false)
+const form = ref({
+  name: '',
+  permissions: ''
+})
+
+const loadRoles = async () => {
+  roles.value = await fetchRoles()
+}
+
+const openCreate = () => {
+  editing.value = false
+  form.value = { name: '', permissions: '' }
+  dialog.value = true
+}
+
+const openEdit = r => {
+  editing.value = true
+  form.value = { ...r, permissions: r.permissions?.join(',') || '' }
+  dialog.value = true
+}
+
+const submit = async () => {
+  const data = {
+    name: form.value.name,
+    permissions: form.value.permissions
+      .split(',')
+      .map(p => p.trim())
+      .filter(Boolean)
+  }
+  if (editing.value) {
+    await updateRole(form.value._id, data)
+    ElMessage.success('已更新角色')
+  } else {
+    await createRole(data)
+    ElMessage.success('已建立角色')
+  }
+  dialog.value = false
+  await loadRoles()
+}
+
+const removeRole = async r => {
+  await ElMessageBox.confirm(`確定刪除「${r.name}」？`, '警告', {
+    confirmButtonText: '刪除',
+    cancelButtonText: '取消',
+    type: 'warning'
+  })
+  await deleteRole(r._id)
+  ElMessage.success('已刪除角色')
+  await loadRoles()
+}
+
+onMounted(loadRoles)
+</script>
+
+<template>
+  <section class="p-6 space-y-6 bg-white text-gray-800">
+    <h1 class="text-2xl font-bold">角色權限管理</h1>
+
+    <el-button type="primary" @click="openCreate">＋ 新增角色</el-button>
+
+    <el-table :data="roles" style="width:100%" stripe border>
+      <el-table-column prop="name" label="角色名稱" />
+      <el-table-column
+        prop="permissions"
+        label="權限"
+        :formatter="(_, __, cell) => Array.isArray(cell) ? cell.join(', ') : ''"
+      />
+      <el-table-column label="操作" width="160">
+        <template #default="{ row }">
+          <el-button link type="primary" @click="openEdit(row)">編輯</el-button>
+          <el-button link type="danger"  @click="removeRole(row)">刪除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialog" :title="editing ? '編輯角色' : '新增角色'" width="420px">
+      <el-form label-position="top" @submit.prevent>
+        <el-form-item label="角色名稱"><el-input v-model="form.name" /></el-form-item>
+        <el-form-item label="權限 (以逗號分隔)">
+          <el-input v-model="form.permissions" placeholder="read,write,delete" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialog=false">取消</el-button>
+        <el-button type="primary" @click="submit">{{ editing ? '更新' : '建立' }}</el-button>
+      </template>
+    </el-dialog>
+  </section>
+</template>


### PR DESCRIPTION
## Summary
- add RoleSettings page for managing role permissions
- integrate role API service for CRUD calls
- update router and sidebar navigation

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845073fc5bc8329b7683418580c839f