### PR TITLE
Fix detail title handling

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -225,7 +225,10 @@ const isImage = a => /\.(png|jpe?g|gif|webp)$/i.test(a?.filename || '')
 
 /* 主題色 */
 const sidebarBg = computed(() => getComputedStyle(document.querySelector('.sidebar')).backgroundColor || '#1f2937')
-const detailTitle = computed(() => previewItem.value ? previewItem.value.filename : currentFolder.value?.name || '資訊')
+const detailTitle = computed(() =>
+  previewItem.value
+    ? (previewItem.value.title || previewItem.value.filename)
+    : currentFolder.value?.name || '資訊')
 
 async function loadData(id = null) {
   folders.value = await fetchFolders(id, filterTags.value, 'raw')
@@ -251,7 +254,9 @@ function showDetailFor(item, type) {
   detailType.value = type
   if (type === 'folder') editingFolder.value = item
 
-  detail.value.title = item.title || item.name || item.filename || ''
+  if (type === 'asset') detail.value.title = item.title || ''
+  else if (type === 'folder') detail.value.title = item.name || ''
+  else detail.value.title = item.title || item.name || ''
   detail.value.description = item.description || ''
   detail.value.script = item.script || ''
   detail.value.tags = Array.isArray(item.tags) ? [...item.tags] : []

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -252,7 +252,10 @@ const stageAsset = ref(null)
 
 /* 主題色 */
 const sidebarBg = computed(() => getComputedStyle(document.querySelector('.sidebar')).backgroundColor || '#1f2937')
-const detailTitle = computed(() => previewItem.value ? previewItem.value.filename : currentFolder.value?.name || '資訊')
+const detailTitle = computed(() =>
+  previewItem.value
+    ? (previewItem.value.title || previewItem.value.filename)
+    : currentFolder.value?.name || '資訊')
 
 async function loadData(id = null) {
   folders.value = await fetchFolders(id, filterTags.value, 'edited')
@@ -287,7 +290,9 @@ async function showDetailFor(item, type) {
   detailType.value = type
   if (type === 'folder') editingFolder.value = item
 
-  detail.value.title = item.title || item.name || item.filename || ''
+  if (type === 'asset') detail.value.title = item.title || ''
+  else if (type === 'folder') detail.value.title = item.name || ''
+  else detail.value.title = item.title || item.name || ''
   detail.value.description = item.description || ''
   detail.value.script = item.script || ''
   detail.value.tags = Array.isArray(item.tags) ? [...item.tags] : []


### PR DESCRIPTION
## Summary
- refine detailTitle computed in Asset and Product libraries
- adjust logic in showDetailFor for assets and folders

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c64682860832981398b89294de8c5