### PR TITLE
Add asset update permission check

### DIFF
--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -37,7 +37,12 @@ router.get('/recent', protect, requirePerm(PERMISSIONS.ASSET_READ), getRecentAss
 
 /* ★ 新增：更新檔名／描述 */
 
-router.put('/:id', protect, updateAsset)
+router.put(
+  '/:id',
+  protect,
+  requirePerm(PERMISSIONS.ASSET_UPDATE),
+  updateAsset
+)
 router.put('/:id/review', protect, reviewAsset)
 router.get('/:id/stages', protect, getAssetStages)
 router.put('/:id/stages/:stageId', protect, updateStageStatus)

--- a/server/tests/asset.test.js
+++ b/server/tests/asset.test.js
@@ -58,3 +58,13 @@ describe('Asset review', () => {
     expect(res.body.reviewStatus).toBe('approved')
   })
 })
+
+describe('Asset update permission', () => {
+  it('should return 403 when no permission', async () => {
+    await request(app)
+      .put(`/api/assets/${assetId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'new title' })
+      .expect(403)
+  })
+})


### PR DESCRIPTION
## Summary
- enforce asset update permission
- test that asset update returns 403 without permission

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474dc0944c832986baa809d7bedca8