### PR TITLE
Restrict user list visibility to managers

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -109,7 +109,7 @@
           <el-form-item v-if="detailType === 'folder'" label="腳本需求">
             <el-input v-model="detail.script" type="textarea" rows="4" resize="vertical" />
           </el-form-item>
-          <el-form-item v-if="detailType === 'folder'" label="可存取使用者">
+          <el-form-item v-if="detailType === 'folder' && isManager" label="可存取使用者">
             <el-select v-model="detail.allowedUsers" multiple filterable style="width:100%">
               <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
             </el-select>
@@ -157,6 +157,7 @@ import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder } fro
 import { fetchAssets, uploadAsset, updateAsset, deleteAsset } from '../services/assets'
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
+import { useAuthStore } from '../stores/auth'
 import { ElMessage } from 'element-plus'
 import { Folder, InfoFilled, Close, Download } from '@element-plus/icons-vue'
 
@@ -164,6 +165,9 @@ const folders = ref([])
 const assets = ref([])
 const currentFolder = ref(null)
 const editingFolder = ref(null)
+
+const store = useAuthStore()
+const isManager = computed(() => store.role === 'manager')
 
 const detail = ref({ title: '', description: '', script: '', tags: [], allowedUsers: [] })
 const showDetail = ref(false)
@@ -217,7 +221,7 @@ async function loadData(id = null) {
 onMounted(() => {
   loadData()
   loadTags()
-  loadUsers()
+  if (isManager.value) loadUsers()
 })
 watch(filterTags, () => loadData(currentFolder.value?._id || null))
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -111,7 +111,7 @@
             <el-form-item v-if="detailType === 'folder'" label="腳本需求">
               <el-input v-model="detail.script" type="textarea" rows="4" resize="vertical" />
             </el-form-item>
-            <el-form-item v-if="detailType === 'folder'" label="可存取使用者">
+            <el-form-item v-if="detailType === 'folder' && isManager" label="可存取使用者">
               <el-select v-model="detail.allowedUsers" multiple filterable style="width:100%">
                 <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
               </el-select>
@@ -197,6 +197,7 @@ const editingFolder = ref(null)
 
 const store = useAuthStore()
 const canReview = computed(() => store.role === 'manager')
+const isManager = computed(() => store.role === 'manager')
 
 const detail = ref({ title: '', description: '', script: '', tags: [], allowedUsers: [] })
 const showDetail = ref(false)
@@ -254,7 +255,7 @@ const loadTags = async () => {
 onMounted(() => {
   loadData()
   loadTags()
-  loadUsers()
+  if (isManager.value) loadUsers()
 })
 watch(filterTags, () => loadData(currentFolder.value?._id || null))
 


### PR DESCRIPTION
## Summary
- use `useAuthStore` in AssetLibrary and ProductLibrary
- add `isManager` computed property
- only managers fetch user list
- hide accessible users field for non-managers

## Testing
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e6cfe854832986dbe9735934196e