### PR TITLE
Implement role-based batch updates

### DIFF
--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -28,3 +28,6 @@ export const deleteFolder = id =>
 
 export const updateFoldersViewers = (ids, users) =>
   api.put('/folders/viewers', { ids, allowedUsers: users }).then(res => res.data)
+
+export const updateFoldersRoles = (ids, roles) =>
+  api.put('/folders/roles', { ids, allowRoles: roles }).then(res => res.data)

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -17,7 +17,7 @@
         <el-select v-model="filterTags" multiple placeholder="標籤篩選" style="min-width:150px">
           <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
         </el-select>
-        <el-button v-if="canBatch" type="warning" :disabled="!selectedItems.length" @click="openBatch">批量設定可查看者</el-button>
+        <el-button v-if="canBatch" type="warning" :disabled="!selectedItems.length" @click="openBatch">批量設定可查看角色</el-button>
 
       </div>
 
@@ -145,9 +145,9 @@
     </el-dialog>
 
     <el-dialog v-if="canBatch" v-model="batchDialog" width="30%" top="20vh">
-      <template #header>批量設定可查看者</template>
-      <el-select v-model="batchUsers" multiple filterable style="width:100%" class="mb-4">
-        <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
+      <template #header>批量設定可查看角色</template>
+      <el-select v-model="batchRoles" multiple style="width:100%" class="mb-4">
+        <el-option v-for="r in roleOptions" :key="r.value" :label="r.label" :value="r.value" />
       </el-select>
       <template #footer>
         <el-button @click="batchDialog = false">取消</el-button>
@@ -179,8 +179,8 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
-import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers } from '../services/folders'
-import { fetchAssets, uploadAsset, updateAsset, deleteAsset, updateAssetsViewers } from '../services/assets'
+import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersRoles } from '../services/folders'
+import { fetchAssets, uploadAsset, updateAsset, deleteAsset, updateAssetsRoles } from '../services/assets'
 import { fetchRoles } from '../services/roles'
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
@@ -210,7 +210,7 @@ const allTags = ref([])
 const users = ref([])
 const selectedItems = ref([])
 const batchDialog = ref(false)
-const batchUsers = ref([])
+const batchRoles = ref([])
 const roleOptions = ref([])
 
 const breadcrumb = ref([])
@@ -357,8 +357,8 @@ function handleError(_, file) {
 }
 
 async function openBatch() {
-  if (!users.value.length) await loadUsers()
-  batchUsers.value = users.value.filter(u => u.role === 'manager').map(u => u._id)
+  if (!roleOptions.value.length) await loadRoles()
+  batchRoles.value = []
   batchDialog.value = true
 }
 
@@ -373,8 +373,8 @@ async function applyBatch() {
     batchDialog.value = false
     return
   }
-  if (assetIds.length) await updateAssetsViewers(assetIds, batchUsers.value)
-  if (folderIds.length) await updateFoldersViewers(folderIds, batchUsers.value)
+  if (assetIds.length) await updateAssetsRoles(assetIds, batchRoles.value)
+  if (folderIds.length) await updateFoldersRoles(folderIds, batchRoles.value)
   batchDialog.value = false
   selectedItems.value = []
   loadData(currentFolder.value?._id)

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -17,7 +17,7 @@
         <el-select v-model="filterTags" multiple placeholder="標籤篩選" style="min-width:150px">
           <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
         </el-select>
-        <el-button v-if="canBatch" type="warning" :disabled="!selectedItems.length" @click="openBatch">批量設定可查看者</el-button>
+        <el-button v-if="canBatch" type="warning" :disabled="!selectedItems.length" @click="openBatch">批量設定可查看角色</el-button>
 
       </div>
 
@@ -184,9 +184,9 @@
       </template>
     </el-dialog>
     <el-dialog v-if="canBatch" v-model="batchDialog" width="30%" top="20vh">
-      <template #header>批量設定可查看者</template>
-      <el-select v-model="batchUsers" multiple filterable style="width:100%" class="mb-4">
-        <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
+      <template #header>批量設定可查看角色</template>
+      <el-select v-model="batchRoles" multiple style="width:100%" class="mb-4">
+        <el-option v-for="r in roleOptions" :key="r.value" :label="r.label" :value="r.value" />
       </el-select>
       <template #footer>
         <el-button @click="batchDialog = false">取消</el-button>
