### PR TITLE
新增客戶與廣告日資料管理功能

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -1,0 +1,37 @@
+import mongoose from 'mongoose'
+import AdDaily from '../models/adDaily.model.js'
+
+export const createAdDaily = async (req, res) => {
+  const rec = await AdDaily.create({ ...req.body, clientId: req.params.clientId })
+  res.status(201).json(rec)
+}
+
+export const getAdDaily = async (req, res) => {
+  const query = { clientId: req.params.clientId }
+  if (req.query.start && req.query.end) {
+    query.date = { $gte: new Date(req.query.start), $lte: new Date(req.query.end) }
+  }
+  const list = await AdDaily.find(query).sort({ date: 1 })
+  res.json(list)
+}
+
+export const getWeeklyData = async (req, res) => {
+  const match = { clientId: new mongoose.Types.ObjectId(req.params.clientId) }
+  if (req.query.start && req.query.end) {
+    match.date = { $gte: new Date(req.query.start), $lte: new Date(req.query.end) }
+  }
+  const data = await AdDaily.aggregate([
+    { $match: match },
+    {
+      $group: {
+        _id: { year: { $isoWeekYear: '$date' }, week: { $isoWeek: '$date' } },
+        spent: { $sum: '$spent' },
+        reach: { $sum: '$reach' },
+        impressions: { $sum: '$impressions' },
+        clicks: { $sum: '$clicks' }
+      }
+    },
+    { $sort: { '_id.year': 1, '_id.week': 1 } }
+  ])
+  res.json(data)
+}

--- a/server/src/controllers/client.controller.js
+++ b/server/src/controllers/client.controller.js
@@ -1,0 +1,28 @@
+import Client from '../models/client.model.js'
+
+export const createClient = async (req, res) => {
+  const client = await Client.create(req.body)
+  res.status(201).json(client)
+}
+
+export const getClients = async (_req, res) => {
+  const clients = await Client.find()
+  res.json(clients)
+}
+
+export const getClient = async (req, res) => {
+  const client = await Client.findById(req.params.id)
+  if (!client) return res.status(404).json({ message: '客戶不存在' })
+  res.json(client)
+}
+
+export const updateClient = async (req, res) => {
+  const client = await Client.findByIdAndUpdate(req.params.id, req.body, { new: true })
+  if (!client) return res.status(404).json({ message: '客戶不存在' })
+  res.json(client)
+}
+
+export const deleteClient = async (req, res) => {
+  await Client.findByIdAndDelete(req.params.id)
+  res.json({ message: '客戶已刪除' })
+}

--- a/server/src/models/adDaily.model.js
+++ b/server/src/models/adDaily.model.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose'
+
+const adDailySchema = new mongoose.Schema(
+  {
+    clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true },
+    date: { type: Date, required: true },
+    spent: { type: Number, default: 0 },
+    reach: { type: Number, default: 0 },
+    impressions: { type: Number, default: 0 },
+    clicks: { type: Number, default: 0 }
+  },
+  { timestamps: true }
+)
+
+adDailySchema.index({ clientId: 1, date: 1 }, { unique: true })
+
+export default mongoose.model('AdDaily', adDailySchema)

--- a/server/src/models/client.model.js
+++ b/server/src/models/client.model.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose'
+
+const clientSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    phone: { type: String, default: '' },
+    email: { type: String, default: '' },
+    address: { type: String, default: '' }
+  },
+  { timestamps: true }
+)
+
+export default mongoose.model('Client', clientSchema)

--- a/server/src/routes/adDaily.routes.js
+++ b/server/src/routes/adDaily.routes.js
@@ -1,0 +1,19 @@
+import { Router } from 'express'
+import { protect } from '../middleware/auth.js'
+import {
+  createAdDaily,
+  getAdDaily,
+  getWeeklyData
+} from '../controllers/adDaily.controller.js'
+
+const router = Router({ mergeParams: true })
+
+router.use(protect)
+
+router.route('/')
+  .post(createAdDaily)
+  .get(getAdDaily)
+
+router.get('/weekly', getWeeklyData)
+
+export default router

--- a/server/src/routes/client.routes.js
+++ b/server/src/routes/client.routes.js
@@ -1,0 +1,24 @@
+import { Router } from 'express'
+import { protect } from '../middleware/auth.js'
+import {
+  createClient,
+  getClients,
+  getClient,
+  updateClient,
+  deleteClient
+} from '../controllers/client.controller.js'
+
+const router = Router()
+
+router.use(protect)
+
+router.route('/')
+  .post(createClient)
+  .get(getClients)
+
+router.route('/:id')
+  .get(getClient)
+  .put(updateClient)
+  .delete(deleteClient)
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -42,6 +42,8 @@ import tagRoutes      from './routes/tag.routes.js'
 import healthRoutes   from './routes/health.routes.js'
 import permissionsRoutes from './routes/permissions.routes.js'
 import reviewStageRoutes from './routes/reviewStage.routes.js'
+import clientRoutes     from './routes/client.routes.js'
+import adDailyRoutes    from './routes/adDaily.routes.js'
 // import analyticsRoutes from './routes/analytics.routes.js' // 未啟用
 
 app.use('/api/auth',     authRoutes)
@@ -53,6 +55,8 @@ app.use('/api/tasks',    taskRoutes)
 app.use('/api/progress', progressRoutes)
 app.use('/api/roles',    roleRoutes)
 app.use('/api/tags',     tagRoutes)
+app.use('/api/clients',  clientRoutes)
+app.use('/api/clients/:clientId/ad-daily', adDailyRoutes)
 app.use('/api/permissions', permissionsRoutes)
 app.use('/api/review-stages', reviewStageRoutes)
 app.use('/api/health',   healthRoutes)

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -1,0 +1,70 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import authRoutes from '../src/routes/auth.routes.js'
+import clientRoutes from '../src/routes/client.routes.js'
+import adDailyRoutes from '../src/routes/adDaily.routes.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+let clientId
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/clients', clientRoutes)
+  app.use('/api/clients/:clientId/ad-daily', adDailyRoutes)
+
+  const role = await Role.create({ name: 'manager' })
+  await User.create({ username: 'admin', password: 'pwd', email: 'admin@test', roleId: role._id })
+  const res = await request(app).post('/api/auth/login').send({ username: 'admin', password: 'pwd' })
+  token = res.body.token
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+describe('Client and AdDaily', () => {
+  it('create client', async () => {
+    const res = await request(app)
+      .post('/api/clients')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: '測試客戶', email: 'a@test.com' })
+      .expect(201)
+    expect(res.body.name).toBe('測試客戶')
+    clientId = res.body._id
+  })
+
+  it('weekly aggregate', async () => {
+    const start = new Date('2024-01-01')
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(start)
+      d.setDate(start.getDate() + i)
+      await request(app)
+        .post(`/api/clients/${clientId}/ad-daily`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ date: d.toISOString(), spent: 10 })
+        .expect(201)
+    }
+
+    const res = await request(app)
+      .get(`/api/clients/${clientId}/ad-daily/weekly`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(res.body[0].spent).toBe(70)
+  })
+})


### PR DESCRIPTION
## Summary
- 建立 `Client` 及 `AdDaily` model
- 新增對應 controller 與 RESTful 路由
- 於 `server.js` 註冊 `/api/clients` 與廣告日資料路由
- 增加測試 `clientAdDaily.test.js` 驗證客戶建立及每週彙總

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499994d9388329b95547560f1056ff