### PR TITLE
Add role management permission

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -75,11 +75,14 @@ const allMenus = {
 
 const navItems = computed(() => {
   const codes = store.user?.menus || []
-  return codes.map(c => ({
-    path: allMenus[c]?.path || '/',
-    icon: allMenus[c]?.icon || '❓',
-    label: MENU_NAMES[c] || c
-  }))
+  const perms = store.user?.permissions || []
+  return codes
+    .filter(c => (c !== 'roles' || perms.includes('role:manage')))
+    .map(c => ({
+      path: allMenus[c]?.path || '/',
+      icon: allMenus[c]?.icon || '❓',
+      label: MENU_NAMES[c] || c
+    }))
 })
 
 /* 事件 */

--- a/client/src/permissionNames.js
+++ b/client/src/permissionNames.js
@@ -9,5 +9,6 @@ export const PERMISSION_NAMES = {
   'task:manage': '任務管理',
   'review:manage': '審查管理',
   'tag:manage': '標籤管理',
+  'role:manage': '角色管理',
   'analytics:view': '統計檢視'
 }

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -5,7 +5,7 @@ import { login as loginService } from '../services/auth'
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
-    user: { menus: [] },          // 使用者資訊
+    user: { menus: [], permissions: [] },          // 使用者資訊
     token: Cookies.get('token') || null
   }),
   getters: {
@@ -23,7 +23,7 @@ export const useAuthStore = defineStore('auth', {
     /* ---------- 登出 ---------- */
     logout() {
       this.token = null
-      this.user = { menus: [] }
+      this.user = { menus: [], permissions: [] }
       Cookies.remove('token')
     },
     /* ---------- 讀取個人資料 ---------- */

--- a/client/src/views/RoleSettings.vue
+++ b/client/src/views/RoleSettings.vue
@@ -8,7 +8,7 @@ import { MENU_NAMES } from '../menuNames'
 import { useAuthStore } from '../stores/auth'
 
 const store = useAuthStore()
-if (store.role !== 'manager') {
+if (!store.user.permissions.includes('role:manage')) {
   window.location.href = '/'
 }
 

--- a/server/src/config/permissions.js
+++ b/server/src/config/permissions.js
@@ -8,5 +8,6 @@ export const PERMISSIONS = Object.freeze({
   TASK_MANAGE: 'task:manage',
   REVIEW_MANAGE: 'review:manage',
   TAG_MANAGE: 'tag:manage',
+  ROLE_MANAGE: 'role:manage',
   ANALYTICS_VIEW: 'analytics:view'
 })

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -18,7 +18,8 @@ export const login = async (req, res) => {
       id: user._id,
       username: user.username,
       role: user.roleId?.name,
-      menus: user.roleId?.menus || []
+      menus: user.roleId?.menus || [],
+      permissions: user.roleId?.permissions || []
     }
   })
 }
@@ -40,7 +41,8 @@ export const register = async (req, res) => {
       id: newUser._id,
       username: newUser.username,
       role: roleDoc?.name,
-      menus: roleDoc?.menus || []
+      menus: roleDoc?.menus || [],
+      permissions: roleDoc?.permissions || []
     }
   })
 }

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -24,7 +24,8 @@ export const getAllUsers = async (req,res) => {
   const result = users.map((u) => ({
     ...u.toObject(),
     role: u.roleId?.name,
-    menus: u.roleId?.menus || []
+    menus: u.roleId?.menus || [],
+    permissions: u.roleId?.permissions || []
   }))
 
   res.json(result)
@@ -40,7 +41,8 @@ export const createUser = async (req,res) => {
   res.status(201).json({
     ...populated.toObject(),
     role: populated.roleId?.name,
-    menus: populated.roleId?.menus || []
+    menus: populated.roleId?.menus || [],
+    permissions: populated.roleId?.permissions || []
   })
 }
 
@@ -66,7 +68,8 @@ export const updateUser = async (req,res) => {
   res.json({
     ...populated.toObject(),
     role: populated.roleId?.name,
-    menus: populated.roleId?.menus || []
+    menus: populated.roleId?.menus || [],
+    permissions: populated.roleId?.permissions || []
   })
 }
 
@@ -82,7 +85,8 @@ export const getProfile = async (req,res) => {
   res.json({
     ...user.toObject(),
     role: user.roleId?.name,
-    menus: user.roleId?.menus || []
+    menus: user.roleId?.menus || [],
+    permissions: user.roleId?.permissions || []
   })
 }
 
@@ -104,6 +108,7 @@ export const updateProfile = async (req,res) => {
   res.json({
     ...populated.toObject(),
     role: populated.roleId?.name,
-    menus: populated.roleId?.menus || []
+    menus: populated.roleId?.menus || [],
+    permissions: populated.roleId?.permissions || []
   })
 }

--- a/server/src/routes/role.routes.js
+++ b/server/src/routes/role.routes.js
@@ -1,5 +1,7 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
+import { requirePerm } from '../middleware/permission.js'
+import { PERMISSIONS } from '../config/permissions.js'
 import {
   createRole,
   getRoles,
@@ -11,6 +13,7 @@ import {
 const router = Router()
 
 router.use(protect)
+router.use(requirePerm(PERMISSIONS.ROLE_MANAGE))
 
 router.route('/')
   .post(createRole)

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -36,7 +36,7 @@ const seed = async () => {
       },
       {
         name: ROLES.MANAGER,
-        permissions: Object.values(PERMISSIONS),
+        permissions: Object.values(PERMISSIONS), // 包含 ROLE_MANAGE
         menus: Object.values(MENUS)
       },
       {


### PR DESCRIPTION
## Summary
- add new permission `role:manage`
- gate role routes with `requirePerm`
- include role permissions in auth and user responses
- update seeding script to note new permission
- store permissions on the frontend and use them to hide role management UI

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bb733b348329aa8f52e8c435609b