### PR TITLE
廣告數據功能改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ server/  # 後端 API
 若有設定審查關卡，點擊成品資訊中的「審查關卡」按鈕可檢視並勾選各階段。
 
 ## 廣告數據頁面
-此頁面匯集各廣告平台的曝光與點擊統計，路徑為 `/ads`。目前後端示範提供 `/api/analytics` 取得資料，未來可依需求串接第三方服務。
+此頁面分為「客戶管理 → 平台管理 → 數據管理」三層。路徑分別為：
+`/ad-clients`、`/clients/:clientId/platforms`、`/clients/:clientId/platforms/:platformId/data`。
+後端對應 `/api/clients/:clientId/platforms/:platformId/ad-daily`，`/weekly` 回傳週統計。
 
 
 ## Heroku 部署

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,8 @@
     "lucide-vue-next": "^0.513.0",
     "pinia": "^3.0.3",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "chart.js": "^4.4.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -11,6 +11,8 @@ import EmployeeManager from '../views/EmployeeManager.vue'
 import RoleSettings from '../views/RoleSettings.vue'
 import TagManager from '../views/TagManager.vue'
 import ReviewSettings from '../views/ReviewSettings.vue'
+import AdClients from '../views/AdClients.vue'
+import AdPlatforms from '../views/AdPlatforms.vue'
 import AdData from '../views/AdData.vue'
 
 
@@ -34,7 +36,9 @@ const routes = [
       { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { menu: 'roles' } },
       { path: 'tags', name: 'TagManager', component: TagManager, meta: { menu: 'tags' } },
       { path: 'review-stages', name: 'ReviewSettings', component: ReviewSettings, meta: { menu: 'review-stages' } },
-      { path: 'ad-data', name: 'AdData', component: AdData, meta: { menu: 'ad-data' } }
+      { path: 'ad-clients', name: 'AdClients', component: AdClients, meta: { menu: 'ad-data' } },
+      { path: 'clients/:clientId/platforms', name: 'AdPlatforms', component: AdPlatforms },
+      { path: 'clients/:clientId/platforms/:platformId/data', name: 'AdData', component: AdData }
     ]
   },
   // 404

--- a/client/src/services/adDaily.js
+++ b/client/src/services/adDaily.js
@@ -1,10 +1,10 @@
 import api from './api'
 
-export const fetchDaily = clientId =>
-  api.get('/ad-daily', { params: { clientId } }).then(r => r.data)
+export const fetchDaily = (clientId, platformId) =>
+  api.get(`/clients/${clientId}/platforms/${platformId}/ad-daily`).then(r => r.data)
 
-export const createDaily = data =>
-  api.post('/ad-daily', data).then(r => r.data)
+export const createDaily = (clientId, platformId, data) =>
+  api.post(`/clients/${clientId}/platforms/${platformId}/ad-daily`, data).then(r => r.data)
 
-export const fetchWeekly = clientId =>
-  api.get('/ad-daily/weekly', { params: { clientId } }).then(r => r.data)
+export const fetchWeekly = (clientId, platformId) =>
+  api.get(`/clients/${clientId}/platforms/${platformId}/ad-daily/weekly`).then(r => r.data)

--- a/client/src/services/platforms.js
+++ b/client/src/services/platforms.js
@@ -1,0 +1,13 @@
+import api from './api'
+
+export const fetchPlatforms = clientId =>
+  api.get(`/clients/${clientId}/platforms`).then(r => r.data)
+
+export const createPlatform = (clientId, data) =>
+  api.post(`/clients/${clientId}/platforms`, data).then(r => r.data)
+
+export const updatePlatform = (clientId, id, data) =>
+  api.put(`/clients/${clientId}/platforms/${id}`, data).then(r => r.data)
+
+export const deletePlatform = (clientId, id) =>
+  api.delete(`/clients/${clientId}/platforms/${id}`).then(r => r.data)

