### PR TITLE
新增素材詳情可查看者設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
    會被加入 `FormData`；剪輯師上傳成品時可傳入 `{ type: 'edited' }`。
 5. 批量修改素材可查看者：`updateAssetsViewers(ids, users)`，參數為素材 `_id` 陣列與使用者 `_id` 陣列。
 6. 批量修改資料夾可查看者：`updateFoldersViewers(ids, users)`，參數為資料夾 `_id` 陣列與使用者 `_id` 陣列。
+7. 素材庫詳情視窗可設定「可查看者」，管理者可指定可瀏覽的使用者。
 
 ## 後端 (server)
 1. 進入 `server` 目錄安裝依賴：

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -119,6 +119,11 @@
               <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
             </el-select>
           </el-form-item>
+          <el-form-item v-if="detailType === 'asset' && isManager" label="可查看者">
+            <el-select v-model="detail.allowedUsers" multiple filterable style="width:100%">
+              <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
+            </el-select>
+          </el-form-item>
         </el-form>
       </el-scrollbar>
 
@@ -255,8 +260,9 @@ watch(filterTags, () => loadData(currentFolder.value?._id || null))
 function openFolder(f) { loadData(f._id) }
 function goUp() { loadData(currentFolder.value?.parentId || null) }
 
-function showDetailFor(item, type) {
+async function showDetailFor(item, type) {
   detailType.value = type
+  if (isManager.value && !users.value.length) await loadUsers()
   if (type === 'folder') editingFolder.value = item
 
   if (type === 'asset') detail.value.title = item.title || ''
@@ -284,7 +290,8 @@ async function saveDetail() {
     await updateAsset(previewItem.value._id, {
       title: detail.value.title,
       description: detail.value.description,
-      tags: detail.value.tags
+      tags: detail.value.tags,
+      ...(isManager.value ? { allowedUsers: detail.value.allowedUsers } : {})
     })
   }
   ElMessage.success('已儲存')


### PR DESCRIPTION
## Summary
- asset 詳情中允許管理者設定可查看者
- 儲存時會傳送 allowedUsers 欄位
- 顯示詳情時若需要則載入使用者清單
- README 補充可查看者設定說明

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9df18234832987fc7c8da58d504f