### PR TITLE
Add products endpoint

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -18,6 +18,22 @@ export const fetchAssets = (folderId, type, tags = []) => {
   )
 }
 
+export const fetchProducts = (folderId, tags = []) => {
+  const params = {}
+  if (folderId) params.folderId = folderId
+  if (tags.length) params.tags = tags
+
+  return api.get('/products', { params }).then(res =>
+    res.data.map(a => {
+      const hasStatic = /^\/static\//.test(a.url || '')
+      return {
+        ...a,
+        url: hasStatic ? a.url : `/static/${a.filename}`
+      }
+    })
+  )
+}
+
 export const uploadAsset = (file, folderId, extraData = null, onUploadProgress = null) => {
   const formData = new FormData()
   formData.append('file', file)

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -155,7 +155,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder } from '../services/folders'
-import { fetchAssets, uploadAsset, updateAsset, deleteAsset, reviewAsset } from '../services/assets'
+import { fetchProducts, uploadAsset, updateAsset, deleteAsset, reviewAsset } from '../services/assets'
 import { useAuthStore } from '../stores/auth'
 import { ElMessage } from 'element-plus'
 import { Folder, InfoFilled, Close } from '@element-plus/icons-vue'
@@ -185,7 +185,7 @@ const detailTitle = computed(() => previewItem.value ? previewItem.value.filenam
 
 async function loadData(id = null) {
   folders.value = await fetchFolders(id, filterTags.value)
-  assets.value = id ? await fetchAssets(id, 'edited', filterTags.value) : []
+  assets.value = id ? await fetchProducts(id, filterTags.value) : []
   allTags.value = Array.from(new Set([
     ...folders.value.flatMap(f => f.tags || []),
     ...assets.value.flatMap(a => a.tags || [])

--- a/server/src/controllers/product.controller.js
+++ b/server/src/controllers/product.controller.js
@@ -1,0 +1,6 @@
+import { getAssets } from './asset.controller.js'
+
+export const getProducts = async (req, res) => {
+  if (!req.query.type) req.query.type = 'edited'
+  await getAssets(req, res)
+}

--- a/server/src/routes/product.routes.js
+++ b/server/src/routes/product.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express'
+import { protect } from '../middleware/auth.js'
+import { requirePerm } from '../middleware/permission.js'
+import { PERMISSIONS } from '../config/permissions.js'
+import { getProducts } from '../controllers/product.controller.js'
+
+const router = Router()
+
+router.get('/', protect, requirePerm(PERMISSIONS.ASSET_READ), getProducts)
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -33,6 +33,7 @@ app.use('/static', express.static(uploadDir))
 import authRoutes     from './routes/auth.routes.js'
 import userRoutes     from './routes/user.routes.js'      // ★ Manager 用帳號管理
 import assetRoutes    from './routes/asset.routes.js'
+import productRoutes  from './routes/product.routes.js'
 import folderRoutes   from './routes/folder.routes.js'
 import taskRoutes     from './routes/task.routes.js'
 import progressRoutes from './routes/progress.routes.js'
@@ -45,6 +46,7 @@ import permissionsRoutes from './routes/permissions.routes.js'
 app.use('/api/auth',     authRoutes)
 app.use('/api/user',     userRoutes)      // <─ CRUD: GET/POST/PUT/DELETE
 app.use('/api/assets',   assetRoutes)
+app.use('/api/products', productRoutes)
 app.use('/api/folders',  folderRoutes)
 app.use('/api/tasks',    taskRoutes)
 app.use('/api/progress', progressRoutes)


### PR DESCRIPTION
## Summary
- add `getProducts` controller
- create product routes for fetching products
- mount products route in `server.js`
- add `fetchProducts` API call
- update `ProductLibrary` to use products endpoint

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847092747688329b43f765804c6d006