### PR TITLE
移除標籤選擇欄的 allow-create 屬性

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -114,7 +114,7 @@
             <el-input v-model="detail.description" type="textarea" rows="4" resize="vertical" />
           </el-form-item>
           <el-form-item label="標籤">
-            <el-select v-model="detail.tags" multiple filterable allow-create>
+            <el-select v-model="detail.tags" multiple filterable>
               <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
             </el-select>
           </el-form-item>

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -104,7 +104,7 @@
               <el-input v-model="detail.description" type="textarea" rows="4" resize="vertical" />
             </el-form-item>
             <el-form-item label="標籤">
-              <el-select v-model="detail.tags" multiple filterable allow-create>
+              <el-select v-model="detail.tags" multiple filterable>
                 <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
               </el-select>
             </el-form-item>


### PR DESCRIPTION
## Summary
- AssetLibrary.vue、ProductLibrary.vue 的標籤選擇器不再允許新建自訂標籤

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a23050548329810f8aefe22f0227