### PR TITLE
Update tag loading for libraries

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -152,6 +152,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder } from '../services/folders'
 import { fetchAssets, uploadAsset, updateAsset, deleteAsset } from '../services/assets'
 import { fetchUsers } from '../services/user'
+import { fetchTags } from '../services/tags'
 import { ElMessage } from 'element-plus'
 import { Folder, InfoFilled, Close } from '@element-plus/icons-vue'
 
@@ -186,6 +187,11 @@ const loadUsers = async () => {
   users.value = await fetchUsers()
 }
 
+const loadTags = async () => {
+  const list = await fetchTags()
+  allTags.value = list.map(t => t.name)
+}
+
 /* 預覽 Dialog */
 const previewVisible = ref(false)
 const previewItem = ref(null)
@@ -198,10 +204,6 @@ const detailTitle = computed(() => previewItem.value ? previewItem.value.filenam
 async function loadData(id = null) {
   folders.value = await fetchFolders(id, filterTags.value, 'raw')
   assets.value = id ? await fetchAssets(id, 'raw', filterTags.value) : []
-  allTags.value = Array.from(new Set([
-    ...folders.value.flatMap(f => f.tags || []),
-    ...assets.value.flatMap(a => a.tags || [])
-  ]))
   currentFolder.value = id ? await getFolder(id) : null
   breadcrumb.value = currentFolder.value
     ? await buildBreadcrumb(currentFolder.value)
@@ -210,6 +212,7 @@ async function loadData(id = null) {
 
 onMounted(() => {
   loadData()
+  loadTags()
   loadUsers()
 })
 watch(filterTags, () => loadData(currentFolder.value?._id || null))

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -181,6 +181,7 @@ import {
   fetchAssetStages,
   updateAssetStage
 } from '../services/assets'
+import { fetchTags } from '../services/tags'
 import { useAuthStore } from '../stores/auth'
 import { ElMessage } from 'element-plus'
 import { Folder, InfoFilled } from '@element-plus/icons-vue'
@@ -231,10 +232,6 @@ const detailTitle = computed(() => previewItem.value ? previewItem.value.filenam
 async function loadData(id = null) {
   folders.value = await fetchFolders(id, filterTags.value, 'edited')
   assets.value = id ? await fetchProducts(id, filterTags.value, false, true) : []
-  allTags.value = Array.from(new Set([
-    ...folders.value.flatMap(f => f.tags || []),
-    ...assets.value.flatMap(a => a.tags || [])
-  ]))
   currentFolder.value = id ? await getFolder(id) : null
   breadcrumb.value = currentFolder.value
     ? await buildBreadcrumb(currentFolder.value)
@@ -245,8 +242,14 @@ const loadUsers = async () => {
   users.value = await fetchUsers()
 }
 
+const loadTags = async () => {
+  const list = await fetchTags()
+  allTags.value = list.map(t => t.name)
+}
+
 onMounted(() => {
   loadData()
+  loadTags()
   loadUsers()
 })
 watch(filterTags, () => loadData(currentFolder.value?._id || null))


### PR DESCRIPTION
## Summary
- fetch tags from API for AssetLibrary and ProductLibrary
- keep tag list updated via `loadTags()`

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b61f16e08329bc03cb5a3664f0a6