### PR TITLE
Add role-based folder permissions

### DIFF
--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -1,6 +1,7 @@
 import Folder from '../models/folder.model.js'
 import { getDescendantFolderIds } from '../utils/folderTree.js'
 import { includeManagers } from '../utils/includeManagers.js'
+import { ROLES } from '../config/roles.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -17,6 +18,9 @@ export const createFolder = async (req, res) => {
   const baseUsers = Array.isArray(req.body.allowedUsers)
     ? Array.from(new Set([...req.body.allowedUsers, req.user._id]))
     : [req.user._id]
+  const roles = Array.isArray(req.body.allowRoles)
+    ? req.body.allowRoles.filter(r => Object.values(ROLES).includes(r))
+    : undefined
   const folder = await Folder.create({
     name: req.body.name,
     parentId: req.body.parentId || null,
@@ -24,7 +28,8 @@ export const createFolder = async (req, res) => {
     script: req.body.script,
     type: req.body.type || 'raw',
     tags: parseTags(req.body.tags),
-    allowedUsers: await includeManagers(baseUsers)
+    allowedUsers: await includeManagers(baseUsers),
+    ...(roles ? { allowRoles: roles } : {})
   })
   res.status(201).json(folder)
 }
@@ -40,7 +45,7 @@ export const getFolders = async (req, res) => {
     parentIds = parentIds.concat(childIds)
   }
 
-  const query = { parentId: { $in: parentIds }, type }
+  const query = { parentId: { $in: parentIds }, type, allowRoles: req.user.roleId?.name }
   if (req.query.tags) {
     const tags = Array.isArray(req.query.tags)
       ? req.query.tags
@@ -71,6 +76,11 @@ export const updateFolder = async (req, res) => {
   } else if (Array.isArray(req.body.allowedUsers)) {
     req.body.allowedUsers = await includeManagers(req.body.allowedUsers)
   }
+  if (req.body.allowRoles && !Array.isArray(req.body.allowRoles)) {
+    delete req.body.allowRoles
+  } else if (Array.isArray(req.body.allowRoles)) {
+    req.body.allowRoles = req.body.allowRoles.filter(r => Object.values(ROLES).includes(r))
+  }
   const folder = await Folder.findByIdAndUpdate(req.params.id, req.body, { new: true })
   if (!folder) return res.status(404).json({ message: '資料夾不存在' })
   res.json(folder)
@@ -88,5 +98,15 @@ export const updateFoldersViewers = async (req, res) => {
   }
   const users = await includeManagers(allowedUsers)
   await Folder.updateMany({ _id: { $in: ids } }, { allowedUsers: users })
+  res.json({ message: '已更新' })
+}
+
+export const updateFoldersRoles = async (req, res) => {
+  const { ids, allowRoles } = req.body
+  if (!Array.isArray(ids) || !Array.isArray(allowRoles)) {
+    return res.status(400).json({ message: '參數錯誤' })
+  }
+  const roles = allowRoles.filter(r => Object.values(ROLES).includes(r))
+  await Folder.updateMany({ _id: { $in: ids } }, { allowRoles: roles })
   res.json({ message: '已更新' })
 }

--- a/server/src/models/folder.model.js
+++ b/server/src/models/folder.model.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import { ROLES } from '../config/roles.js'
 
 const folderSchema = new mongoose.Schema(
   {
@@ -10,6 +11,13 @@ const folderSchema = new mongoose.Schema(
 
     /* 可存取使用者 */
     allowedUsers: { type: [mongoose.Schema.Types.ObjectId], ref: 'User', default: [] },
+
+    /* 允許查看角色 */
+    allowRoles: {
+      type: [String],
+      enum: Object.values(ROLES),
+      default: [ROLES.MANAGER, ROLES.EMPLOYEE]
+    },
 
     /* 標籤 */
     tags: { type: [String], default: [] }

--- a/server/src/routes/folder.routes.js
+++ b/server/src/routes/folder.routes.js
@@ -8,7 +8,8 @@ import {
   getFolder,
   updateFolder,
   deleteFolder,
-  updateFoldersViewers
+  updateFoldersViewers,
+  updateFoldersRoles
 } from '../controllers/folder.controller.js'
 
 const router = Router()
@@ -21,6 +22,12 @@ router.put(
   protect,
   requirePerm(PERMISSIONS.FOLDER_MANAGE),
   updateFoldersViewers
+)
+router.put(
+  '/roles',
+  protect,
+  requirePerm(PERMISSIONS.FOLDER_MANAGE),
+  updateFoldersRoles
 )
 router.put('/:id', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), updateFolder)
 router.delete(

--- a/server/tests/folder.test.js
+++ b/server/tests/folder.test.js
@@ -18,6 +18,7 @@ let token
 let token2
 let token3
 let folderId
+let folderEmployeeId
 let user1Id
 let user2Id
 
@@ -157,5 +158,29 @@ describe('Batch update folder viewers', () => {
   const f = await Folder.findById(folderId)
   const ids = f.allowedUsers.map(id => id.toString())
   expect(ids).toContain(newUser._id.toString())
+  })
+})
+
+describe('Batch update folder roles', () => {
+  beforeAll(async () => {
+    const f = await Folder.create({
+      name: 'femp',
+      type: 'edited',
+      allowRoles: ['employee']
+    })
+    folderEmployeeId = f._id
+  })
+
+  it('should update allowRoles for multiple folders', async () => {
+    await request(app)
+      .put('/api/folders/roles')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ids: [folderId.toString(), folderEmployeeId.toString()], allowRoles: ['manager'] })
+      .expect(200)
+
+    const f1 = await Folder.findById(folderId)
+    const f2 = await Folder.findById(folderEmployeeId)
+    expect(f1.allowRoles).toEqual(['manager'])
+    expect(f2.allowRoles).toEqual(['manager'])
   })
 })


### PR DESCRIPTION
## Summary
- allow folders to set permitted roles
- filter folders by roles in controller
- add API for bulk role updates
- test new role permission logic

## Testing
- `npm test --silent --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db1607df08329876b5877ebcc3746