### PR TITLE
Fix permission check when role is populated

### DIFF
--- a/server/src/middleware/permission.js
+++ b/server/src/middleware/permission.js
@@ -1,7 +1,13 @@
 import Role from '../models/role.model.js'
 
 export const requirePerm = (perm) => async (req, res, next) => {
-  const role = await Role.findById(req.user.roleId)
+  let role = req.user.roleId
+
+  // `protect` middleware may have populated roleId
+  if (!role?.permissions) {
+    role = await Role.findById(req.user.roleId)
+  }
+
   if (!role || !role.permissions.includes(perm)) {
     return res.status(403).json({ message: '權限不足' })
   }

--- a/server/src/middleware/permissionGuard.js
+++ b/server/src/middleware/permissionGuard.js
@@ -1,8 +1,13 @@
 import Role from '../models/role.model.js'
 
 export const requirePerm = (...perms) => async (req, res, next) => {
-  const role = await Role.findById(req.user.roleId)
-  const allowed = perms.every(p => role.permissions.includes(p))
+  let role = req.user.roleId
+
+  if (!role?.permissions) {
+    role = await Role.findById(req.user.roleId)
+  }
+
+  const allowed = role && perms.every(p => role.permissions.includes(p))
   if (!allowed) return res.status(403).json({ message: '權限不足' })
   next()
 }

--- a/server/tests/permissionCheck.test.js
+++ b/server/tests/permissionCheck.test.js
@@ -1,0 +1,57 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import userRoutes from '../src/routes/user.routes.js'
+import authRoutes from '../src/routes/auth.routes.js'
+import Role from '../src/models/role.model.js'
+import User from '../src/models/user.model.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/user', userRoutes)
+
+  const role = await Role.create({
+    name: 'manager',
+    permissions: ['user:manage']
+  })
+
+  await User.create({
+    username: 'admin',
+    password: 'mypwd',
+    email: 'admin@example.com',
+    roleId: role._id
+  })
+
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'admin', password: 'mypwd' })
+  token = res.body.token
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+describe('permission middleware with populated role', () => {
+  it('allows access when role has permission', async () => {
+    await request(app)
+      .get('/api/user')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure middleware detects populated roles
- add regression test for permissions with populated roles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0c85afb88329b30299f324bfb2c0