### PR TITLE
Add review stage management

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -77,6 +77,7 @@ const menus = {
 
     { path: '/employees', icon: '👥', label: '人員管理' },
     { path: '/roles', icon: '🛡️', label: '角色設定' },
+    { path: '/review-stages', icon: '✅', label: '審查關卡' },
     { path: '/account', icon: '👤', label: '帳號資訊' }
   ],
   outsource: [

--- a/client/src/permissionNames.js
+++ b/client/src/permissionNames.js
@@ -7,6 +7,7 @@ export const PERMISSION_NAMES = {
   'progress:manage': '進度管理',
   'user:manage': '使用者管理',
   'task:manage': '任務管理',
+  'review:manage': '審查管理',
   'tag:manage': '標籤管理',
   'analytics:view': '統計檢視'
 }

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -11,6 +11,7 @@ import ProductLibrary from '../views/ProductLibrary.vue'
 import EmployeeManager from '../views/EmployeeManager.vue'
 import RoleSettings from '../views/RoleSettings.vue'
 import TagManager from '../views/TagManager.vue'
+import ReviewSettings from '../views/ReviewSettings.vue'
 
 
 const routes = [
@@ -32,7 +33,8 @@ const routes = [
 
       { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { role: 'manager' } },
       { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { role: 'manager' } },
-      { path: 'tags', name: 'TagManager', component: TagManager, meta: { role: 'manager' } }
+      { path: 'tags', name: 'TagManager', component: TagManager, meta: { role: 'manager' } },
+      { path: 'review-stages', name: 'ReviewSettings', component: ReviewSettings, meta: { role: 'manager' } }
     ]
   },
   // 404

--- a/client/src/services/reviewStages.js
+++ b/client/src/services/reviewStages.js
@@ -1,0 +1,13 @@
+import api from './api'
+
+export const fetchReviewStages = () =>
+  api.get('/review-stages').then(r => r.data)
+
+export const createReviewStage = data =>
+  api.post('/review-stages', data).then(r => r.data)
+
+export const updateReviewStage = (id, data) =>
+  api.put(`/review-stages/${id}`, data).then(r => r.data)
+
+export const deleteReviewStage = id =>
+  api.delete(`/review-stages/${id}`).then(r => r.data)

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -286,7 +286,7 @@ function handleError(_, file) {
 
 async function uploadRequest({ file, onProgress, onSuccess, onError }) {
   try {
-    await uploadAsset(file, currentFolder.value?._id, null, onProgress)
+    await uploadAsset(file, currentFolder.value?._id, { type: 'edited' }, onProgress)
     onSuccess()
   } catch (e) {
     onError(e)

--- a/client/src/views/ReviewSettings.vue
+++ b/client/src/views/ReviewSettings.vue
@@ -1,0 +1,96 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { fetchReviewStages, createReviewStage, updateReviewStage, deleteReviewStage } from '../services/reviewStages'
+import { fetchUsers } from '../services/user'
+import { useAuthStore } from '../stores/auth'
+
+const store = useAuthStore()
+if (store.role !== 'manager') {
+  window.location.href = '/'
+}
+
+const stages = ref([])
+const users = ref([])
+const dialog = ref(false)
+const editing = ref(false)
+const form = ref({ name: '', order: 1, responsible: '' })
+
+const loadStages = async () => { stages.value = await fetchReviewStages() }
+const loadUsers = async () => { users.value = await fetchUsers() }
+
+const openCreate = () => {
+  editing.value = false
+  form.value = { name: '', order: 1, responsible: '' }
+  dialog.value = true
+}
+
+const openEdit = s => {
+  editing.value = true
+  form.value = { ...s, responsible: s.responsible?._id }
+  dialog.value = true
+}
+
+const submit = async () => {
+  const data = { name: form.value.name, order: form.value.order, responsible: form.value.responsible }
+  if (editing.value) {
+    await updateReviewStage(form.value._id, data)
+    ElMessage.success('已更新階段')
+  } else {
+    await createReviewStage(data)
+    ElMessage.success('已新增階段')
+  }
+  dialog.value = false
+  await loadStages()
+}
+
+const removeStage = async s => {
+  await ElMessageBox.confirm(`確定刪除「${s.name}」？`, '警告', {
+    confirmButtonText: '刪除',
+    cancelButtonText: '取消',
+    type: 'warning'
+  })
+  await deleteReviewStage(s._id)
+  ElMessage.success('已刪除階段')
+  await loadStages()
+}
+
+onMounted(() => {
+  loadStages()
+  loadUsers()
+})
+</script>
+
+<template>
+  <section class="p-6 space-y-6 bg-white text-gray-800">
+    <h1 class="text-2xl font-bold">審查關卡設定</h1>
+    <el-button type="primary" @click="openCreate">＋ 新增關卡</el-button>
+    <el-table :data="stages" style="width:100%" stripe border>
+      <el-table-column prop="order" label="順序" width="80" />
+      <el-table-column prop="name" label="名稱" />
+      <el-table-column prop="responsible.name" label="負責人" />
+      <el-table-column label="操作" width="160">
+        <template #default="{ row }">
+          <el-button link type="primary" @click="openEdit(row)">編輯</el-button>
+          <el-button link type="danger" @click="removeStage(row)">刪除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialog" :title="editing ? '編輯關卡' : '新增關卡'" width="420px">
+      <el-form label-position="top" @submit.prevent>
+        <el-form-item label="名稱"><el-input v-model="form.name" /></el-form-item>
+        <el-form-item label="順序"><el-input-number v-model="form.order" :min="1" style="width:100%" /></el-form-item>
+        <el-form-item label="負責人">
+          <el-select v-model="form.responsible" placeholder="選擇負責人" style="width:100%">
+            <el-option v-for="u in users" :key="u._id" :label="u.name" :value="u._id" />
+          </el-select>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialog=false">取消</el-button>
+        <el-button type="primary" @click="submit">{{ editing ? '更新' : '建立' }}</el-button>
+      </template>
+    </el-dialog>
+  </section>
+</template>

--- a/server/README.md
+++ b/server/README.md
@@ -46,3 +46,6 @@ npm start                 # 啟動伺服器
 `PUT /api/assets/:id/review` 並傳入 `{ reviewStatus: 'approved' | 'rejected' }`
 更新審核狀態。前端可依 `GET /api/assets?type=edited&reviewStatus=pending`
 取得待審成品。
+
+## 審查關卡 API
+管理者可自 `/api/review-stages` 建立或管理審查關卡，每個關卡包含 `name`、`order` 與 `responsible` 等欄位。

--- a/server/src/config/permissions.js
+++ b/server/src/config/permissions.js
@@ -7,6 +7,7 @@ export const PERMISSIONS = Object.freeze({
   PROGRESS_MANAGE: 'progress:manage',
   USER_MANAGE: 'user:manage',
   TASK_MANAGE: 'task:manage',
+  REVIEW_MANAGE: 'review:manage',
   TAG_MANAGE: 'tag:manage',
   ANALYTICS_VIEW: 'analytics:view'
 })

--- a/server/src/controllers/reviewStage.controller.js
+++ b/server/src/controllers/reviewStage.controller.js
@@ -1,0 +1,22 @@
+import ReviewStage from '../models/reviewStage.model.js'
+
+export const createStage = async (req, res) => {
+  const stage = await ReviewStage.create(req.body)
+  res.status(201).json(stage)
+}
+
+export const getStages = async (_, res) => {
+  const stages = await ReviewStage.find().populate('responsible').sort('order')
+  res.json(stages)
+}
+
+export const updateStage = async (req, res) => {
+  const stage = await ReviewStage.findByIdAndUpdate(req.params.id, req.body, { new: true })
+  if (!stage) return res.status(404).json({ message: '階段不存在' })
+  res.json(stage)
+}
+
+export const deleteStage = async (req, res) => {
+  await ReviewStage.findByIdAndDelete(req.params.id)
+  res.json({ message: '已刪除' })
+}

--- a/server/src/models/reviewStage.model.js
+++ b/server/src/models/reviewStage.model.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose'
+
+const reviewStageSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    order: { type: Number, required: true },
+    responsible: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }
+  },
+  { timestamps: true }
+)
+
+export default mongoose.model('ReviewStage', reviewStageSchema)

--- a/server/src/routes/reviewStage.routes.js
+++ b/server/src/routes/reviewStage.routes.js
@@ -1,0 +1,16 @@
+import { Router } from 'express'
+import { protect } from '../middleware/auth.js'
+import { requirePerm } from '../middleware/permission.js'
+import { PERMISSIONS } from '../config/permissions.js'
+import { createStage, getStages, updateStage, deleteStage } from '../controllers/reviewStage.controller.js'
+
+const router = Router()
+
+router.use(protect)
+
+router.get('/', requirePerm(PERMISSIONS.REVIEW_MANAGE), getStages)
+router.post('/', requirePerm(PERMISSIONS.REVIEW_MANAGE), createStage)
+router.put('/:id', requirePerm(PERMISSIONS.REVIEW_MANAGE), updateStage)
+router.delete('/:id', requirePerm(PERMISSIONS.REVIEW_MANAGE), deleteStage)
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -41,6 +41,7 @@ import roleRoutes     from './routes/role.routes.js'
 import tagRoutes      from './routes/tag.routes.js'
 import healthRoutes   from './routes/health.routes.js'
 import permissionsRoutes from './routes/permissions.routes.js'
+import reviewStageRoutes from './routes/reviewStage.routes.js'
 // import analyticsRoutes from './routes/analytics.routes.js' // 未啟用
 
 app.use('/api/auth',     authRoutes)
@@ -53,6 +54,7 @@ app.use('/api/progress', progressRoutes)
 app.use('/api/roles',    roleRoutes)
 app.use('/api/tags',     tagRoutes)
 app.use('/api/permissions', permissionsRoutes)
+app.use('/api/review-stages', reviewStageRoutes)
 app.use('/api/health',   healthRoutes)
 // app.use('/api/analytics', analyticsRoutes)
 

--- a/server/tests/reviewStage.test.js
+++ b/server/tests/reviewStage.test.js
@@ -1,0 +1,50 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import reviewStageRoutes from '../src/routes/reviewStage.routes.js'
+import authRoutes from '../src/routes/auth.routes.js'
+import ReviewStage from '../src/models/reviewStage.model.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/review-stages', reviewStageRoutes)
+
+  const role = await Role.create({ name: 'manager', permissions: ['review:manage'] })
+  await User.create({ username: 'admin', password: 'pwd', email: 'admin@test', roleId: role._id })
+  const user = await User.findOne({ username: 'admin' })
+  const res = await request(app).post('/api/auth/login').send({ username: 'admin', password: 'pwd' })
+  token = res.body.token
+  global.userId = user._id
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+describe('ReviewStage CRUD', () => {
+  it('create stage', async () => {
+    const res = await request(app)
+      .post('/api/review-stages')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: '審核一', order: 1, responsible: global.userId })
+      .expect(201)
+    expect(res.body.name).toBe('審核一')
+  })
+})


### PR DESCRIPTION
## Summary
- add review stage model and CRUD APIs
- introduce `review:manage` permission
- allow managers to configure review stages in new page
- update sidebar and router
- include basic tests

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471771ec008329b646f1235aeec120