### PR TITLE
Add folder type support

### DIFF
--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -1,14 +1,17 @@
 import api from './api'
 
-export const fetchFolders = (parentId = null, tags = []) => {
+export const fetchFolders = (parentId = null, tags = [], type) => {
   const params = {}
   if (parentId) params.parentId = parentId
   if (tags.length) params.tags = tags
+  if (type) params.type = type
   return api.get('/folders', { params }).then((res) => res.data)
 }
 
-export const createFolder = (data) => {
-  return api.post('/folders', data).then((res) => res.data)
+export const createFolder = (data, type) => {
+  const payload = { ...data }
+  if (type) payload.type = type
+  return api.post('/folders', payload).then((res) => res.data)
 }
 
 export const getFolder = (id) => {

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -163,7 +163,7 @@ const sidebarBg = computed(() => getComputedStyle(document.querySelector('.sideb
 const detailTitle = computed(() => previewItem.value ? previewItem.value.filename : currentFolder.value?.name || '資訊')
 
 async function loadData(id = null) {
-  folders.value = await fetchFolders(id, filterTags.value)
+  folders.value = await fetchFolders(id, filterTags.value, 'raw')
   assets.value = id ? await fetchAssets(id, 'raw', filterTags.value) : []
   allTags.value = Array.from(new Set([
     ...folders.value.flatMap(f => f.tags || []),
@@ -225,7 +225,7 @@ async function handleDelete() {
 
 async function createNewFolder() {
   if (!newFolderName.value.trim()) return
-  await createFolder({ name: newFolderName.value.trim(), parentId: currentFolder.value?._id || null })
+  await createFolder({ name: newFolderName.value.trim(), parentId: currentFolder.value?._id || null }, 'raw')
   newFolderName.value = ''
   loadData(currentFolder.value?._id)
 }

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -184,7 +184,7 @@ const sidebarBg = computed(() => getComputedStyle(document.querySelector('.sideb
 const detailTitle = computed(() => previewItem.value ? previewItem.value.filename : currentFolder.value?.name || '資訊')
 
 async function loadData(id = null) {
-  folders.value = await fetchFolders(id, filterTags.value)
+  folders.value = await fetchFolders(id, filterTags.value, 'edited')
   assets.value = id ? await fetchProducts(id, filterTags.value) : []
   allTags.value = Array.from(new Set([
     ...folders.value.flatMap(f => f.tags || []),
@@ -246,7 +246,7 @@ async function handleDelete() {
 
 async function createNewFolder() {
   if (!newFolderName.value.trim()) return
-  await createFolder({ name: newFolderName.value.trim(), parentId: currentFolder.value?._id || null })
+  await createFolder({ name: newFolderName.value.trim(), parentId: currentFolder.value?._id || null }, 'edited')
   newFolderName.value = ''
   loadData(currentFolder.value?._id)
 }

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -17,6 +17,7 @@ export const createFolder = async (req, res) => {
     parentId: req.body.parentId || null,
     description: req.body.description,
     script: req.body.script,
+    type: req.body.type || 'raw',
     tags: parseTags(req.body.tags)
   })
   res.status(201).json(folder)
@@ -24,7 +25,7 @@ export const createFolder = async (req, res) => {
 
 export const getFolders = async (req, res) => {
   const parentId = req.query.parentId || null
-  const query = { parentId }
+  const query = { parentId, type: req.query.type || 'raw' }
   if (req.query.tags) {
     const tags = Array.isArray(req.query.tags)
       ? req.query.tags
@@ -43,6 +44,9 @@ export const getFolder = async (req, res) => {
 
 export const updateFolder = async (req, res) => {
   if (req.body.tags) req.body.tags = parseTags(req.body.tags)
+  if (req.body.type && !['raw', 'edited'].includes(req.body.type)) {
+    delete req.body.type
+  }
   const folder = await Folder.findByIdAndUpdate(req.params.id, req.body, { new: true })
   if (!folder) return res.status(404).json({ message: '資料夾不存在' })
   res.json(folder)

--- a/server/src/models/folder.model.js
+++ b/server/src/models/folder.model.js
@@ -6,6 +6,7 @@ const folderSchema = new mongoose.Schema(
     parentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Folder', default: null },
     description: { type: String },
     script: { type: String },
+    type: { type: String, enum: ['raw', 'edited'], default: 'raw' },
 
     /* 標籤 */
     tags: { type: [String], default: [] }

--- a/server/tests/folder.test.js
+++ b/server/tests/folder.test.js
@@ -1,0 +1,83 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import folderRoutes from '../src/routes/folder.routes.js'
+import authRoutes from '../src/routes/auth.routes.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+let folderId
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/folders', folderRoutes)
+
+  const role = await Role.create({ name: 'manager', permissions: ['folder:manage'] })
+  await User.create({
+    username: 'admin',
+    password: 'mypwd',
+    email: 'admin@example.com',
+    roleId: role._id
+  })
+
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'admin', password: 'mypwd' })
+  token = res.body.token
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+describe('Folder type', () => {
+  it('create edited folder', async () => {
+    const res = await request(app)
+      .post('/api/folders')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'f1', type: 'edited' })
+      .expect(201)
+    folderId = res.body._id
+    expect(res.body.type).toBe('edited')
+  })
+
+  it('default query should return 0', async () => {
+    const res = await request(app)
+      .get('/api/folders')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(res.body.length).toBe(0)
+  })
+
+  it('query type edited should return folder', async () => {
+    const res = await request(app)
+      .get('/api/folders')
+      .query({ type: 'edited' })
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(res.body.length).toBe(1)
+  })
+
+  it('update folder type to raw', async () => {
+    const res = await request(app)
+      .put(`/api/folders/${folderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ type: 'raw' })
+      .expect(200)
+    expect(res.body.type).toBe('raw')
+  })
+})


### PR DESCRIPTION
## Summary
- add `type` field to folder model
- filter folders by `type` in controller
- send and receive `type` via folder service
- update asset & product libraries to use folder type
- add basic API tests for folder type

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470d5a72588329b67b5006bdf86afd