### PR TITLE
Fix newline for progress service

### DIFF
--- a/client/src/services/progress.js
+++ b/client/src/services/progress.js
@@ -25,3 +25,4 @@ export const createRecord = data =>
 
 export const updateRecord = (id, data) =>
   api.put(`/progress/records/${id}`, data).then(res => res.data)
+


### PR DESCRIPTION
## Summary
- add a blank line after `updateRecord`

## Testing
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d7dbe21483298bc1b3d42965fe28