### PR TITLE
Update detail title logic

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -228,7 +228,7 @@ function showDetailFor(item, type) {
   detailType.value = type
   if (type === 'folder') editingFolder.value = item
 
-  detail.value.title = item.title || item.filename || ''
+  detail.value.title = item.title || item.name || item.filename || ''
   detail.value.description = item.description || ''
   detail.value.script = item.script || ''
   detail.value.tags = Array.isArray(item.tags) ? [...item.tags] : []

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -265,7 +265,7 @@ async function showDetailFor(item, type) {
   detailType.value = type
   if (type === 'folder') editingFolder.value = item
 
-  detail.value.title = item.title || item.filename || ''
+  detail.value.title = item.title || item.name || item.filename || ''
   detail.value.description = item.description || ''
   detail.value.script = item.script || ''
   detail.value.tags = Array.isArray(item.tags) ? [...item.tags] : []


### PR DESCRIPTION
## Summary
- include `item.name` when setting detail title so folder info populates correctly

## Testing
- `npm --prefix server test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e6cebd5c83298aad3b42205fd081