### PR TITLE
Implement permissions API and UI

### DIFF
--- a/client/src/services/roles.js
+++ b/client/src/services/roles.js
@@ -11,3 +11,6 @@ export const updateRole = (id, data) =>
 
 export const deleteRole = id =>
   api.delete(`/roles/${id}`).then(r => r.data)
+
+export const fetchPermissions = () =>
+  api.get('/permissions').then(r => r.data)

--- a/server/src/routes/permissions.routes.js
+++ b/server/src/routes/permissions.routes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express'
+import { PERMISSIONS } from '../config/permissions.js'
+
+const router = Router()
+
+router.get('/', (req, res) => {
+  res.json(Object.values(PERMISSIONS))
+})
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -38,6 +38,7 @@ import taskRoutes     from './routes/task.routes.js'
 import progressRoutes from './routes/progress.routes.js'
 import roleRoutes     from './routes/role.routes.js'
 import healthRoutes   from './routes/health.routes.js'
+import permissionsRoutes from './routes/permissions.routes.js'
 // import analyticsRoutes from './routes/analytics.routes.js' // 未啟用
 
 app.use('/api/auth',     authRoutes)
@@ -47,6 +48,7 @@ app.use('/api/folders',  folderRoutes)
 app.use('/api/tasks',    taskRoutes)
 app.use('/api/progress', progressRoutes)
 app.use('/api/roles',    roleRoutes)
+app.use('/api/permissions', permissionsRoutes)
 app.use('/api/health',   healthRoutes)
 // app.use('/api/analytics', analyticsRoutes)
 


### PR DESCRIPTION
## Summary
- add permissions routes to expose PERMISSIONS enum
- mount `/api/permissions` in server
- provide `fetchPermissions` service on the client
- show permission checkboxes in role editor
- send permissions as array

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c5e18370832986e82f54e7e23339