### PR TITLE
Implement role-based menu controls

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -48,6 +48,7 @@
 import { ref, computed, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
+import { MENU_NAMES } from '../menuNames'
 import { Menu, SwitchButton } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
 
@@ -59,34 +60,28 @@ const store = useAuthStore()
 const router = useRouter()
 const route = useRoute()
 
-/* 角色對應選單 */
-const menus = {
-  employee: [
-    { path: '/', icon: '🏠', label: '首頁' },
-    { path: '/progress', icon: '📈', label: '進度追踪' },
-    { path: '/assets', icon: '🎞️', label: '素材庫' },
-    { path: '/products', icon: '🎬', label: '成品區' },
-
-    { path: '/account', icon: '👤', label: '帳號資訊' }
-  ],
-  manager: [
-    { path: '/', icon: '🏠', label: '首頁' },
-    { path: '/progress', icon: '📈', label: '進度追踪' },
-    { path: '/assets', icon: '🎞️', label: '素材庫' },
-    { path: '/products', icon: '🎬', label: '成品區' },
-
-    { path: '/employees', icon: '👥', label: '人員管理' },
-    { path: '/roles', icon: '🛡️', label: '角色設定' },
-    { path: '/review-stages', icon: '✅', label: '審查關卡' },
-    { path: '/ad-data', icon: '📊', label: '廣告數據' },
-    { path: '/account', icon: '👤', label: '帳號資訊' }
-  ],
-  outsource: [
-    { path: '/assets', icon: '🎞️', label: '素材庫' },
-    { path: '/progress', icon: '📈', label: '任務追踪' }
-  ]
+/* 全部選單定義 */
+const allMenus = {
+  dashboard: { path: '/', icon: '🏠' },
+  progress: { path: '/progress', icon: '📈' },
+  assets: { path: '/assets', icon: '🎞️' },
+  products: { path: '/products', icon: '🎬' },
+  employees: { path: '/employees', icon: '👥' },
+  roles: { path: '/roles', icon: '🛡️' },
+  tags: { path: '/tags', icon: '🏷️' },
+  'review-stages': { path: '/review-stages', icon: '✅' },
+  'ad-data': { path: '/ad-data', icon: '📊' },
+  account: { path: '/account', icon: '👤' }
 }
-const navItems = computed(() => menus[store.role] || [])
+
+const navItems = computed(() => {
+  const codes = store.user?.menus || []
+  return codes.map(c => ({
+    path: allMenus[c]?.path || '/',
+    icon: allMenus[c]?.icon || '❓',
+    label: MENU_NAMES[c] || c
+  }))
+})
 
 /* 事件 */
 const toggleCollapse = () => (isCollapsed.value = !isCollapsed.value)

--- a/client/src/menuNames.js
+++ b/client/src/menuNames.js
@@ -1,0 +1,12 @@
+export const MENU_NAMES = {
+  dashboard: '首頁',
+  progress: '進度追踪',
+  assets: '素材庫',
+  products: '成品區',
+  employees: '人員管理',
+  roles: '角色設定',
+  tags: '標籤管理',
+  'review-stages': '審查關卡',
+  'ad-data': '廣告數據',
+  account: '帳號資訊'
+}

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -26,17 +26,17 @@ const routes = [
     path: '/',
     component: DashboardLayout,
     children: [
-      { path: '', name: 'Dashboard', component: Dashboard },
-      { path: 'account', name: 'Account', component: Account },
-      { path: 'progress', name: 'Progress', component: Progress },
-      { path: 'assets', name: 'Assets', component: AssetLibrary },
-      { path: 'products', name: 'Products', component: ProductLibrary },
+      { path: '', name: 'Dashboard', component: Dashboard, meta: { menu: 'dashboard' } },
+      { path: 'account', name: 'Account', component: Account, meta: { menu: 'account' } },
+      { path: 'progress', name: 'Progress', component: Progress, meta: { menu: 'progress' } },
+      { path: 'assets', name: 'Assets', component: AssetLibrary, meta: { menu: 'assets' } },
+      { path: 'products', name: 'Products', component: ProductLibrary, meta: { menu: 'products' } },
 
-      { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { role: 'manager' } },
-      { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { role: 'manager' } },
-      { path: 'tags', name: 'TagManager', component: TagManager, meta: { role: 'manager' } },
-      { path: 'review-stages', name: 'ReviewSettings', component: ReviewSettings, meta: { role: 'manager' } },
-      { path: 'ad-data', name: 'AdData', component: AdData, meta: { role: 'manager' } }
+      { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { menu: 'employees' } },
+      { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { menu: 'roles' } },
+      { path: 'tags', name: 'TagManager', component: TagManager, meta: { menu: 'tags' } },
+      { path: 'review-stages', name: 'ReviewSettings', component: ReviewSettings, meta: { menu: 'review-stages' } },
+      { path: 'ad-data', name: 'AdData', component: AdData, meta: { menu: 'ad-data' } }
     ]
   },
   // 404
@@ -55,7 +55,8 @@ router.beforeEach((to) => {
 
   // 若尚未登入，導向 login
   if (!store.isAuthenticated) return '/login'
-  if (to.meta.role && store.role !== to.meta.role) return '/'
+  const menus = store.user?.menus || []
+  if (to.meta.menu && !menus.includes(to.meta.menu)) return '/'
   return true
 })
 

--- a/client/src/services/roles.js
+++ b/client/src/services/roles.js
@@ -14,3 +14,6 @@ export const deleteRole = id =>
 
 export const fetchPermissions = () =>
   api.get('/permissions').then(r => r.data)
+
+export const fetchMenus = () =>
+  api.get('/menus').then(r => r.data)

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -5,7 +5,7 @@ import { login as loginService } from '../services/auth'
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
-    user: null,          // 使用者資訊
+    user: { menus: [] },          // 使用者資訊
     token: Cookies.get('token') || null
   }),
   getters: {
@@ -23,7 +23,7 @@ export const useAuthStore = defineStore('auth', {
     /* ---------- 登出 ---------- */
     logout() {
       this.token = null
-      this.user = null
+      this.user = { menus: [] }
       Cookies.remove('token')
     },
     /* ---------- 讀取個人資料 ---------- */

--- a/client/src/views/RoleSettings.vue
+++ b/client/src/views/RoleSettings.vue
@@ -2,8 +2,9 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { fetchRoles, createRole, updateRole, deleteRole, fetchPermissions } from '../services/roles'
+import { fetchRoles, createRole, updateRole, deleteRole, fetchPermissions, fetchMenus } from '../services/roles'
 import { PERMISSION_NAMES } from '../permissionNames'
+import { MENU_NAMES } from '../menuNames'
 import { useAuthStore } from '../stores/auth'
 
 const store = useAuthStore()
@@ -15,9 +16,11 @@ const roles = ref([])
 const dialog = ref(false)
 const editing = ref(false)
 const permissionList = ref([])
+const menuList = ref([])
 const form = ref({
   name: '',
-  permissions: []
+  permissions: [],
+  menus: []
 })
 
 const loadRoles = async () => {
@@ -29,22 +32,32 @@ const loadPermissions = async () => {
   permissionList.value = codes.map(code => ({ value: code, label: PERMISSION_NAMES[code] }))
 }
 
+const loadMenus = async () => {
+  const codes = await fetchMenus()
+  menuList.value = codes.map(code => ({ value: code, label: MENU_NAMES[code] }))
+}
+
 const openCreate = () => {
   editing.value = false
-  form.value = { name: '', permissions: [] }
+  form.value = { name: '', permissions: [], menus: [] }
   dialog.value = true
 }
 
 const openEdit = r => {
   editing.value = true
-  form.value = { ...r, permissions: Array.isArray(r.permissions) ? [...r.permissions] : [] }
+  form.value = {
+    ...r,
+    permissions: Array.isArray(r.permissions) ? [...r.permissions] : [],
+    menus: Array.isArray(r.menus) ? [...r.menus] : []
+  }
   dialog.value = true
 }
 
 const submit = async () => {
   const data = {
     name: form.value.name,
-    permissions: form.value.permissions
+    permissions: form.value.permissions,
+    menus: form.value.menus
   }
   if (editing.value) {
     await updateRole(form.value._id, data)
@@ -71,6 +84,7 @@ const removeRole = async r => {
 onMounted(() => {
   loadRoles()
   loadPermissions()
+  loadMenus()
 })
 </script>
 
@@ -106,6 +120,17 @@ onMounted(() => {
               :label="p.value"
             >
               {{ p.label }}
+            </el-checkbox>
+          </el-checkbox-group>
+        </el-form-item>
+        <el-form-item label="選單">
+          <el-checkbox-group v-model="form.menus">
+            <el-checkbox
+              v-for="m in menuList"
+              :key="m.value"
+              :label="m.value"
+            >
+              {{ m.label }}
             </el-checkbox>
           </el-checkbox-group>
         </el-form-item>

--- a/server/src/config/menus.js
+++ b/server/src/config/menus.js
@@ -1,0 +1,12 @@
+export const MENUS = Object.freeze({
+  DASHBOARD: 'dashboard',
+  PROGRESS: 'progress',
+  ASSETS: 'assets',
+  PRODUCTS: 'products',
+  EMPLOYEES: 'employees',
+  ROLES: 'roles',
+  TAGS: 'tags',
+  REVIEW_STAGES: 'review-stages',
+  AD_DATA: 'ad-data',
+  ACCOUNT: 'account'
+})

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -17,7 +17,8 @@ export const login = async (req, res) => {
     user: {
       id: user._id,
       username: user.username,
-      role: user.roleId?.name
+      role: user.roleId?.name,
+      menus: user.roleId?.menus || []
     }
   })
 }
@@ -38,7 +39,8 @@ export const register = async (req, res) => {
     user: {
       id: newUser._id,
       username: newUser.username,
-      role: roleDoc?.name
+      role: roleDoc?.name,
+      menus: roleDoc?.menus || []
     }
   })
 }

--- a/server/src/controllers/role.controller.js
+++ b/server/src/controllers/role.controller.js
@@ -1,7 +1,11 @@
 import Role from '../models/role.model.js'
 
 export const createRole = async (req, res) => {
-  const role = await Role.create({ name: req.body.name, permissions: req.body.permissions })
+  const role = await Role.create({
+    name: req.body.name,
+    permissions: req.body.permissions,
+    menus: req.body.menus
+  })
   res.status(201).json(role)
 }
 
@@ -17,7 +21,15 @@ export const getRole = async (req, res) => {
 }
 
 export const updateRole = async (req, res) => {
-  const role = await Role.findByIdAndUpdate(req.params.id, req.body, { new: true })
+  const role = await Role.findByIdAndUpdate(
+    req.params.id,
+    {
+      name: req.body.name,
+      permissions: req.body.permissions,
+      menus: req.body.menus
+    },
+    { new: true }
+  )
   if (!role) return res.status(404).json({ message: '\u89d2\u8272\u4e0d\u5b58\u5728' })
   res.json(role)
 }

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -23,7 +23,8 @@ export const getAllUsers = async (req,res) => {
 
   const result = users.map((u) => ({
     ...u.toObject(),
-    role: u.roleId?.name
+    role: u.roleId?.name,
+    menus: u.roleId?.menus || []
   }))
 
   res.json(result)
@@ -38,7 +39,8 @@ export const createUser = async (req,res) => {
   const populated = await u.populate('roleId')
   res.status(201).json({
     ...populated.toObject(),
-    role: populated.roleId?.name
+    role: populated.roleId?.name,
+    menus: populated.roleId?.menus || []
   })
 }
 
@@ -63,7 +65,8 @@ export const updateUser = async (req,res) => {
   const populated = await u.populate('roleId')
   res.json({
     ...populated.toObject(),
-    role: populated.roleId?.name
+    role: populated.roleId?.name,
+    menus: populated.roleId?.menus || []
   })
 }
 
@@ -78,7 +81,8 @@ export const getProfile = async (req,res) => {
   const user = await req.user.populate('roleId')
   res.json({
     ...user.toObject(),
-    role: user.roleId?.name
+    role: user.roleId?.name,
+    menus: user.roleId?.menus || []
   })
 }
 
@@ -97,5 +101,9 @@ export const updateProfile = async (req,res) => {
   if (password) u.password = password
   await u.save()
   const populated = await u.populate('roleId')
-  res.json(populated)
+  res.json({
+    ...populated.toObject(),
+    role: populated.roleId?.name,
+    menus: populated.roleId?.menus || []
+  })
 }

--- a/server/src/models/role.model.js
+++ b/server/src/models/role.model.js
@@ -1,6 +1,7 @@
 
 import mongoose from 'mongoose'
 import { PERMISSIONS } from '../config/permissions.js'
+import { MENUS } from '../config/menus.js'
 
 
 const roleSchema = new mongoose.Schema(
@@ -12,6 +13,15 @@ const roleSchema = new mongoose.Schema(
       validate: {
         validator: (arr) => arr.every((p) => Object.values(PERMISSIONS).includes(p)),
         message: 'Invalid permission'
+      },
+      default: []
+    },
+
+    menus: {
+      type: [String],
+      validate: {
+        validator: (arr) => arr.every((m) => Object.values(MENUS).includes(m)),
+        message: 'Invalid menu'
       },
       default: []
     }

--- a/server/src/routes/menus.routes.js
+++ b/server/src/routes/menus.routes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express'
+import { MENUS } from '../config/menus.js'
+
+const router = Router()
+
+router.get('/', (req, res) => {
+  res.json(Object.values(MENUS))
+})
+
+export default router

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -5,6 +5,7 @@ import User from '../models/user.model.js'
 import Role from '../models/role.model.js'
 import { ROLES } from '../config/roles.js'
 import { PERMISSIONS } from '../config/permissions.js'
+import { MENUS } from '../config/menus.js'
 
 dotenv.config()
 
@@ -24,9 +25,25 @@ const seed = async () => {
 
     // 建立角色資料
     const roleDocs = await Role.insertMany([
-      { name: ROLES.EMPLOYEE },
-      { name: ROLES.MANAGER, permissions: Object.values(PERMISSIONS) },
-      { name: ROLES.OUTSOURCE }
+      {
+        name: ROLES.EMPLOYEE,
+        menus: [
+          MENUS.DASHBOARD,
+          MENUS.PROGRESS,
+          MENUS.ASSETS,
+          MENUS.PRODUCTS,
+          MENUS.ACCOUNT
+        ]
+      },
+      {
+        name: ROLES.MANAGER,
+        permissions: Object.values(PERMISSIONS),
+        menus: Object.values(MENUS)
+      },
+      {
+        name: ROLES.OUTSOURCE,
+        menus: [MENUS.ASSETS, MENUS.PROGRESS]
+      }
     ])
     const roleMap = {}
     for (const r of roleDocs) roleMap[r.name] = r._id

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -41,6 +41,7 @@ import roleRoutes     from './routes/role.routes.js'
 import tagRoutes      from './routes/tag.routes.js'
 import healthRoutes   from './routes/health.routes.js'
 import permissionsRoutes from './routes/permissions.routes.js'
+import menusRoutes from './routes/menus.routes.js'
 import reviewStageRoutes from './routes/reviewStage.routes.js'
 import clientRoutes     from './routes/client.routes.js'
 import adDailyRoutes    from './routes/adDaily.routes.js'
@@ -58,6 +59,7 @@ app.use('/api/tags',     tagRoutes)
 app.use('/api/clients',  clientRoutes)
 app.use('/api/clients/:clientId/ad-daily', adDailyRoutes)
 app.use('/api/permissions', permissionsRoutes)
+app.use('/api/menus', menusRoutes)
 app.use('/api/review-stages', reviewStageRoutes)
 app.use('/api/health',   healthRoutes)
 // app.use('/api/analytics', analyticsRoutes)


### PR DESCRIPTION
## Summary
- add server menu constants and route
- allow roles to store allowed menus
- return menus with user data
- seed initial roles with default menus
- expose menu checkboxes on Role Settings page
- compute sidebar and route guards using user menus

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499ec277408329bc43c365f874c7b5