### PR TITLE
Enforce review permission and expose permissions

### DIFF
--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -17,13 +17,6 @@ const parseTags = (t) => {
   }
 }
 
-const managerOnly = (req, res) => {
-  if (req.user.roleId?.name !== 'manager') {
-    res.status(403).json({ message: '僅限 Manager 操作' })
-    return true
-  }
-  return false
-}
 
 /* ---------- POST /api/assets/upload ---------- */
 export const uploadFile = async (req, res) => {
@@ -121,7 +114,6 @@ export const updateAsset = async (req, res) => {
 }
 
 export const reviewAsset = async (req, res) => {
-  if (managerOnly(req, res)) return
   const { reviewStatus } = req.body
   if (!['pending', 'approved', 'rejected'].includes(reviewStatus)) {
     return res.status(400).json({ message: '狀態錯誤' })

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -18,7 +18,8 @@ export const login = async (req, res) => {
       id: user._id,
       username: user.username,
       role: user.roleId?.name,
-      menus: user.roleId?.menus || []
+      menus: user.roleId?.menus || [],
+      permissions: user.roleId?.permissions || []
     }
   })
 }

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -66,7 +66,8 @@ export const updateUser = async (req,res) => {
   res.json({
     ...populated.toObject(),
     role: populated.roleId?.name,
-    menus: populated.roleId?.menus || []
+    menus: populated.roleId?.menus || [],
+    permissions: populated.roleId?.permissions || []
   })
 }
 
@@ -82,7 +83,8 @@ export const getProfile = async (req,res) => {
   res.json({
     ...user.toObject(),
     role: user.roleId?.name,
-    menus: user.roleId?.menus || []
+    menus: user.roleId?.menus || [],
+    permissions: user.roleId?.permissions || []
   })
 }
 
@@ -104,6 +106,7 @@ export const updateProfile = async (req,res) => {
   res.json({
     ...populated.toObject(),
     role: populated.roleId?.name,
-    menus: populated.roleId?.menus || []
+    menus: populated.roleId?.menus || [],
+    permissions: populated.roleId?.permissions || []
   })
 }

--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -43,7 +43,12 @@ router.put(
   requirePerm(PERMISSIONS.ASSET_UPDATE),
   updateAsset
 )
-router.put('/:id/review', protect, reviewAsset)
+router.put(
+  '/:id/review',
+  protect,
+  requirePerm(PERMISSIONS.REVIEW_MANAGE),
+  reviewAsset
+)
 router.get('/:id/stages', protect, getAssetStages)
 router.put('/:id/stages/:stageId', protect, updateStageStatus)
 router.delete('/:id', protect, deleteAsset)    // assets

--- a/server/tests/asset.test.js
+++ b/server/tests/asset.test.js
@@ -26,7 +26,7 @@ beforeAll(async () => {
   app.use('/api/auth', authRoutes)
   app.use('/api/assets', assetRoutes)
 
-  const role = await Role.create({ name: 'manager' })
+  const role = await Role.create({ name: 'manager', permissions: ['review:manage'] })
   await User.create({
     username: 'admin',
     password: 'mypwd',

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -43,5 +43,6 @@ describe('POST /api/auth/login', () => {
 
     expect(res.body).toHaveProperty('token')
     expect(res.body).toHaveProperty('user.role')
+    expect(res.body.user).toHaveProperty('permissions')
   })
 })


### PR DESCRIPTION
## Summary
- require `review:manage` permission when reviewing assets
- remove `managerOnly` check from asset controller
- return user permissions in login and profile APIs
- adjust asset and auth tests for new permission model

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bb71955c8329ba5ff1b46ba32d0b