### PR TITLE
新增批次設定可查看者

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 4. 上傳檔案可呼叫 `uploadAsset(file, folderId, extraData)`，其中 `extraData`
    會被加入 `FormData`；剪輯師上傳成品時可傳入 `{ type: 'edited' }`。
 5. 素材庫詳情視窗可設定可查看使用者，管理者可指定具有瀏覽權限的帳號。
+6. 於素材庫與成品區可批次設定可查看者，選取多項後點擊「批次設定可查看者」。
 
 ## 後端 (server)
 1. 進入 `server` 目錄安裝依賴：

--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -68,7 +68,13 @@ export const fetchAssetStages = id =>
 export const updateAssetStage = (assetId, stageId, completed) =>
   api.put(`/assets/${assetId}/stages/${stageId}`, { completed }).then(res => res.data)
 
-export const updateAssetsViewers = (ids, users) =>
-  api.put('/assets/viewers', { ids, allowedUsers: users }).then(res => res.data)
+export const updateAssetsViewers = async (ids, users) => {
+  try {
+    const res = await api.put('/assets/viewers', { ids, allowedUsers: users })
+    return res.data
+  } catch (e) {
+    throw e.response?.data?.message || '更新失敗'
+  }
+}
 
 

--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -26,6 +26,12 @@ export const updateFolder = (id, data) => {
 export const deleteFolder = id =>
   api.delete(`/folders/${id}`).then(res => res.data)
 
-export const updateFoldersViewers = (ids, users) =>
-  api.put('/folders/viewers', { ids, allowedUsers: users }).then(res => res.data)
+export const updateFoldersViewers = async (ids, users) => {
+  try {
+    const res = await api.put('/folders/viewers', { ids, allowedUsers: users })
+    return res.data
+  } catch (e) {
+    throw e.response?.data?.message || '更新失敗'
+  }
+}
 

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -18,6 +18,10 @@
           <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
         </el-select>
 
+        <el-button v-if="selectedItems.length && isManager" @click="openBatchDialog">
+          批次設定可查看者
+        </el-button>
+
       </div>
 
       <el-breadcrumb separator="/" class="mb-2" style="font-size: larger;margin: 1rem;">
@@ -157,14 +161,24 @@
       </template>
     </el-dialog>
 
+    <el-dialog v-model="batchDialog" title="批次設定可查看者" width="30%" append-to-body>
+      <el-select v-model="batchUsers" multiple filterable style="width:100%">
+        <el-option v-for="u in users" :key="u._id" :label="u.username" :value="u._id" />
+      </el-select>
+      <template #footer>
+        <el-button @click="batchDialog = false">取消</el-button>
+        <el-button type="primary" @click="applyBatch">確定</el-button>
+      </template>
+    </el-dialog>
+
 
   </section>
 </template>
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
-import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder } from '../services/folders'
-import { fetchAssets, uploadAsset, updateAsset, deleteAsset } from '../services/assets'
+import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers } from '../services/folders'
+import { fetchAssets, uploadAsset, updateAsset, deleteAsset, updateAssetsViewers } from '../services/assets'
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
 import { useAuthStore } from '../stores/auth'
@@ -188,6 +202,8 @@ const allTags = ref([])
 
 const users = ref([])
 const selectedItems = ref([])
+const batchDialog = ref(false)
+const batchUsers = ref([])
 
 const breadcrumb = ref([])
 
@@ -243,6 +259,23 @@ watch(filterTags, () => loadData(currentFolder.value?._id || null))
 
 function openFolder(f) { loadData(f._id) }
 function goUp() { loadData(currentFolder.value?.parentId || null) }
+
+function openBatchDialog() {
+  if (!users.value.length) loadUsers()
+  batchUsers.value = []
+  batchDialog.value = true
+}
+
+async function applyBatch() {
+  const assetIds = selectedItems.value.filter(id => assets.value.some(a => a._id === id))
+  const folderIds = selectedItems.value.filter(id => folders.value.some(f => f._id === id))
+  if (assetIds.length) await updateAssetsViewers(assetIds, batchUsers.value)
+  if (folderIds.length) await updateFoldersViewers(folderIds, batchUsers.value)
+  ElMessage.success('已更新可查看者')
+  batchDialog.value = false
+  selectedItems.value = []
+  loadData(currentFolder.value?._id)
+}
 
 async function showDetailFor(item, type) {
   detailType.value = type

--- a/server/README.md
+++ b/server/README.md
@@ -86,6 +86,14 @@ GET /api/assets/:id/stages
 PUT /api/assets/:id/stages/:stageId { completed: true | false }
 ```
 
+## 批次設定可查看者
+一次更新多個素材或資料夾的 `allowedUsers`：
+
+```bash
+PUT /api/assets/viewers  { ids: [id], allowedUsers: [userId] }
+PUT /api/folders/viewers { ids: [id], allowedUsers: [userId] }
+```
+
 ## 客戶與廣告資料 API
 下列為常見操作範例：
 ```bash


### PR DESCRIPTION
## Summary
- 在素材庫與成品區加入「批次設定可查看者」功能
- 新增批次對話框並串接 `/api/assets/viewers`、`/api/folders/viewers`
- 服務層加入簡易錯誤處理
- 更新文件說明批次設定操作及相關 API

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dca0abb008329aca82bd990c0dc60