### PR TITLE
Add user loading when enabling batch actions

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -251,6 +251,9 @@ onMounted(() => {
   if (canBatch.value) loadUsers()
 })
 watch(filterTags, () => loadData(currentFolder.value?._id || null))
+watch(canBatch, val => {
+  if (val && !users.value.length) loadUsers()
+})
 
 function openFolder(f) { loadData(f._id) }
 function goUp() { loadData(currentFolder.value?.parentId || null) }
@@ -332,6 +335,7 @@ function handleError(_, file) {
 }
 
 function openBatch() {
+  if (!users.value.length) loadUsers()
   batchUsers.value = []
   batchDialog.value = true
 }

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -290,6 +290,9 @@ onMounted(() => {
   if (canBatch.value) loadUsers()
 })
 watch(filterTags, () => loadData(currentFolder.value?._id || null))
+watch(canBatch, val => {
+  if (val && !users.value.length) loadUsers()
+})
 
 function openFolder(f) { loadData(f._id) }
 function goUp() { loadData(currentFolder.value?.parentId || null) }
@@ -376,6 +379,7 @@ function handleError(_, file) {
 }
 
 function openBatch() {
+  if (!users.value.length) loadUsers()
   batchUsers.value = []
   batchDialog.value = true
 }


### PR DESCRIPTION
## Summary
- load user list when batch function is enabled in both libraries
- ensure `openBatch` loads users if needed

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6c9324048329947e9ce82b740a08