### PR TITLE
移除重複的 role-setting 路由

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -32,7 +32,6 @@ const routes = [
 
       { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { menu: 'employees' } },
       { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { menu: 'roles' } },
-      { path: 'role-setting', name: 'RoleSetting', component: RoleSettings, meta: { menu: 'roles' } },
       { path: 'tags', name: 'TagManager', component: TagManager, meta: { menu: 'tags' } },
       { path: 'review-stages', name: 'ReviewSettings', component: ReviewSettings, meta: { menu: 'review-stages' } },
       { path: 'ad-data', name: 'AdData', component: AdData, meta: { menu: 'ad-data' } }


### PR DESCRIPTION
## Summary
- 刪除與 `roles` 功能重複的 `role-setting` 路由設定

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1c55ae808329b97e567f9dbf832c