### PR TITLE
新增成品區路由與選單

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -65,12 +65,14 @@ const menus = {
     { path: '/', icon: '🏠', label: '首頁' },
     { path: '/progress', icon: '📈', label: '進度追踪' },
     { path: '/assets', icon: '🎞️', label: '素材庫' },
+    { path: '/products', icon: '🎬', label: '成品區' },
     { path: '/account', icon: '👤', label: '帳號資訊' }
   ],
   manager: [
     { path: '/', icon: '🏠', label: '首頁' },
     { path: '/progress', icon: '📈', label: '進度追踪' },
     { path: '/assets', icon: '🎞️', label: '素材庫' },
+    { path: '/products', icon: '🎬', label: '成品區' },
     { path: '/employees', icon: '👥', label: '人員管理' },
     { path: '/account', icon: '👤', label: '帳號資訊' }
   ],

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -8,6 +8,7 @@ import Account from '../views/Account.vue'
 import Progress from '../views/Progress.vue'
 import AssetLibrary from '../views/AssetLibrary.vue'
 import EmployeeManager from '../views/EmployeeManager.vue'
+import Products from '../views/Products.vue'
 
 const routes = [
   {
@@ -24,6 +25,7 @@ const routes = [
       { path: 'account', name: 'Account', component: Account },
       { path: 'progress', name: 'Progress', component: Progress },
       { path: 'assets', name: 'Assets', component: AssetLibrary },
+      { path: 'products', name: 'Products', component: Products },
       { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { role: 'manager' } }
     ]
   },

--- a/client/src/views/Products.vue
+++ b/client/src/views/Products.vue
@@ -1,0 +1,7 @@
+<script setup>
+</script>
+
+<template>
+  <h1 class="text-2xl font-bold mb-4">成品區</h1>
+  <p>此頁面待實作</p>
+</template>


### PR DESCRIPTION
## Summary
- 更新 `menus.employee` 及 `menus.manager` 新增成品區連結
- 新增 `/products` 路由
- 建立簡易的 `Products.vue` 頁面

## Testing
- `npm test --prefix server` *(失敗：jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684509c394a083299a3a1498da8c2f32