### PR TITLE
Update batch dialog logic

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -331,8 +331,9 @@ function handleError(_, file) {
   delete progressList.value[file.uid]
 }
 
-function openBatch() {
-  batchUsers.value = []
+async function openBatch() {
+  if (!users.value.length) await loadUsers()
+  batchUsers.value = users.value.filter(u => u.role === 'manager').map(u => u._id)
   batchDialog.value = true
 }
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -375,8 +375,9 @@ function handleError(_, file) {
   delete progressList.value[file.uid]
 }
 
-function openBatch() {
-  batchUsers.value = []
+async function openBatch() {
+  if (!users.value.length) await loadUsers()
+  batchUsers.value = users.value.filter(u => u.role === 'manager').map(u => u._id)
   batchDialog.value = true
 }
 


### PR DESCRIPTION
## Summary
- load managers list automatically before opening batch dialog
- filter manager IDs for batch user selection

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6c8fff9083299eeb58ed392de2f2