### PR TITLE
Add url field to asset schema

### DIFF
--- a/server/src/models/asset.model.js
+++ b/server/src/models/asset.model.js
@@ -23,6 +23,7 @@ const assetSchema = new mongoose.Schema(
     filename:   { type: String, required: true },
 
     path:       { type: String, required: true },
+    url:        { type: String },
     type:         { type: String, enum: ['raw', 'edited'], default: 'raw' },
     reviewStatus: { type: String, enum: ['pending', 'approved', 'rejected'], default: 'pending' },
     description:  { type: String, default: '' },


### PR DESCRIPTION
## Summary
- add optional `url` field to `Asset` schema so uploaded files can store their access URL

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e969d0c48329a5b5547185825a36