### PR TITLE
Update role-based access docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 3. 如需連接後端，可在 `.env` 檔中設定 `VITE_API_BASE`，預設為 `http://localhost:3000/api`。
 4. 上傳檔案可呼叫 `uploadAsset(file, folderId, extraData)`，其中 `extraData`
    會被加入 `FormData`；剪輯師上傳成品時可傳入 `{ type: 'edited' }`。
-5. 批量修改素材可查看者：`updateAssetsViewers(ids, users)`，參數為素材 `_id` 陣列與使用者 `_id` 陣列。
-6. 批量修改資料夾可查看者：`updateFoldersViewers(ids, users)`，參數為資料夾 `_id` 陣列與使用者 `_id` 陣列。
-7. 素材庫詳情視窗可設定「可查看者」，管理者可指定可瀏覽的使用者。
+5. 批量修改素材角色設定：`updateAssetsRoles(ids, roles)`，參數為素材 `_id` 陣列與角色陣列。
+6. 批量修改資料夾角色設定：`updateFoldersRoles(ids, roles)`，參數為資料夾 `_id` 陣列與角色陣列。
+7. 素材庫詳情視窗可設定角色，管理者可指定具有瀏覽權限的角色。
 
 ## 後端 (server)
 1. 進入 `server` 目錄安裝依賴：
@@ -70,8 +70,9 @@ server/  # 後端 API
 新增的成品區僅顯示 `type=edited` 的素材，管理者可在此審核成品並決定是否通過或退回。
 前端路徑為 `/products`，員工與管理者皆可瀏覽。
 相對地，素材庫 `/assets` 只會呈現 `type=raw` 的素材。
+素材庫與成品區的存取權限皆以角色判斷，只有具備相應角色者才能瀏覽。
 若有設定審查關卡，點擊成品資訊中的「審查關卡」按鈕可檢視並勾選各階段。
-素材庫工具列新增「批量設定可查看者」，可勾選多筆素材或資料夾後一次變更其 `allowedUsers`，對應 API 為 `PUT /api/assets/viewers` 與 `PUT /api/folders/viewers`。
+素材庫工具列新增「批量設定角色」，可勾選多筆素材或資料夾後一次變更其 `allowedRoles`，對應 API 為 `PUT /api/assets/roles` 與 `PUT /api/folders/roles`。
 
 ## 廣告數據頁面
 此頁面匯集各廣告平台的曝光與點擊統計，路徑為 `/ads`。目前後端示範提供 `/api/analytics` 取得資料，未來可依需求串接第三方服務。


### PR DESCRIPTION
## Summary
- revise README so access is explained in terms of roles
- document that assets and products rely purely on role-based permissions

## Testing
- `npm test --prefix server` *(fails: jest not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684db1621aa88329a62de657f3257904