### PR TITLE
Fix deep fetch params

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -178,8 +178,8 @@ const sidebarBg = computed(() => getComputedStyle(document.querySelector('.sideb
 const detailTitle = computed(() => previewItem.value ? previewItem.value.filename : currentFolder.value?.name || '資訊')
 
 async function loadData(id = null) {
-  folders.value = await fetchFolders(id, filterTags.value, 'raw', true)
-  assets.value = id ? await fetchAssets(id, 'raw', filterTags.value, true) : []
+  folders.value = await fetchFolders(id, filterTags.value, 'raw')
+  assets.value = id ? await fetchAssets(id, 'raw', filterTags.value) : []
   allTags.value = Array.from(new Set([
     ...folders.value.flatMap(f => f.tags || []),
     ...assets.value.flatMap(a => a.tags || [])

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -200,8 +200,8 @@ const sidebarBg = computed(() => getComputedStyle(document.querySelector('.sideb
 const detailTitle = computed(() => previewItem.value ? previewItem.value.filename : currentFolder.value?.name || '資訊')
 
 async function loadData(id = null) {
-  folders.value = await fetchFolders(id, filterTags.value, 'edited', true)
-  assets.value = id ? await fetchProducts(id, filterTags.value, true) : []
+  folders.value = await fetchFolders(id, filterTags.value, 'edited')
+  assets.value = id ? await fetchProducts(id, filterTags.value) : []
   allTags.value = Array.from(new Set([
     ...folders.value.flatMap(f => f.tags || []),
     ...assets.value.flatMap(a => a.tags || [])


### PR DESCRIPTION
## Summary
- 更新 AssetLibrary 與 ProductLibrary 的 `loadData` 函式，使 `fetchFolders`、`fetchAssets`、`fetchProducts` 不再帶入 `deep=true`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485ff9d71c8329a48fdd10b2127b0c