--- a/client/src/views/AdClients.vue
+++ b/client/src/views/AdClients.vue
@@ -1,0 +1,83 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { fetchClients, createClient, updateClient, deleteClient } from '../services/clients'
+
+const router = useRouter()
+const clients = ref([])
+const dialog = ref(false)
+const editing = ref(false)
+const form = ref({ name: '' })
+
+const loadClients = async () => {
+  clients.value = await fetchClients()
+}
+
+const openCreate = () => {
+  editing.value = false
+  form.value = { name: '' }
+  dialog.value = true
+}
+
+const openEdit = c => {
+  editing.value = true
+  form.value = { ...c }
+  dialog.value = true
+}
+
+const submit = async () => {
+  if (editing.value) {
+    await updateClient(form.value._id, form.value)
+    ElMessage.success('已更新客戶')
+  } else {
+    await createClient(form.value)
+    ElMessage.success('已新增客戶')
+  }
+  dialog.value = false
+  await loadClients()
+}
+
+const managePlatforms = c => {
+  router.push(`/clients/${c._id}/platforms`)
+}
+
+const removeClient = async c => {
+  await ElMessageBox.confirm(`確定刪除「${c.name}」？`, '警告', { confirmButtonText: '刪除', cancelButtonText: '取消', type: 'warning' })
+  await deleteClient(c._id)
+  ElMessage.success('已刪除客戶')
+  await loadClients()
+}
+
+onMounted(loadClients)
+</script>
+
+<template>
+  <section class="p-6 space-y-6 bg-white text-gray-800">
+    <h1 class="text-2xl font-bold">客戶管理</h1>
+    <el-button type="primary" @click="openCreate">＋ 新增客戶</el-button>
+    <el-table :data="clients" stripe style="width:100%" class="mt-4">
+      <el-table-column prop="name" label="客戶名稱" />
+      <el-table-column label="操作" width="200">
+        <template #default="{ row }">
+          <el-button link type="primary" @click="managePlatforms(row)">平台</el-button>
+          <el-button link type="primary" @click="openEdit(row)">編輯</el-button>
+          <el-button link type="danger" @click="removeClient(row)">刪除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialog" :title="editing ? '編輯客戶' : '新增客戶'" width="420px">
+      <el-form label-position="top" @submit.prevent>
+        <el-form-item label="客戶名稱"><el-input v-model="form.name" /></el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialog=false">取消</el-button>
+        <el-button type="primary" @click="submit">{{ editing ? '更新' : '建立' }}</el-button>
+      </template>
+    </el-dialog>
+  </section>
+</template>
+
+<style scoped>
+</style>

--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -1,139 +1,92 @@
 <script setup>
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import { ElMessage } from 'element-plus'
-import { fetchClients, createClient, updateClient } from '../services/clients'
 import { fetchDaily, createDaily, fetchWeekly } from '../services/adDaily'
+import { Chart, LineController, LineElement, PointElement, LinearScale, Title, CategoryScale } from 'chart.js'
 
-const clients = ref([])
-const selected = ref('')
+Chart.register(LineController, LineElement, PointElement, LinearScale, Title, CategoryScale)
+
+const route = useRoute()
+const clientId = route.params.clientId
+const platformId = route.params.platformId
+
 const dailyData = ref([])
 const weeklyData = ref([])
-
-const clientDialog = ref(false)
-const editingClient = ref(false)
-const clientForm = ref({ name: '' })
-
-const recordForm = ref({
-  date: '',
-  cost: '',
-  impressions: '',
-  clicks: '',
-  conversions: ''
-})
+const recordForm = ref({ date: '', spent: '', enquiries: '', reach: '', impressions: '', clicks: '' })
 const activeTab = ref('daily')
+let chart
 
