### PR TITLE
Implement folder viewer batch update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 4. 上傳檔案可呼叫 `uploadAsset(file, folderId, extraData)`，其中 `extraData`
    會被加入 `FormData`；剪輯師上傳成品時可傳入 `{ type: 'edited' }`。
 5. 批量修改素材可查看者：`updateAssetsViewers(ids, users)`，參數為素材 `_id` 陣列與使用者 `_id` 陣列。
+6. 批量修改資料夾可查看者：`updateFoldersViewers(ids, users)`，參數為資料夾 `_id` 陣列與使用者 `_id` 陣列。
 
 ## 後端 (server)
 1. 進入 `server` 目錄安裝依賴：
@@ -69,7 +70,7 @@ server/  # 後端 API
 前端路徑為 `/products`，員工與管理者皆可瀏覽。
 相對地，素材庫 `/assets` 只會呈現 `type=raw` 的素材。
 若有設定審查關卡，點擊成品資訊中的「審查關卡」按鈕可檢視並勾選各階段。
-素材庫工具列新增「批量設定可查看者」，可勾選多筆素材後一次變更其 `allowedUsers`，對應 API 為 `PUT /api/assets/viewers`。
+素材庫工具列新增「批量設定可查看者」，可勾選多筆素材或資料夾後一次變更其 `allowedUsers`，對應 API 為 `PUT /api/assets/viewers` 與 `PUT /api/folders/viewers`。
 
 ## 廣告數據頁面
 此頁面匯集各廣告平台的曝光與點擊統計，路徑為 `/ads`。目前後端示範提供 `/api/analytics` 取得資料，未來可依需求串接第三方服務。

--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -25,3 +25,6 @@ export const updateFolder = (id, data) => {
 
 export const deleteFolder = id =>
   api.delete(`/folders/${id}`).then(res => res.data)
+
+export const updateFoldersViewers = (ids, users) =>
+  api.put('/folders/viewers', { ids, allowedUsers: users }).then(res => res.data)

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -194,7 +194,7 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
-import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder } from '../services/folders'
+import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers } from '../services/folders'
 import { fetchUsers } from '../services/user'
 import {
   fetchProducts,
@@ -219,7 +219,10 @@ const editingFolder = ref(null)
 const store = useAuthStore()
 const canReview = computed(() => store.role === 'manager')
 const isManager = computed(() => store.role === 'manager')
-const canBatch = computed(() => store.user.permissions?.includes('asset:update'))
+const canBatch = computed(() =>
+  store.user.permissions?.includes('asset:update') ||
+  store.user.permissions?.includes('folder:manage')
+)
 
 const detail = ref({ title: '', description: '', script: '', tags: [], allowedUsers: [] })
 const showDetail = ref(false)
@@ -378,14 +381,18 @@ function openBatch() {
 }
 
 async function applyBatch() {
-  const ids = selectedItems.value.filter(id =>
+  const assetIds = selectedItems.value.filter(id =>
     assets.value.some(a => a._id === id)
   )
-  if (!ids.length) {
+  const folderIds = selectedItems.value.filter(id =>
+    folders.value.some(f => f._id === id)
+  )
+  if (!assetIds.length && !folderIds.length) {
     batchDialog.value = false
     return
   }
-  await updateAssetsViewers(ids, batchUsers.value)
+  if (assetIds.length) await updateAssetsViewers(assetIds, batchUsers.value)
+  if (folderIds.length) await updateFoldersViewers(folderIds, batchUsers.value)
   batchDialog.value = false
   selectedItems.value = []
   loadData(currentFolder.value?._id)

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -80,3 +80,13 @@ export const deleteFolder = async (req, res) => {
   await Folder.findByIdAndDelete(req.params.id)
   res.json({ message: '資料夾已刪除' })
 }
+
+export const updateFoldersViewers = async (req, res) => {
+  const { ids, allowedUsers } = req.body
+  if (!Array.isArray(ids) || !Array.isArray(allowedUsers)) {
+    return res.status(400).json({ message: '參數錯誤' })
+  }
+  const users = await includeManagers(allowedUsers)
+  await Folder.updateMany({ _id: { $in: ids } }, { allowedUsers: users })
+  res.json({ message: '已更新' })
+}

--- a/server/src/routes/folder.routes.js
+++ b/server/src/routes/folder.routes.js
@@ -7,7 +7,8 @@ import {
   getFolders,
   getFolder,
   updateFolder,
-  deleteFolder
+  deleteFolder,
+  updateFoldersViewers
 } from '../controllers/folder.controller.js'
 
 const router = Router()
@@ -15,6 +16,12 @@ const router = Router()
 router.post('/', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), createFolder)
 router.get('/', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), getFolders)
 router.get('/:id', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), getFolder)
+router.put(
+  '/viewers',
+  protect,
+  requirePerm(PERMISSIONS.FOLDER_MANAGE),
+  updateFoldersViewers
+)
 router.put('/:id', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), updateFolder)
 router.delete(
   '/:id',

--- a/server/tests/folder.test.js
+++ b/server/tests/folder.test.js
@@ -6,6 +6,7 @@ import folderRoutes from '../src/routes/folder.routes.js'
 import authRoutes from '../src/routes/auth.routes.js'
 import User from '../src/models/user.model.js'
 import Role from '../src/models/role.model.js'
+import Folder from '../src/models/folder.model.js'
 import dotenv from 'dotenv'
 
 dotenv.config({ override: true })
@@ -129,5 +130,26 @@ describe('Folder access control', () => {
       .set('Authorization', `Bearer ${token3}`)
       .expect(200)
     expect(res.body.length).toBe(0)
+  })
+})
+
+describe('Batch update folder viewers', () => {
+  it('should update allowedUsers for multiple folders', async () => {
+    const newUser = await User.create({
+      username: 'viewf',
+      password: 'pwd',
+      email: 'viewf@example.com',
+      roleId: (await Role.findOne({ name: 'employee' }))._id
+    })
+
+    await request(app)
+      .put('/api/folders/viewers')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ids: [folderId.toString()], allowedUsers: [newUser._id.toString()] })
+      .expect(200)
+
+  const f = await Folder.findById(folderId)
+  const ids = f.allowedUsers.map(id => id.toString())
+  expect(ids).toContain(newUser._id.toString())
   })
 })


### PR DESCRIPTION
## Summary
- support bulk setting folder viewers on backend and frontend
- add service method `updateFoldersViewers`
- enable batch option when user has folder permission
- update README
- test folder viewer update

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8a13d7708329b7dd2d60b73baddd