### PR TITLE
Enable permission-based access

### DIFF
--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -5,7 +5,7 @@ import { login as loginService } from '../services/auth'
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
-    user: { menus: [] },          // 使用者資訊
+    user: { menus: [], permissions: [] }, // 使用者資訊
     token: Cookies.get('token') || null
   }),
   getters: {
@@ -23,7 +23,7 @@ export const useAuthStore = defineStore('auth', {
     /* ---------- 登出 ---------- */
     logout() {
       this.token = null
-      this.user = { menus: [] }
+      this.user = { menus: [], permissions: [] }
       Cookies.remove('token')
     },
     /* ---------- 讀取個人資料 ---------- */

--- a/client/src/views/EmployeeManager.vue
+++ b/client/src/views/EmployeeManager.vue
@@ -15,9 +15,9 @@ const loadRoles = async () => {
   roleOptions.value = roles.map(r => ({ label: r.name, value: r.name }))
 }
 
-/* ---------- 權限檢查：非 manager 直接跳回首頁 ---------- */
+/* ---------- 權限檢查：無權限直接跳回首頁 ---------- */
 const store = useAuthStore()
-if (store.role !== 'manager') {
+if (!store.user.permissions.includes('user:manage')) {
   window.location.href = '/'   // 或用 router.replace('/')
 }
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -192,7 +192,7 @@ const currentFolder = ref(null)
 const editingFolder = ref(null)
 
 const store = useAuthStore()
-const canReview = computed(() => store.role === 'manager')
+const canReview = computed(() => store.user.permissions.includes('review:manage'))
 
 const detail = ref({ title: '', description: '', script: '', tags: [], allowedUsers: [] })
 const showDetail = ref(false)

--- a/client/src/views/ReviewSettings.vue
+++ b/client/src/views/ReviewSettings.vue
@@ -6,7 +6,7 @@ import { fetchUsers } from '../services/user'
 import { useAuthStore } from '../stores/auth'
 
 const store = useAuthStore()
-if (store.role !== 'manager') {
+if (!store.user.permissions.includes('review:manage')) {
   window.location.href = '/'
 }
 

--- a/client/src/views/RoleSettings.vue
+++ b/client/src/views/RoleSettings.vue
@@ -8,7 +8,7 @@ import { MENU_NAMES } from '../menuNames'
 import { useAuthStore } from '../stores/auth'
 
 const store = useAuthStore()
-if (store.role !== 'manager') {
+if (!store.user.permissions.includes('user:manage')) {
   window.location.href = '/'
 }
 

--- a/client/src/views/TagManager.vue
+++ b/client/src/views/TagManager.vue
@@ -5,7 +5,7 @@ import { fetchTags, createTag, updateTag, deleteTag } from '../services/tags'
 import { useAuthStore } from '../stores/auth'
 
 const store = useAuthStore()
-if (store.role !== 'manager') {
+if (!store.user.permissions.includes('tag:manage')) {
   window.location.href = '/'
 }
 

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -18,7 +18,8 @@ export const login = async (req, res) => {
       id: user._id,
       username: user.username,
       role: user.roleId?.name,
-      menus: user.roleId?.menus || []
+      menus: user.roleId?.menus || [],
+      permissions: user.roleId?.permissions || []
     }
   })
 }
@@ -40,7 +41,8 @@ export const register = async (req, res) => {
       id: newUser._id,
       username: newUser.username,
       role: roleDoc?.name,
-      menus: roleDoc?.menus || []
+      menus: roleDoc?.menus || [],
+      permissions: roleDoc?.permissions || []
     }
   })
 }

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -24,7 +24,8 @@ export const getAllUsers = async (req,res) => {
   const result = users.map((u) => ({
     ...u.toObject(),
     role: u.roleId?.name,
-    menus: u.roleId?.menus || []
+    menus: u.roleId?.menus || [],
+    permissions: u.roleId?.permissions || []
   }))
 
   res.json(result)
@@ -40,7 +41,8 @@ export const createUser = async (req,res) => {
   res.status(201).json({
     ...populated.toObject(),
     role: populated.roleId?.name,
-    menus: populated.roleId?.menus || []
+    menus: populated.roleId?.menus || [],
+    permissions: populated.roleId?.permissions || []
   })
 }
 
@@ -66,7 +68,8 @@ export const updateUser = async (req,res) => {
   res.json({
     ...populated.toObject(),
     role: populated.roleId?.name,
-    menus: populated.roleId?.menus || []
+    menus: populated.roleId?.menus || [],
+    permissions: populated.roleId?.permissions || []
   })
 }
 
@@ -82,7 +85,8 @@ export const getProfile = async (req,res) => {
   res.json({
     ...user.toObject(),
     role: user.roleId?.name,
-    menus: user.roleId?.menus || []
+    menus: user.roleId?.menus || [],
+    permissions: user.roleId?.permissions || []
   })
 }
 
@@ -104,6 +108,7 @@ export const updateProfile = async (req,res) => {
   res.json({
     ...populated.toObject(),
     role: populated.roleId?.name,
-    menus: populated.roleId?.menus || []
+    menus: populated.roleId?.menus || [],
+    permissions: populated.roleId?.permissions || []
   })
 }


### PR DESCRIPTION
## Summary
- send `permissions` with login and profile APIs
- record permissions in auth store
- check permissions in manager pages
- allow product review through permission

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bc4dfd1083298e658c0193b3b9a2