### PR TITLE
新增權限名稱對照並優化角色設定介面

### DIFF
--- a/client/src/permissionNames.js
+++ b/client/src/permissionNames.js
@@ -1,0 +1,11 @@
+export const PERMISSION_NAMES = {
+  'asset:create': '資源建立',
+  'asset:read': '資源讀取',
+  'asset:update': '資源更新',
+  'asset:delete': '資源刪除',
+  'folder:manage': '資料夾管理',
+  'progress:manage': '進度管理',
+  'user:manage': '使用者管理',
+  'task:manage': '任務管理',
+  'analytics:view': '統計檢視'
+}

--- a/client/src/views/RoleSettings.vue
+++ b/client/src/views/RoleSettings.vue
@@ -3,6 +3,7 @@
 import { ref, onMounted } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { fetchRoles, createRole, updateRole, deleteRole, fetchPermissions } from '../services/roles'
+import { PERMISSION_NAMES } from '../permissionNames'
 import { useAuthStore } from '../stores/auth'
 
 const store = useAuthStore()
@@ -24,7 +25,8 @@ const loadRoles = async () => {
 }
 
 const loadPermissions = async () => {
-  permissionList.value = await fetchPermissions()
+  const codes = await fetchPermissions()
+  permissionList.value = codes.map(code => ({ value: code, label: PERMISSION_NAMES[code] }))
 }
 
 const openCreate = () => {
@@ -98,7 +100,13 @@ onMounted(() => {
         <el-form-item label="角色名稱"><el-input v-model="form.name" /></el-form-item>
         <el-form-item label="權限">
           <el-checkbox-group v-model="form.permissions">
-            <el-checkbox v-for="p in permissionList" :key="p" :label="p">{{ p }}</el-checkbox>
+            <el-checkbox
+              v-for="p in permissionList"
+              :key="p.value"
+              :label="p.value"
+            >
+              {{ p.label }}
+            </el-checkbox>
           </el-checkbox-group>
         </el-form-item>
       </el-form>


### PR DESCRIPTION
## Summary
- 新增 `permissionNames.js` 定義權限代碼對應的中文名稱
- 於 `RoleSettings.vue` 載入權限時轉成含 `value` 與 `label` 的物件陣列
- 調整 `el-checkbox` 迴圈以顯示中文名稱，並保持 `form.permissions` 儲存原始代碼

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c98eddb88329802b3ea2726f963e