@@ -199,7 +199,7 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
-import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers } from '../services/folders'
+import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersRoles } from '../services/folders'
 import { fetchUsers } from '../services/user'
 import {
   fetchProducts,
@@ -209,7 +209,7 @@ import {
   reviewAsset,
   fetchAssetStages,
   updateAssetStage,
-  updateAssetsViewers
+  updateAssetsRoles
 } from '../services/assets'
 import { fetchTags } from '../services/tags'
 import { fetchRoles } from '../services/roles'
@@ -240,7 +240,7 @@ const allTags = ref([])
 const users = ref([])
 const selectedItems = ref([])
 const batchDialog = ref(false)
-const batchUsers = ref([])
+const batchRoles = ref([])
 const roleOptions = ref([])
 
 const breadcrumb = ref([])
@@ -394,8 +394,8 @@ function handleError(_, file) {
 }
 
 async function openBatch() {
-  if (!users.value.length) await loadUsers()
-  batchUsers.value = users.value.filter(u => u.role === 'manager').map(u => u._id)
+  if (!roleOptions.value.length) await loadRoles()
+  batchRoles.value = []
   batchDialog.value = true
 }
 
@@ -410,8 +410,8 @@ async function applyBatch() {
     batchDialog.value = false
     return
   }
-  if (assetIds.length) await updateAssetsViewers(assetIds, batchUsers.value)
-  if (folderIds.length) await updateFoldersViewers(folderIds, batchUsers.value)
+  if (assetIds.length) await updateAssetsRoles(assetIds, batchRoles.value)
+  if (folderIds.length) await updateFoldersRoles(folderIds, batchRoles.value)
   batchDialog.value = false
   selectedItems.value = []
   loadData(currentFolder.value?._id)

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -1,6 +1,7 @@
 import Folder from '../models/folder.model.js'
 import { getDescendantFolderIds } from '../utils/folderTree.js'
 import { includeManagers } from '../utils/includeManagers.js'
+import { ROLES } from '../config/roles.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -88,5 +89,15 @@ export const updateFoldersViewers = async (req, res) => {
   }
   const users = await includeManagers(allowedUsers)
   await Folder.updateMany({ _id: { $in: ids } }, { allowedUsers: users })
+  res.json({ message: '已更新' })
+}
+
+export const updateFoldersRoles = async (req, res) => {
+  const { ids, allowRoles } = req.body
+  if (!Array.isArray(ids) || !Array.isArray(allowRoles)) {
+    return res.status(400).json({ message: '參數錯誤' })
+  }
+  const roles = allowRoles.filter(r => Object.values(ROLES).includes(r))
+  await Folder.updateMany({ _id: { $in: ids } }, { allowRoles: roles })
   res.json({ message: '已更新' })
 }

--- a/server/src/models/folder.model.js
+++ b/server/src/models/folder.model.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import { ROLES } from '../config/roles.js'
 
 const folderSchema = new mongoose.Schema(
   {
@@ -10,6 +11,13 @@ const folderSchema = new mongoose.Schema(
 
     /* 可存取使用者 */
     allowedUsers: { type: [mongoose.Schema.Types.ObjectId], ref: 'User', default: [] },
+
+    /* 允許查看角色 */
+    allowRoles: {
+      type: [String],
+      enum: Object.values(ROLES),
+      default: [ROLES.MANAGER, ROLES.EMPLOYEE]
+    },
 
     /* 標籤 */
     tags: { type: [String], default: [] }

--- a/server/src/routes/folder.routes.js
+++ b/server/src/routes/folder.routes.js
@@ -8,7 +8,8 @@ import {
   getFolder,
   updateFolder,
   deleteFolder,
-  updateFoldersViewers
+  updateFoldersViewers,
+  updateFoldersRoles
 } from '../controllers/folder.controller.js'
 
 const router = Router()
@@ -21,6 +22,12 @@ router.put(
   protect,
   requirePerm(PERMISSIONS.FOLDER_MANAGE),
   updateFoldersViewers
+)
+router.put(
+  '/roles',
+  protect,
+  requirePerm(PERMISSIONS.FOLDER_MANAGE),
+  updateFoldersRoles
 )
 router.put('/:id', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), updateFolder)
 router.delete(


### PR DESCRIPTION
## Summary
- support role-based access for folders
- add `updateFoldersRoles` controller, route and client service
- call role-based batch APIs from AssetLibrary and ProductLibrary
- update folder model with allowRoles

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db162f8e08329abc547e36b434b57