### PR TITLE
改善標籤篩選機制

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -1,11 +1,12 @@
 import api from './api'
 
 
-export const fetchAssets = (folderId, type, tags = []) => {
+export const fetchAssets = (folderId, type, tags = [], deep = false) => {
   const params = {}
   if (folderId) params.folderId = folderId
   if (type) params.type = type
   if (tags.length) params.tags = tags
+  if (deep) params.deep = 'true'
 
   return api.get('/assets', { params }).then(res =>
     res.data.map(a => {
@@ -18,10 +19,11 @@ export const fetchAssets = (folderId, type, tags = []) => {
   )
 }
 
-export const fetchProducts = (folderId, tags = []) => {
+export const fetchProducts = (folderId, tags = [], deep = false) => {
   const params = {}
   if (folderId) params.folderId = folderId
   if (tags.length) params.tags = tags
+  if (deep) params.deep = 'true'
 
   return api.get('/products', { params }).then(res =>
     res.data.map(a => {

--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -1,10 +1,11 @@
 import api from './api'
 
-export const fetchFolders = (parentId = null, tags = [], type) => {
+export const fetchFolders = (parentId = null, tags = [], type, deep = false) => {
   const params = {}
   if (parentId) params.parentId = parentId
   if (tags.length) params.tags = tags
   if (type) params.type = type
+  if (deep) params.deep = 'true'
   return api.get('/folders', { params }).then((res) => res.data)
 }
 

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -22,7 +22,6 @@
         <el-select v-model="filterTags" multiple placeholder="標籤篩選" style="min-width:150px">
           <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
         </el-select>
-        <el-button @click="loadData(currentFolder.value?._id || null)">套用</el-button>
 
       </div>
 
@@ -152,7 +151,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder } from '../services/folders'
 import { fetchAssets, uploadAsset, updateAsset, deleteAsset } from '../services/assets'
 import { ElMessage } from 'element-plus'
@@ -179,8 +178,8 @@ const sidebarBg = computed(() => getComputedStyle(document.querySelector('.sideb
 const detailTitle = computed(() => previewItem.value ? previewItem.value.filename : currentFolder.value?.name || '資訊')
 
 async function loadData(id = null) {
-  folders.value = await fetchFolders(id, filterTags.value, 'raw')
-  assets.value = id ? await fetchAssets(id, 'raw', filterTags.value) : []
+  folders.value = await fetchFolders(id, filterTags.value, 'raw', true)
+  assets.value = id ? await fetchAssets(id, 'raw', filterTags.value, true) : []
   allTags.value = Array.from(new Set([
     ...folders.value.flatMap(f => f.tags || []),
     ...assets.value.flatMap(a => a.tags || [])
@@ -189,6 +188,7 @@ async function loadData(id = null) {
 }
 
 onMounted(() => loadData())
+watch(filterTags, () => loadData(currentFolder.value?._id || null))
 
 function openFolder(f) { loadData(f._id) }
 function goUp() { loadData(currentFolder.value?.parentId || null) }

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -23,7 +23,6 @@
         <el-select v-model="filterTags" multiple placeholder="標籤篩選" style="min-width:150px">
           <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
         </el-select>
-        <el-button @click="loadData(currentFolder.value?._id || null)">套用</el-button>
 
       </div>
 
@@ -169,7 +168,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder } from '../services/folders'
 import { fetchProducts, uploadAsset, updateAsset, deleteAsset, reviewAsset } from '../services/assets'
 import { useAuthStore } from '../stores/auth'
@@ -200,8 +199,8 @@ const sidebarBg = computed(() => getComputedStyle(document.querySelector('.sideb
 const detailTitle = computed(() => previewItem.value ? previewItem.value.filename : currentFolder.value?.name || '資訊')
 
 async function loadData(id = null) {
-  folders.value = await fetchFolders(id, filterTags.value, 'edited')
-  assets.value = id ? await fetchProducts(id, filterTags.value) : []
+  folders.value = await fetchFolders(id, filterTags.value, 'edited', true)
+  assets.value = id ? await fetchProducts(id, filterTags.value, true) : []
   allTags.value = Array.from(new Set([
     ...folders.value.flatMap(f => f.tags || []),
     ...assets.value.flatMap(a => a.tags || [])
@@ -210,6 +209,7 @@ async function loadData(id = null) {
 }
 
 onMounted(() => loadData())
+watch(filterTags, () => loadData(currentFolder.value?._id || null))
 
 function openFolder(f) { loadData(f._id) }
 function goUp() { loadData(currentFolder.value?.parentId || null) }

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -2,6 +2,7 @@
  * Asset Controller  (完整)
  */
 import Asset from '../models/asset.model.js'
+import { getDescendantFolderIds } from '../utils/folderTree.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -46,8 +47,17 @@ export const uploadFile = async (req, res) => {
 
 /* ---------- GET /api/assets ---------- */
 export const getAssets = async (req, res) => {
+  const deep = req.query.deep === 'true'
   const query = { allowRoles: req.user.roleId?.name }
-  query.folderId = req.query.folderId ? req.query.folderId : null
+  let folderId = req.query.folderId ? req.query.folderId : null
+
+  if (deep) {
+    const childIds = await getDescendantFolderIds(folderId)
+    query.folderId = { $in: [folderId, ...childIds] }
+  } else {
+    query.folderId = folderId
+  }
+
   if (req.query.type) query.type = req.query.type
 
   if (req.query.reviewStatus) query.reviewStatus = req.query.reviewStatus

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -1,4 +1,5 @@
 import Folder from '../models/folder.model.js'
+import { getDescendantFolderIds } from '../utils/folderTree.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -25,7 +26,16 @@ export const createFolder = async (req, res) => {
 
 export const getFolders = async (req, res) => {
   const parentId = req.query.parentId || null
-  const query = { parentId, type: req.query.type || 'raw' }
+  const deep = req.query.deep === 'true'
+  const type = req.query.type || 'raw'
+
+  let parentIds = [parentId]
+  if (deep) {
+    const childIds = await getDescendantFolderIds(parentId)
+    parentIds = parentIds.concat(childIds)
+  }
+
+  const query = { parentId: { $in: parentIds }, type }
   if (req.query.tags) {
     const tags = Array.isArray(req.query.tags)
       ? req.query.tags

--- a/server/src/utils/folderTree.js
+++ b/server/src/utils/folderTree.js
@@ -1,0 +1,15 @@
+import Folder from '../models/folder.model.js'
+
+export const getDescendantFolderIds = async (parentId = null) => {
+  const ids = []
+  const queue = [parentId]
+  while (queue.length) {
+    const id = queue.shift()
+    const children = await Folder.find({ parentId: id })
+    for (const child of children) {
+      ids.push(child._id)
+      queue.push(child._id)
+    }
+  }
+  return ids
+}


### PR DESCRIPTION
## Summary
- 新增 `deep` 參數支援遞迴搜尋資料夾與素材
- 前端移除「套用」按鈕並改為監聽標籤變化自動載入
- 更新服務函式以傳遞 `deep` 參數

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847144e95088329aaefb178616b73a6