### PR TITLE
Add permission checks for batch edit buttons

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -332,11 +332,19 @@ function handleError(_, file) {
 }
 
 function openBatch() {
+  if (!canBatch.value) {
+    ElMessage.error('沒有權限執行此操作')
+    return
+  }
   batchUsers.value = []
   batchDialog.value = true
 }
 
 async function applyBatch() {
+  if (!canBatch.value) {
+    ElMessage.error('沒有權限執行此操作')
+    return
+  }
   const assetIds = selectedItems.value.filter(id =>
     assets.value.some(a => a._id === id)
   )

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -376,11 +376,19 @@ function handleError(_, file) {
 }
 
 function openBatch() {
+  if (!canBatch.value) {
+    ElMessage.error('沒有權限執行此操作')
+    return
+  }
   batchUsers.value = []
   batchDialog.value = true
 }
 
 async function applyBatch() {
+  if (!canBatch.value) {
+    ElMessage.error('沒有權限執行此操作')
+    return
+  }
   const assetIds = selectedItems.value.filter(id =>
     assets.value.some(a => a._id === id)
   )


### PR DESCRIPTION
## Summary
- ensure batch edit actions verify permissions before proceeding
- keep Element Plus message usage

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6c96640c8329b2bfe33f95050a4b