### PR TITLE
Validate responsible user in review stage

### DIFF
--- a/server/src/controllers/reviewStage.controller.js
+++ b/server/src/controllers/reviewStage.controller.js
@@ -1,6 +1,10 @@
 import ReviewStage from '../models/reviewStage.model.js'
+import User from '../models/user.model.js'
 
 export const createStage = async (req, res) => {
+  const user = await User.findById(req.body.responsible)
+  if (!user) return res.status(400).json({ message: '找不到使用者' })
+
   const stage = await ReviewStage.create(req.body)
   res.status(201).json(stage)
 }
@@ -11,6 +15,11 @@ export const getStages = async (_, res) => {
 }
 
 export const updateStage = async (req, res) => {
+  if (req.body.responsible) {
+    const user = await User.findById(req.body.responsible)
+    if (!user) return res.status(400).json({ message: '找不到使用者' })
+  }
+
   const stage = await ReviewStage.findByIdAndUpdate(req.params.id, req.body, { new: true })
   if (!stage) return res.status(404).json({ message: '階段不存在' })
   res.json(stage)

--- a/server/tests/reviewStage.test.js
+++ b/server/tests/reviewStage.test.js
@@ -15,6 +15,7 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
 let mongo
 let app
 let token
+let stageId
 
 beforeAll(async () => {
   mongo = await MongoMemoryServer.create()
@@ -46,5 +47,24 @@ describe('ReviewStage CRUD', () => {
       .send({ name: '審核一', order: 1, responsible: global.userId })
       .expect(201)
     expect(res.body.name).toBe('審核一')
+    stageId = res.body._id
+  })
+
+  it('create stage with invalid responsible', async () => {
+    const fakeId = new mongoose.Types.ObjectId()
+    await request(app)
+      .post('/api/review-stages')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: '審核二', order: 2, responsible: fakeId })
+      .expect(400)
+  })
+
+  it('update stage with invalid responsible', async () => {
+    const fakeId = new mongoose.Types.ObjectId()
+    await request(app)
+      .put(`/api/review-stages/${stageId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ responsible: fakeId })
+      .expect(400)
   })
 })


### PR DESCRIPTION
## Summary
- ensure responsible user exists when creating/updating review stage
- test invalid responsible user cases

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474dc222048329b9adeda0a1c847e0