### PR TITLE
Remove duplicate download button

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -61,9 +61,6 @@
             <div class="flex items-center mb-2">
               <el-checkbox v-model="selectedItems" :label="a._id" @click.stop class="mr-1" />
               <div class="flex-1 truncate" :title="a.title || a.filename">📄 {{ a.title || a.filename }}</div>
-              <el-button link size="small" @click.stop="downloadAsset(a)"><el-icon>
-                  <Download />
-                </el-icon>下載</el-button>
               <el-button link size="small" @click.stop="showDetailFor(a, 'asset')"><el-icon>
                   <InfoFilled />
                 </el-icon></el-button>

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -63,9 +63,6 @@
               <el-checkbox v-model="selectedItems" :label="a._id" @click.stop class="mr-1" />
               <div class="flex-1 truncate" :title="a.title || a.filename">{{ a.title || a.filename }}</div>
               
-              <el-button link size="small" @click.stop="downloadAsset(a)"><el-icon>
-                  <Download />
-                </el-icon>下載</el-button>
               <el-button link size="small" @click.stop="showDetailFor(a, 'asset')"><el-icon>
                   <InfoFilled />
                 </el-icon></el-button>


### PR DESCRIPTION
## Summary
- remove download buttons from asset/product cards

## Testing
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c64675cd48329b16544752d5964e4