### PR TITLE
新增上傳進度條

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -17,7 +17,7 @@ export const fetchAssets = (folderId, type) => {
   )
 }
 
-export const uploadAsset = (file, folderId, extraData = null) => {
+export const uploadAsset = (file, folderId, extraData = null, onUploadProgress = null) => {
   const formData = new FormData()
   formData.append('file', file)
   if (folderId) formData.append('folderId', folderId)
@@ -28,7 +28,8 @@ export const uploadAsset = (file, folderId, extraData = null) => {
   }
 
   return api.post('/assets/upload', formData, {
-    headers: { 'Content-Type': 'multipart/form-data' }
+    headers: { 'Content-Type': 'multipart/form-data' },
+    onUploadProgress
   }).then((res) => res.data)
 }
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -10,9 +10,22 @@
         <el-button :disabled="!currentFolder" @click="goUp">返回上層</el-button>
         <el-input v-model="newFolderName" placeholder="新增資料夾名稱" class="w-56" @keyup.enter="createNewFolder" />
         <el-button type="primary" @click="createNewFolder">建立資料夾</el-button>
-        <el-upload v-if="currentFolder" :before-upload="beforeUpload" :show-file-list="false">
+        <el-upload
+          v-if="currentFolder"
+          :http-request="uploadRequest"
+          :on-progress="handleProgress"
+          :on-success="handleSuccess"
+          :on-error="handleError"
+          :show-file-list="false"
+        >
           <el-button type="success">上傳檔案</el-button>
         </el-upload>
+        <el-progress
+          v-for="(p, id) in progressList"
+          :key="id"
+          class="w-56 mt-2"
+          :percentage="p"
+        />
       </div>
 
       <!-- 卡片格線 -->
@@ -227,12 +240,30 @@ async function createNewFolder() {
   loadData(currentFolder.value?._id)
 }
 
-async function beforeUpload(file) {
-  await uploadAsset(file, currentFolder.value?._id)
+const progressList = ref({})
 
+function handleProgress(evt, file) {
+  progressList.value[file.uid] = Math.round(evt.percent)
+}
+
+function handleSuccess(_, file) {
+  progressList.value[file.uid] = 100
+  setTimeout(() => delete progressList.value[file.uid], 500)
   ElMessage.success('上傳完成')
   loadData(currentFolder.value?._id)
-  return false
+}
+
+function handleError(_, file) {
+  delete progressList.value[file.uid]
+}
+
+async function uploadRequest({ file, onProgress, onSuccess, onError }) {
+  try {
+    await uploadAsset(file, currentFolder.value?._id, null, onProgress)
+    onSuccess()
+  } catch (e) {
+    onError(e)
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- 回傳 axios `onUploadProgress` 供外部監聽
- AssetLibrary / ProductLibrary 以 `http-request` 方式上傳，並以 `el-progress` 顯示進度

## Testing
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e2690d608329a284a481afa6847d