### PR TITLE
限制僅負責人可更新審核階段

### DIFF
--- a/server/src/controllers/reviewRecord.controller.js
+++ b/server/src/controllers/reviewRecord.controller.js
@@ -25,8 +25,7 @@ export const updateStageStatus = async (req, res) => {
   const stage = await ReviewStage.findById(stageId).populate('responsible')
   if (!stage) return res.status(404).json({ message: '階段不存在' })
 
-  const isManager = req.user.roleId?.name === 'manager'
-  if (!isManager && String(stage.responsible._id) !== String(req.user._id)) {
+  if (String(stage.responsible._id) !== String(req.user._id)) {
     return res.status(403).json({ message: '無權審核此階段' })
   }
 


### PR DESCRIPTION
## Summary
- 修改 `updateStageStatus`，只允許階段負責人更新
- 移除 `isManager` 判斷

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684854e6971483298bb125425cf0c00e