### PR TITLE
Add batch viewer improvements

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -17,7 +17,7 @@
         <el-select v-model="filterTags" multiple placeholder="標籤篩選" style="min-width:150px">
           <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
         </el-select>
-        <el-button type="warning" :disabled="!selectedItems.length" @click="openBatch">批量設定可查看者</el-button>
+        <el-button v-if="canBatch" type="warning" :disabled="!selectedItems.length" @click="openBatch">批量設定可查看者</el-button>
 
       </div>
 
@@ -134,7 +134,7 @@
       </template>
     </el-dialog>
 
-    <el-dialog v-model="batchDialog" width="30%" top="20vh">
+    <el-dialog v-if="canBatch" v-model="batchDialog" width="30%" top="20vh">
       <template #header>批量設定可查看者</template>
       <el-select v-model="batchUsers" multiple filterable style="width:100%" class="mb-4">
         <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
@@ -184,6 +184,7 @@ const editingFolder = ref(null)
 
 const store = useAuthStore()
 const isManager = computed(() => store.role === 'manager')
+const canBatch = computed(() => store.user.permissions?.includes('asset:update'))
 
 const detail = ref({ title: '', description: '', script: '', tags: [], allowedUsers: [] })
 const showDetail = ref(false)
@@ -244,7 +245,10 @@ async function loadData(id = null) {
 onMounted(() => {
   loadData()
   loadTags()
-  if (isManager.value) loadUsers()
+  if (canBatch.value) loadUsers()
+})
+watch(canBatch, (val) => {
+  if (val && !users.value.length) loadUsers()
 })
 watch(filterTags, () => loadData(currentFolder.value?._id || null))
 
@@ -328,19 +332,26 @@ function handleError(_, file) {
 }
 
 function openBatch() {
+  if (!users.value.length) loadUsers()
   batchUsers.value = []
   batchDialog.value = true
 }
 
 async function applyBatch() {
-  const ids = selectedItems.value.filter(id =>
+  const assetIds = selectedItems.value.filter(id =>
     assets.value.some(a => a._id === id)
   )
-  if (!ids.length) {
+  const folderIds = selectedItems.value.filter(id =>
+    folders.value.some(f => f._id === id)
+  )
+  if (!assetIds.length && !folderIds.length) {
     batchDialog.value = false
     return
   }
-  await updateAssetsViewers(ids, batchUsers.value)
+  if (assetIds.length) await updateAssetsViewers(assetIds, batchUsers.value)
+  for (const fid of folderIds) {
+    await updateFolder(fid, { allowedUsers: batchUsers.value })
+  }
   batchDialog.value = false
   selectedItems.value = []
   loadData(currentFolder.value?._id)

--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -39,6 +39,12 @@ router.get('/recent', protect, requirePerm(PERMISSIONS.ASSET_READ), getRecentAss
 /* ★ 新增：更新檔名／描述 */
 
 router.put(
+  '/viewers',
+  protect,
+  requirePerm(PERMISSIONS.ASSET_UPDATE),
+  updateAssetsViewers
+)
+router.put(
   '/:id',
   protect,
   requirePerm(PERMISSIONS.ASSET_UPDATE),
@@ -49,12 +55,6 @@ router.put(
   protect,
   requirePerm(PERMISSIONS.REVIEW_MANAGE),
   reviewAsset
-)
-router.put(
-  '/viewers',
-  protect,
-  requirePerm(PERMISSIONS.ASSET_UPDATE),
-  updateAssetsViewers
 )
 router.get('/:id/stages', protect, getAssetStages)
 router.put('/:id/stages/:stageId', protect, updateStageStatus)

--- a/server/src/utils/includeManagers.js
+++ b/server/src/utils/includeManagers.js
@@ -1,0 +1,13 @@
+import User from '../models/user.model.js'
+import Role from '../models/role.model.js'
+import { ROLES } from '../config/roles.js'
+
+export const includeManagers = async (ids = []) => {
+  const role = await Role.findOne({ name: ROLES.MANAGER })
+  if (!role) return ids
+  const managers = await User.find({ roleId: role._id }).select('_id')
+  const managerIds = managers.map(m => m._id.toString())
+  const final = Array.from(new Set([...ids.map(id => id.toString()), ...managerIds]))
+  return final
+}
+


### PR DESCRIPTION
## Summary
- ensure permission changes also update folders in batch dialogs
- reload user list when gaining permission for batch updates
- always fetch users when opening the batch viewer dialog

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c78d2079c8329bb6e85b306cbdabf