### PR TITLE
Fix ad-data menu path

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -69,7 +69,7 @@ const allMenus = {
   roles: { path: '/roles', icon: '🛡️' },
   tags: { path: '/tags', icon: '🏷️' },
   'review-stages': { path: '/review-stages', icon: '✅' },
-  'ad-data': { path: '/ad-data', icon: '📊' },
+  'ad-data': { path: '/ad-clients', icon: '📊' },
   account: { path: '/account', icon: '👤' }
 }
 


### PR DESCRIPTION
## Summary
- update Sidebar menu path for 'ad-data' to `/ad-clients`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de06106f88329bf31731657748235