### PR TITLE
Add root env example and adjust docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ PORT=3000
 
 # 檔案上傳資料夾（自動建立）
 UPLOAD_DIR=uploads
+
+# 前端 API 基底位址
+VITE_API_BASE=http://localhost:3000/api

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
    會被加入 `FormData`；剪輯師上傳成品時可傳入 `{ type: 'edited' }`。
 
 ## 後端 (server)
-1. 進入 `server` 目錄安裝依賴並設定環境：
+1. 進入 `server` 目錄安裝依賴：
    ```bash
-   cp .env.example .env     # 調整 MongoDB、JWT 等設定
    npm install
    ```
+   伺服器啟動前，請在根目錄複製 `.env.example` 為 `.env`，並依需求調整 MongoDB、JWT 等設定。
 2. 啟動 API：
    ```bash
    npm start

--- a/server/README.md
+++ b/server/README.md
@@ -4,10 +4,11 @@
 
 ## 安裝
 ```bash
-cp .env.example .env       # 修改 MongoDB、JWT 等設定
 npm install
 npm start                 # 啟動伺服器
 ```
+
+伺服器啟動前請在根目錄複製 `.env.example` 為 `.env`，並修改 MongoDB、JWT 等設定。
 
 執行 `npm run seed` 可建立預設帳號，方便初次測試。
 

--- a/server/src/config/db.js
+++ b/server/src/config/db.js
@@ -3,7 +3,11 @@
  */
 import mongoose from 'mongoose'
 import dotenv from 'dotenv'
-dotenv.config()
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
 const connectDB = async () => {
   try {

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,10 +1,14 @@
 /**
  * 驗證 JWT，並把登入者寫入 req.user
  */
-import jwt from 'jsonwebtoken';
-import dotenv from 'dotenv';
-import User from '../models/user.model.js';
-dotenv.config();
+import jwt from 'jsonwebtoken'
+import dotenv from 'dotenv'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import User from '../models/user.model.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
 export const protect = async (req, res, next) => {
   const authHeader = req.headers.authorization;

--- a/server/src/middleware/upload.js
+++ b/server/src/middleware/upload.js
@@ -4,7 +4,10 @@
 import multer from 'multer'
 import path from 'node:path'
 import dotenv from 'dotenv'
-dotenv.config()
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
 const storage = multer.diskStorage({
   destination: (_, __, cb) => {

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -1,13 +1,16 @@
 import dotenv from 'dotenv'
 import mongoose from 'mongoose'
 import bcrypt from 'bcryptjs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import User from '../models/user.model.js'
 import Role from '../models/role.model.js'
 import { ROLES } from '../config/roles.js'
 import { PERMISSIONS } from '../config/permissions.js'
 import { MENUS } from '../config/menus.js'
 
-dotenv.config()
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
 const users = [
   { username: 'employee', name: '員工', password: '123456', email: 'employee@example.com', role: ROLES.EMPLOYEE },

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -7,12 +7,14 @@ import cookieParser   from 'cookie-parser'
 import dotenv         from 'dotenv'
 import path           from 'node:path'
 import fs             from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 import connectDB                    from './config/db.js'
 import { notFound, errorHandler }   from './utils/handleError.js'
 
 /* ---------- 初始化 ---------- */
-dotenv.config()
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 connectDB()
 
 const app = express()

--- a/server/src/utils/generateToken.js
+++ b/server/src/utils/generateToken.js
@@ -3,7 +3,11 @@
  */
 import jwt from 'jsonwebtoken'
 import dotenv from 'dotenv'
-dotenv.config()
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
 export const generateToken = (userId) =>
   jwt.sign({ id: userId }, process.env.JWT_SECRET, {


### PR DESCRIPTION
## Summary
- centralize environment variables in `.env.example`
- remove old server `.env.example`
- load env from repo root
- update docs to copy root `.env.example`

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed8708548329a4671221878020e9