### PR TITLE
Implement folder read permission

### DIFF
--- a/client/src/permissionNames.js
+++ b/client/src/permissionNames.js
@@ -3,6 +3,7 @@ export const PERMISSION_NAMES = {
   'asset:read': '資源讀取',
   'asset:update': '資源更新',
   'asset:delete': '資源刪除',
+  'folder:read': '資料夾瀏覽',
   'folder:manage': '資料夾管理',
   'user:manage': '使用者管理',
   'task:manage': '任務管理',

--- a/server/README.md
+++ b/server/README.md
@@ -29,6 +29,7 @@ npm start                 # 啟動伺服器
 | `asset:read`    | 讀取素材或成品 |
 | `asset:update`  | 編輯素材與設定檔案可查看者 |
 | `asset:delete`  | 刪除素材 |
+| `folder:read`   | 瀏覽資料夾內容 |
 | `folder:manage` | 新增、編輯或刪除資料夾，包含設定資料夾可查看者 |
 | `user:manage`   | 管理使用者帳號 |
 | `task:manage`   | 任務管理 |

--- a/server/src/config/permissions.js
+++ b/server/src/config/permissions.js
@@ -3,6 +3,7 @@ export const PERMISSIONS = Object.freeze({
   ASSET_READ: 'asset:read',
   ASSET_UPDATE: 'asset:update',
   ASSET_DELETE: 'asset:delete',
+  FOLDER_READ: 'folder:read',
   FOLDER_MANAGE: 'folder:manage',
   USER_MANAGE: 'user:manage',
   TASK_MANAGE: 'task:manage',

--- a/server/src/routes/folder.routes.js
+++ b/server/src/routes/folder.routes.js
@@ -14,8 +14,8 @@ import {
 const router = Router()
 
 router.post('/', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), createFolder)
-router.get('/', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), getFolders)
-router.get('/:id', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), getFolder)
+router.get('/', protect, requirePerm(PERMISSIONS.FOLDER_READ), getFolders)
+router.get('/:id', protect, requirePerm(PERMISSIONS.FOLDER_READ), getFolder)
 router.put(
   '/viewers',
   protect,

--- a/server/tests/folder.test.js
+++ b/server/tests/folder.test.js
@@ -30,8 +30,14 @@ beforeAll(async () => {
   app.use('/api/auth', authRoutes)
   app.use('/api/folders', folderRoutes)
 
-  const managerRole = await Role.create({ name: 'manager', permissions: ['folder:manage'] })
-  const empRole = await Role.create({ name: 'employee', permissions: ['folder:manage'] })
+  const managerRole = await Role.create({
+    name: 'manager',
+    permissions: ['folder:manage', 'folder:read']
+  })
+  const empRole = await Role.create({
+    name: 'employee',
+    permissions: ['folder:read']
+  })
 
   await User.create({
     username: 'admin',


### PR DESCRIPTION
## Summary
- add `folder:read` permission for viewing folders
- use new permission in folder routes
- document new permission in server README
- include translation in client permission list
- update folder tests to reflect new permission

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8d6e59ec83299ddcbf672c22989d