### PR TITLE
檢查前置審核狀態

### DIFF
--- a/server/tests/reviewRecord.test.js
+++ b/server/tests/reviewRecord.test.js
@@ -52,6 +52,14 @@ afterAll(async () => {
 })
 
 describe('updateStageStatus', () => {
+  it('should fail when previous stages are incomplete', async () => {
+    await request(app)
+      .put(`/api/assets/${assetId}/stages/${stageId2}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ completed: true })
+      .expect(400)
+  })
+
   it('should set reviewStatus to pending when not all stages done', async () => {
     await request(app)
       .put(`/api/assets/${assetId}/stages/${stageId1}`)


### PR DESCRIPTION
## Summary
- 檢查後續關卡更新時是否有未完成的前置關卡
- 新增測試覆蓋此邏輯

## Testing
- `npm test --prefix server` *(失敗：找不到 jest 指令)*

------
https://chatgpt.com/codex/tasks/task_e_684854e799688329ba0723f503a15968