### PR TITLE
Fix edited upload request

### DIFF
--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -286,7 +286,7 @@ function handleError(_, file) {
 
 async function uploadRequest({ file, onProgress, onSuccess, onError }) {
   try {
-    await uploadAsset(file, currentFolder.value?._id, null, onProgress)
+    await uploadAsset(file, currentFolder.value?._id, { type: 'edited' }, onProgress)
     onSuccess()
   } catch (e) {
     onError(e)


### PR DESCRIPTION
## Summary
- pass `{ type: 'edited' }` when uploading files in ProductLibrary

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471771ec008329b646f1235aeec120