### PR TITLE
fix vite alias placement

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -13,7 +13,9 @@ export default defineConfig({
       '/static': 'http://localhost:3000'
     }
   },
-  alias: {
-    '@': path.resolve(__dirname, 'src')   // ★ 加這行
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')   // ★ 加這行
+    }
   }
 })


### PR DESCRIPTION
## Summary
- move alias into resolve in vite config

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bb530e008329b8ed336107111874