### PR TITLE
Fix router syntax

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -30,7 +30,7 @@ const routes = [
       { path: 'assets', name: 'Assets', component: AssetLibrary },
       { path: 'products', name: 'Products', component: ProductLibrary },
 
-      { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { role: 'manager' } }
+      { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { role: 'manager' } },
       { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { role: 'manager' } }
     ]
   },


### PR DESCRIPTION
## Summary
- add a missing comma in router configuration

## Testing
- `npm run build --prefix client` *(fails: npm not found)*
- `npm test --prefix server` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bb51b8d88329a3eed7169a837f6b