### PR TITLE
Add per-user asset permissions

### DIFF
--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -116,6 +116,11 @@
                 <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
               </el-select>
             </el-form-item>
+            <el-form-item v-if="detailType === 'asset' && isManager" label="可查看者">
+              <el-select v-model="detail.allowedUsers" multiple filterable style="width:100%">
+                <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
+              </el-select>
+            </el-form-item>
           </el-form>
         </el-scrollbar>
 
@@ -293,7 +298,8 @@ async function saveDetail() {
     await updateAsset(previewItem.value._id, {
       title: detail.value.title,
       description: detail.value.description,
-      tags: detail.value.tags
+      tags: detail.value.tags,
+      ...(isManager.value ? { allowedUsers: detail.value.allowedUsers } : {})
     })
   }
   ElMessage.success('已儲存')

--- a/server/src/models/asset.model.js
+++ b/server/src/models/asset.model.js
@@ -41,6 +41,9 @@ const assetSchema = new mongoose.Schema(
       default: [ROLES.MANAGER, ROLES.EMPLOYEE]
     },
 
+    /* 可查看使用者 */
+    allowedUsers: { type: [mongoose.Schema.Types.ObjectId], ref: 'User', default: [] },
+
     /* 留言 */
     comments: [commentSchema]
   },


### PR DESCRIPTION
## Summary
- allow specifying `allowedUsers` on assets and update APIs
- enable manager to select asset viewers in product library
- filter assets by `allowedUsers` when listing
- test asset access control

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c52250b5c8329bd24d6eb971b4493