-async function loadClients() {
-  clients.value = await fetchClients()
+const loadDaily = async () => {
+  dailyData.value = await fetchDaily(clientId, platformId)
 }
 
-async function loadDaily() {
-  if (!selected.value) return
-  dailyData.value = await fetchDaily(selected.value)
+const loadWeekly = async () => {
+  weeklyData.value = await fetchWeekly(clientId, platformId)
+  drawChart()
 }
 
-async function loadWeekly() {
-  if (!selected.value) return
-  weeklyData.value = await fetchWeekly(selected.value)
-}
-
-watch(selected, async () => {
+onMounted(async () => {
   await loadDaily()
   await loadWeekly()
 })
-
-onMounted(loadClients)
-
-const openCreateClient = () => {
-  editingClient.value = false
-  clientForm.value = { name: '' }
-  clientDialog.value = true
-}
-
-const openEditClient = (c) => {
-  editingClient.value = true
-  clientForm.value = { ...c }
-  clientDialog.value = true
-}
-
-const submitClient = async () => {
-  if (editingClient.value) {
-    await updateClient(clientForm.value._id, clientForm.value)
-    ElMessage.success('已更新客戶')
-  } else {
-    await createClient(clientForm.value)
-    ElMessage.success('已新增客戶')
-  }
-  clientDialog.value = false
-  await loadClients()
-}
 
 const submitRecord = async () => {
-  if (!selected.value) return
-  await createDaily({ ...recordForm.value, clientId: selected.value })
+  await createDaily(clientId, platformId, { ...recordForm.value })
   ElMessage.success('已新增記錄')
-  recordForm.value = { date: '', cost: '', impressions: '', clicks: '', conversions: '' }
+  recordForm.value = { date: '', spent: '', enquiries: '', reach: '', impressions: '', clicks: '' }
   await loadDaily()
   await loadWeekly()
+}
+
+const drawChart = () => {
+  const ctx = document.getElementById('weekly-chart')
+  if (!ctx) return
+  const labels = weeklyData.value.map(d => d.week)
+  const data = weeklyData.value.map(d => d.spent)
+  if (chart) chart.destroy()
+  chart = new Chart(ctx, {
+    type: 'line',
+    data: { labels, datasets: [{ label: '花費', data, borderColor: '#409EFF' }] },
+    options: { responsive: true }
+  })
 }
 </script>
 
 <template>
   <section class="p-6 space-y-6 bg-white text-gray-800">
     <h1 class="text-2xl font-bold">廣告數據</h1>
-
-    <div class="flex items-center gap-4 mb-4">
-      <el-select v-model="selected" placeholder="選擇客戶" style="min-width: 200px">
-        <el-option v-for="c in clients" :key="c._id" :label="c.name" :value="c._id" />
-      </el-select>
-      <el-button type="primary" @click="openCreateClient">＋ 新增客戶</el-button>
-    </div>
-
-    <el-table :data="clients" stripe style="width:100%" class="mb-6">
-      <el-table-column prop="name" label="客戶名稱" />
-      <el-table-column label="操作" width="120">
-        <template #default="{ row }">
-          <el-button link type="primary" @click="openEditClient(row)">編輯</el-button>
-        </template>
-      </el-table-column>
-    </el-table>
-
-    <el-dialog v-model="clientDialog" :title="editingClient ? '編輯客戶' : '新增客戶'" width="420px">
-      <el-form label-position="top" @submit.prevent>
-        <el-form-item label="客戶名稱"><el-input v-model="clientForm.name" /></el-form-item>
-      </el-form>
-      <template #footer>
-        <el-button @click="clientDialog=false">取消</el-button>
-        <el-button type="primary" @click="submitClient">{{ editingClient ? '更新' : '建立' }}</el-button>
-      </template>
-    </el-dialog>
-
     <el-tabs v-model="activeTab">
       <el-tab-pane label="每日記錄" name="daily">
         <el-table :data="dailyData" stripe style="width:100%" empty-text="尚無資料">
           <el-table-column prop="date" label="日期" />
-          <el-table-column prop="cost" label="花費" />
+          <el-table-column prop="spent" label="花費" />
+          <el-table-column prop="enquiries" label="詢問" />
+          <el-table-column prop="reach" label="觸及" />
           <el-table-column prop="impressions" label="曝光" />
           <el-table-column prop="clicks" label="點擊" />
-          <el-table-column prop="conversions" label="轉換" />
         </el-table>
         <el-form label-position="top" class="mt-4" @submit.prevent="submitRecord">
           <div class="flex flex-wrap gap-4 items-end">
             <el-date-picker v-model="recordForm.date" type="date" placeholder="日期" />
-            <el-input v-model.number="recordForm.cost" placeholder="花費" class="w-28" />
+            <el-input v-model.number="recordForm.spent" placeholder="花費" class="w-28" />
+            <el-input v-model.number="recordForm.enquiries" placeholder="詢問" class="w-28" />
+            <el-input v-model.number="recordForm.reach" placeholder="觸及" class="w-28" />
             <el-input v-model.number="recordForm.impressions" placeholder="曝光" class="w-28" />
             <el-input v-model.number="recordForm.clicks" placeholder="點擊" class="w-28" />
-            <el-input v-model.number="recordForm.conversions" placeholder="轉換" class="w-28" />
             <el-button type="primary" native-type="submit">新增記錄</el-button>
           </div>
         </el-form>
       </el-tab-pane>
       <el-tab-pane label="週報表" name="weekly">
-        <el-table :data="weeklyData" stripe style="width:100%" empty-text="尚無資料">
+        <canvas id="weekly-chart" height="260"></canvas>
+        <el-table :data="weeklyData" stripe style="width:100%" empty-text="尚無資料" class="mt-4">
           <el-table-column prop="week" label="週" />
-          <el-table-column prop="cost" label="總花費" />
+          <el-table-column prop="spent" label="總花費" />
+          <el-table-column prop="enquiries" label="總詢問" />
+          <el-table-column prop="reach" label="總觸及" />
           <el-table-column prop="impressions" label="總曝光" />
           <el-table-column prop="clicks" label="總點擊" />
-          <el-table-column prop="conversions" label="總轉換" />
         </el-table>
       </el-tab-pane>
     </el-tabs>

--- a/client/src/views/AdPlatforms.vue
+++ b/client/src/views/AdPlatforms.vue
@@ -1,0 +1,87 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { fetchPlatforms, createPlatform, updatePlatform, deletePlatform } from '../services/platforms'
+
+const route = useRoute()
+const router = useRouter()
+const clientId = route.params.clientId
+const platforms = ref([])
+const dialog = ref(false)
+const editing = ref(false)
+const form = ref({ name: '', platformType: '' })
+
+const loadPlatforms = async () => {
+  platforms.value = await fetchPlatforms(clientId)
+}
+
+const openCreate = () => {
+  editing.value = false
+  form.value = { name: '', platformType: '' }
+  dialog.value = true
+}
+
+const openEdit = p => {
+  editing.value = true
+  form.value = { ...p }
+  dialog.value = true
+}
+
+const submit = async () => {
+  if (editing.value) {
+    await updatePlatform(clientId, form.value._id, form.value)
+    ElMessage.success('已更新平台')
+  } else {
+    await createPlatform(clientId, form.value)
+    ElMessage.success('已新增平台')
+  }
+  dialog.value = false
+  await loadPlatforms()
+}
+
+const manageData = p => {
+  router.push(`/clients/${clientId}/platforms/${p._id}/data`)
+}
+
+const removePlatform = async p => {
+  await ElMessageBox.confirm(`確定刪除「${p.name}」？`, '警告', { confirmButtonText: '刪除', cancelButtonText: '取消', type: 'warning' })
+  await deletePlatform(clientId, p._id)
+  ElMessage.success('已刪除平台')
+  await loadPlatforms()
+}
+
+onMounted(loadPlatforms)
+</script>
+
+<template>
+  <section class="p-6 space-y-6 bg-white text-gray-800">
+    <h1 class="text-2xl font-bold">平台管理</h1>
+    <el-button type="primary" @click="openCreate">＋ 新增平台</el-button>
+    <el-table :data="platforms" stripe style="width:100%" class="mt-4">
+      <el-table-column prop="name" label="名稱" />
+      <el-table-column prop="platformType" label="類型" />
+      <el-table-column label="操作" width="200">
+        <template #default="{ row }">
+          <el-button link type="primary" @click="manageData(row)">數據</el-button>
+          <el-button link type="primary" @click="openEdit(row)">編輯</el-button>
+          <el-button link type="danger" @click="removePlatform(row)">刪除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialog" :title="editing ? '編輯平台' : '新增平台'" width="420px">
+      <el-form label-position="top" @submit.prevent>
+        <el-form-item label="平台名稱"><el-input v-model="form.name" /></el-form-item>
+        <el-form-item label="類型"><el-input v-model="form.platformType" /></el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialog=false">取消</el-button>
+        <el-button type="primary" @click="submit">{{ editing ? '更新' : '建立' }}</el-button>
+      </template>
+    </el-dialog>
+  </section>
+</template>
+
+<style scoped>
+</style>

--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -2,12 +2,16 @@ import mongoose from 'mongoose'
 import AdDaily from '../models/adDaily.model.js'
 
 export const createAdDaily = async (req, res) => {
-  const rec = await AdDaily.create({ ...req.body, clientId: req.params.clientId })
+  const rec = await AdDaily.create({
+    ...req.body,
+    clientId: req.params.clientId,
+    platformId: req.params.platformId
+  })
   res.status(201).json(rec)
 }
 
 export const getAdDaily = async (req, res) => {
-  const query = { clientId: req.params.clientId }
+  const query = { clientId: req.params.clientId, platformId: req.params.platformId }
   if (req.query.start && req.query.end) {
     query.date = { $gte: new Date(req.query.start), $lte: new Date(req.query.end) }
   }
@@ -16,7 +20,10 @@ export const getAdDaily = async (req, res) => {
 }
 
 export const getWeeklyData = async (req, res) => {
-  const match = { clientId: new mongoose.Types.ObjectId(req.params.clientId) }
+  const match = {
+    clientId: new mongoose.Types.ObjectId(req.params.clientId),
+    platformId: new mongoose.Types.ObjectId(req.params.platformId)
+  }
   if (req.query.start && req.query.end) {
     match.date = { $gte: new Date(req.query.start), $lte: new Date(req.query.end) }
   }
@@ -26,6 +33,7 @@ export const getWeeklyData = async (req, res) => {
       $group: {
         _id: { year: { $isoWeekYear: '$date' }, week: { $isoWeek: '$date' } },
         spent: { $sum: '$spent' },
+        enquiries: { $sum: '$enquiries' },
         reach: { $sum: '$reach' },
         impressions: { $sum: '$impressions' },
         clicks: { $sum: '$clicks' }
@@ -33,5 +41,13 @@ export const getWeeklyData = async (req, res) => {
     },
     { $sort: { '_id.year': 1, '_id.week': 1 } }
   ])
-  res.json(data)
+  const result = data.map(d => ({
+    week: `${d._id.year}-W${d._id.week}`,
+    spent: d.spent,
+    enquiries: d.enquiries,
+    reach: d.reach,
+    impressions: d.impressions,
+    clicks: d.clicks
+  }))
+  res.json(result)
 }

--- a/server/src/controllers/platform.controller.js
+++ b/server/src/controllers/platform.controller.js
@@ -1,0 +1,35 @@
+import Platform from '../models/platform.model.js'
+
+export const createPlatform = async (req, res) => {
+  const platform = await Platform.create({
+    ...req.body,
+    clientId: req.params.clientId
+  })
+  res.status(201).json(platform)
+}
+
+export const getPlatforms = async (req, res) => {
+  const list = await Platform.find({ clientId: req.params.clientId })
+  res.json(list)
+}
+
+export const getPlatform = async (req, res) => {
+  const p = await Platform.findOne({ _id: req.params.id, clientId: req.params.clientId })
+  if (!p) return res.status(404).json({ message: '平台不存在' })
+  res.json(p)
+}
+
+export const updatePlatform = async (req, res) => {
+  const p = await Platform.findOneAndUpdate(
+    { _id: req.params.id, clientId: req.params.clientId },
+    req.body,
+    { new: true }
+  )
+  if (!p) return res.status(404).json({ message: '平台不存在' })
+  res.json(p)
+}
+
+export const deletePlatform = async (req, res) => {
+  await Platform.findOneAndDelete({ _id: req.params.id, clientId: req.params.clientId })
+  res.json({ message: '平台已刪除' })
+}

--- a/server/src/models/adDaily.model.js
+++ b/server/src/models/adDaily.model.js
@@ -3,8 +3,10 @@ import mongoose from 'mongoose'
 const adDailySchema = new mongoose.Schema(
   {
     clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true },
+    platformId: { type: mongoose.Schema.Types.ObjectId, ref: 'Platform', required: true },
     date: { type: Date, required: true },
     spent: { type: Number, default: 0 },
+    enquiries: { type: Number, default: 0 },
     reach: { type: Number, default: 0 },
     impressions: { type: Number, default: 0 },
     clicks: { type: Number, default: 0 }
@@ -12,6 +14,6 @@ const adDailySchema = new mongoose.Schema(
   { timestamps: true }
 )
 
-adDailySchema.index({ clientId: 1, date: 1 }, { unique: true })
+adDailySchema.index({ clientId: 1, platformId: 1, date: 1 }, { unique: true })
 
 export default mongoose.model('AdDaily', adDailySchema)

--- a/server/src/models/client.model.js
+++ b/server/src/models/client.model.js
@@ -5,7 +5,8 @@ const clientSchema = new mongoose.Schema(
     name: { type: String, required: true },
     phone: { type: String, default: '' },
     email: { type: String, default: '' },
-    address: { type: String, default: '' }
+    address: { type: String, default: '' },
+    platforms: { type: [String], default: [] }
   },
   { timestamps: true }
 )

--- a/server/src/models/platform.model.js
+++ b/server/src/models/platform.model.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose'
+
+const platformSchema = new mongoose.Schema(
+  {
+    clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true },
+    name: { type: String, required: true },
+    platformType: { type: String, default: '' }
+  },
+  { timestamps: true }
+)
+
+platformSchema.index({ clientId: 1, name: 1 }, { unique: true })
+
+export default mongoose.model('Platform', platformSchema)

--- a/server/src/routes/platform.routes.js
+++ b/server/src/routes/platform.routes.js
@@ -1,0 +1,24 @@
+import { Router } from 'express'
+import { protect } from '../middleware/auth.js'
+import {
+  createPlatform,
+  getPlatforms,
+  getPlatform,
+  updatePlatform,
+  deletePlatform
+} from '../controllers/platform.controller.js'
+
+const router = Router({ mergeParams: true })
+
+router.use(protect)
+
+router.route('/')
+  .post(createPlatform)
+  .get(getPlatforms)
+
+router.route('/:id')
+  .get(getPlatform)
+  .put(updatePlatform)
+  .delete(deletePlatform)
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -45,6 +45,7 @@ import permissionsRoutes from './routes/permissions.routes.js'
 import menusRoutes from './routes/menus.routes.js'
 import reviewStageRoutes from './routes/reviewStage.routes.js'
 import clientRoutes     from './routes/client.routes.js'
+import platformRoutes   from './routes/platform.routes.js'
 import adDailyRoutes    from './routes/adDaily.routes.js'
 // import analyticsRoutes from './routes/analytics.routes.js' // 未啟用
 
@@ -57,7 +58,8 @@ app.use('/api/tasks',    taskRoutes)
 app.use('/api/roles',    roleRoutes)
 app.use('/api/tags',     tagRoutes)
 app.use('/api/clients',  clientRoutes)
-app.use('/api/clients/:clientId/ad-daily', adDailyRoutes)
+app.use('/api/clients/:clientId/platforms', platformRoutes)
+app.use('/api/clients/:clientId/platforms/:platformId/ad-daily', adDailyRoutes)
 app.use('/api/permissions', permissionsRoutes)
 app.use('/api/menus', menusRoutes)
 app.use('/api/review-stages', reviewStageRoutes)


### PR DESCRIPTION
## Summary
- 新增 Platform 模型與 CRUD API
- AdDaily 模型加入 platformId 與 enquiries
- 更新後端路由以支援 `/platforms/:platformId/ad-daily`
- 前端增加客戶與平台管理頁面
- AdData.vue 改為依路由參數載入並加入圖表
- 補充文件說明路徑

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd267fdd48329ac688cde53eb7b85