### PR TITLE
Add Heroku deployment support

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm --prefix server start

--- a/README.md
+++ b/README.md
@@ -61,3 +61,18 @@ server/  # 後端 API
 
 ## 廣告數據頁面
 此頁面匯集各廣告平台的曝光與點擊統計，路徑為 `/ads`。目前後端示範提供 `/api/analytics` 取得資料，未來可依需求串接第三方服務。
+
+## Heroku 部署
+以下為將專案部署至 **Heroku** 的基本流程：
+
+1. **設定環境變數**：在 Heroku 後台依序新增
+   `MONGODB_URI`、`JWT_SECRET`、`JWT_EXPIRES_IN` 及 `UPLOAD_DIR` 等欄位，
+   值可參考 `server/.env.example`。
+2. **部署程式碼**：登入後建立應用程式並執行
+   ```bash
+   heroku login
+   heroku create <app-name>
+   git push heroku main
+   ```
+   Heroku 會在部署後自動執行 `heroku-postbuild` 產生前端靜態檔，
+   接著根據 `Procfile` 內容啟動伺服器。

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "scripts": {
     "client": "npm --prefix client run dev",
     "server": "npm --prefix server run dev",
-    "dev": "concurrently \"npm --prefix client run dev\" \"npm --prefix server run dev\""
+    "dev": "concurrently \"npm --prefix client run dev\" \"npm --prefix server run dev\"",
+    "heroku-postbuild": "npm --prefix client install && npm --prefix client run build"
   },
   "devDependencies": {
     "concurrently": "^8.2.0"
+  },
+  "engines": {
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
## Summary
- add `Procfile` for Heroku
- add `heroku-postbuild` script and node engine
- document Heroku deployment steps

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed89e3b8832981bf3e47f76fb465