### PR TITLE
新增使用者姓名欄位與前端表單更新

### DIFF
--- a/client/src/views/Account.vue
+++ b/client/src/views/Account.vue
@@ -5,12 +5,13 @@ import api from '../services/api'
 
 const store = useAuthStore()
 const username = ref(store.user?.username || '')
+const name = ref(store.user?.name || '')
 const email = ref(store.user?.email || '')
 const password = ref('')
 
 const onSubmit = async () => {
   try {
-    const payload = { username: username.value, email: email.value }
+    const payload = { username: username.value, name: name.value, email: email.value }
     if (password.value) payload.password = password.value
     const { data } = await api.put('/user/profile', payload)
     store.user = data
@@ -25,7 +26,8 @@ const onSubmit = async () => {
 <template>
   <h1 class="text-2xl font-bold mb-4">帳號資訊</h1>
   <el-form @submit.prevent="onSubmit" class="w-80 space-y-6">
-    <el-input v-model="username" placeholder="使用者名稱" clearable />
+    <el-input v-model="username" placeholder="登入帳號" clearable />
+    <el-input v-model="name" placeholder="姓名" clearable />
     <el-input v-model="email" placeholder="Email" clearable />
     <el-input
       v-model="password"

--- a/client/src/views/EmployeeManager.vue
+++ b/client/src/views/EmployeeManager.vue
@@ -26,6 +26,7 @@ const users = ref([])
 const dialog = ref(false)
 const editing = ref(false)        // true=編輯, false=新增
 const form = ref({
+  username: '',
   name: '',
   email: '',
   role: 'employee',
@@ -38,7 +39,7 @@ const loadUsers = async () => { users.value = await fetchUsers() }
 /* 開新增/編輯 Dialog */
 const openCreate = () => {
   editing.value = false
-  form.value = { name: '', email: '', role: 'employee', password: '' }
+  form.value = { username: '', name: '', email: '', role: 'employee', password: '' }
   dialog.value = true
 }
 const openEdit = u => {
@@ -49,7 +50,7 @@ const openEdit = u => {
 
 /* 送出 */
 const submit = async () => {
-  if (!form.value.name.trim() || !form.value.email.trim()) return
+  if (!form.value.username.trim() || !form.value.name.trim() || !form.value.email.trim()) return
   if (editing.value) {
     await updateUser(form.value._id, form.value)
     ElMessage.success('已更新帳號')
@@ -85,6 +86,7 @@ onMounted(() => {
 
     <!-- 使用者表格 -->
     <el-table :data="users" style="width:100%" stripe border>
+      <el-table-column prop="username" label="登入帳號" />
       <el-table-column prop="name" label="姓名" />
       <el-table-column prop="email" label="Email" />
       <el-table-column prop="role" label="角色" :formatter="(_, __, cell) => {
@@ -103,6 +105,7 @@ onMounted(() => {
     <!-- 新增 / 編輯 Dialog -->
     <el-dialog v-model="dialog" :title="editing ? '編輯帳號' : '新增帳號'" width="420px">
       <el-form label-position="top" @submit.prevent>
+        <el-form-item label="登入帳號"><el-input v-model="form.username" /></el-form-item>
         <el-form-item label="姓名"><el-input v-model="form.name" /></el-form-item>
         <el-form-item label="Email"><el-input v-model="form.email" /></el-form-item>
         <el-form-item label="角色">

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -32,11 +32,11 @@ export const getAllUsers = async (req,res) => {
 
 /* 新增 */
 export const createUser = async (req,res) => {
-  const { name,email,role,password } = req.body
+  const { username, name, email, role, password } = req.body
   if (await User.findOne({ email })) return res.status(400).json({ message:'Email 已存在' })
   const hash = await bcrypt.hash(password,12)
   const roleDoc = await Role.findOne({ name: role })
-  const u = await User.create({ name,email,roleId: roleDoc?._id,password:hash })
+  const u = await User.create({ username, name, email, roleId: roleDoc?._id, password:hash })
   const populated = await u.populate('roleId')
   res.status(201).json({
     ...populated.toObject(),
@@ -46,11 +46,14 @@ export const createUser = async (req,res) => {
 
 /* 更新 */
 export const updateUser = async (req,res) => {
-  const { name,email,role,password } = req.body
+  const { username, name, email, role, password } = req.body
   const u = await User.findById(req.params.id)
   if (!u) return res.status(404).json({ message:'找不到使用者' })
+  if (username && username!==u.username && await User.findOne({ username }))
+    return res.status(400).json({ message:'使用者已存在' })
   if (email && email!==u.email && await User.findOne({ email }))
     return res.status(400).json({ message:'Email 已存在' })
+  if (username) u.username = username
   if (name)  u.name  = name
   if (email) u.email = email
   if (role) {
@@ -83,7 +86,7 @@ export const getProfile = async (req,res) => {
 
 /* 更新個人資料 */
 export const updateProfile = async (req,res) => {
-  const { username,email,password } = req.body
+  const { username, name, email, password } = req.body
   const u = await User.findById(req.user._id)
   if (!u) return res.status(404).json({ message:'找不到使用者' })
   if (username && username!==u.username && await User.findOne({ username }))
@@ -91,6 +94,7 @@ export const updateProfile = async (req,res) => {
   if (email && email!==u.email && await User.findOne({ email }))
     return res.status(400).json({ message:'Email 已存在' })
   if (username) u.username = username
+  if (name)     u.name     = name
   if (email)    u.email    = email
   if (password) u.password = await bcrypt.hash(password,12)
   await u.save()

--- a/server/src/models/user.model.js
+++ b/server/src/models/user.model.js
@@ -9,6 +9,7 @@ import Role from './role.model.js'
 const userSchema = new mongoose.Schema(
   {
     username: { type: String, required: true, unique: true },
+    name: { type: String },
     password: { type: String, required: true, select: false },
     email: { type: String, required: true, unique: true },
     // 角色參照 Role 集合

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -9,9 +9,9 @@ import { PERMISSIONS } from '../config/permissions.js'
 dotenv.config()
 
 const users = [
-  { username: 'employee', password: '123456', email: 'employee@example.com', role: ROLES.EMPLOYEE },
-  { username: 'manager', password: '123456', email: 'manager@example.com', role: ROLES.MANAGER },
-  { username: 'outsource', password: '123456', email: 'outsource@example.com', role: ROLES.OUTSOURCE }
+  { username: 'employee', name: '員工', password: '123456', email: 'employee@example.com', role: ROLES.EMPLOYEE },
+  { username: 'manager', name: '經理', password: '123456', email: 'manager@example.com', role: ROLES.MANAGER },
+  { username: 'outsource', name: '外包', password: '123456', email: 'outsource@example.com', role: ROLES.OUTSOURCE }
 ]
 
 const seed = async () => {


### PR DESCRIPTION
## Summary
- 後端 User model 新增 `name` 欄位
- 調整使用者相關 API 以同時處理 `username` 與 `name`
- 種子資料新增預設姓名
- 員工管理與帳號設定畫面可編輯登入帳號與姓名

## Testing
- `npm test --prefix server` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484d07a7d48329ba08127bcab5583c