### PR TITLE
Remove progress permission

### DIFF
--- a/client/src/permissionNames.js
+++ b/client/src/permissionNames.js
@@ -4,7 +4,6 @@ export const PERMISSION_NAMES = {
   'asset:update': '資源更新',
   'asset:delete': '資源刪除',
   'folder:manage': '資料夾管理',
-  'progress:manage': '進度管理',
   'user:manage': '使用者管理',
   'task:manage': '任務管理',
   'review:manage': '審查管理',


### PR DESCRIPTION
## Summary
- remove `progress:manage` from client permission list since it's not defined on the server

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1c535e508329bc53da6c96e64649