### PR TITLE
Add download buttons and auto permissions

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -57,6 +57,9 @@
           <template #header>
             <div class="flex items-center mb-2">
               <div class="flex-1 truncate" :title="a.title || a.filename">📄 {{ a.title || a.filename }}</div>
+              <el-button link size="small" @click.stop="downloadAsset(a)"><el-icon>
+                  <Download />
+                </el-icon>下載</el-button>
               <el-button link size="small" @click.stop="showDetailFor(a, 'asset')"><el-icon>
                   <InfoFilled />
                 </el-icon></el-button>
@@ -139,6 +142,7 @@
       </div>
 
       <template #footer>
+        <el-button type="primary" @click="downloadAsset(previewItem)">下載</el-button>
         <el-button @click="previewVisible = false">關閉</el-button>
       </template>
     </el-dialog>
@@ -154,7 +158,7 @@ import { fetchAssets, uploadAsset, updateAsset, deleteAsset } from '../services/
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
 import { ElMessage } from 'element-plus'
-import { Folder, InfoFilled, Close } from '@element-plus/icons-vue'
+import { Folder, InfoFilled, Close, Download } from '@element-plus/icons-vue'
 
 const folders = ref([])
 const assets = ref([])
@@ -309,6 +313,18 @@ function previewAsset(a) {
   previewItem.value = { ...a, url }
   console.log('[預覽素材]', url)
   previewVisible.value = true
+}
+
+function downloadAsset(asset) {
+  const url = /^\/static\//.test(asset.url)
+    ? asset.url
+    : `/static/${asset.filename}`
+  const link = document.createElement('a')
+  link.href = url
+  link.download = asset.title || asset.filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
 }
 </script>
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -60,6 +60,9 @@
             <div class="flex items-center mb-2">
               <div class="flex-1 truncate" :title="a.title || a.filename">{{ a.title || a.filename }}</div>
 
+              <el-button link size="small" @click.stop="downloadAsset(a)"><el-icon>
+                  <Download />
+                </el-icon>下載</el-button>
               <el-button link size="small" @click.stop="showDetailFor(a, 'asset')"><el-icon>
                   <InfoFilled />
                 </el-icon></el-button>
@@ -159,6 +162,7 @@
       </div>
 
       <template #footer>
+        <el-button type="primary" @click="downloadAsset(previewItem)">下載</el-button>
         <el-button @click="previewVisible = false">關閉</el-button>
       </template>
     </el-dialog>
@@ -184,7 +188,7 @@ import {
 import { fetchTags } from '../services/tags'
 import { useAuthStore } from '../stores/auth'
 import { ElMessage } from 'element-plus'
-import { Folder, InfoFilled } from '@element-plus/icons-vue'
+import { Folder, InfoFilled, Download } from '@element-plus/icons-vue'
 
 const folders = ref([])
 const assets = ref([])
@@ -371,6 +375,18 @@ function previewAsset(a) {
   previewItem.value = { ...a, url }
   console.log('[預覽素材]', url)
   previewVisible.value = true
+}
+
+function downloadAsset(asset) {
+  const url = /^\/static\//.test(asset.url)
+    ? asset.url
+    : `/static/${asset.filename}`
+  const link = document.createElement('a')
+  link.href = url
+  link.download = asset.title || asset.filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
 }
 
 

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -2,6 +2,7 @@
  * Asset Controller  (完整)
  */
 import Asset from '../models/asset.model.js'
+import Folder from '../models/folder.model.js'
 import ReviewStage from '../models/reviewStage.model.js'
 import ReviewRecord from '../models/reviewRecord.model.js'
 import { getDescendantFolderIds } from '../utils/folderTree.js'
@@ -36,6 +37,12 @@ export const uploadFile = async (req, res) => {
     description: req.body.description || '',
     tags: parseTags(req.body.tags)
   })
+
+  if (asset.folderId) {
+    await Folder.findByIdAndUpdate(asset.folderId, {
+      $addToSet: { allowedUsers: req.user._id }
+    })
+  }
 
   res.status(201).json(asset)
 }

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -20,7 +20,9 @@ export const createFolder = async (req, res) => {
     script: req.body.script,
     type: req.body.type || 'raw',
     tags: parseTags(req.body.tags),
-    allowedUsers: Array.isArray(req.body.allowedUsers) ? req.body.allowedUsers : []
+    allowedUsers: Array.isArray(req.body.allowedUsers)
+      ? Array.from(new Set([...req.body.allowedUsers, req.user._id]))
+      : [req.user._id]
   })
   res.status(201).json(folder)
 }


### PR DESCRIPTION
## Summary
- enable asset download from card and preview dialog
- add download feature in product library
- auto add uploader to allowed users when creating folders
- keep folder permissions when uploading assets

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d9b42d548329bcf65fd13f6cb187