### PR TITLE
Add consistent column widths to AdData tables

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -64,14 +64,14 @@ const drawChart = () => {
     <el-tabs v-model="activeTab">
       <el-tab-pane label="每日記錄" name="daily">
         <el-table :data="dailyData" stripe style="width:100%" empty-text="尚無資料">
-          <el-table-column prop="date" label="日期" />
-          <el-table-column prop="spent" label="花費" />
+          <el-table-column prop="date" label="日期" width="100" />
+          <el-table-column prop="spent" label="花費" width="100" />
 
-          <el-table-column prop="enquiries" label="詢問" />
+          <el-table-column prop="enquiries" label="詢問" width="100" />
 
-          <el-table-column prop="reach" label="觸及" />
-          <el-table-column prop="impressions" label="曝光" />
-          <el-table-column prop="clicks" label="點擊" />
+          <el-table-column prop="reach" label="觸及" width="100" />
+          <el-table-column prop="impressions" label="曝光" width="100" />
+          <el-table-column prop="clicks" label="點擊" width="100" />
         </el-table>
         <el-form label-position="top" class="mt-4" @submit.prevent="submitRecord">
           <div class="flex flex-wrap gap-4 items-end">
@@ -90,13 +90,13 @@ const drawChart = () => {
       <el-tab-pane label="週報表" name="weekly">
         <canvas id="weekly-chart" height="260"></canvas>
         <el-table :data="weeklyData" stripe style="width:100%" empty-text="尚無資料" class="mt-4">
-          <el-table-column prop="week" label="週" />
-          <el-table-column prop="spent" label="總花費" />
-          <el-table-column prop="enquiries" label="總詢問" />
+          <el-table-column prop="week" label="週" width="100" />
+          <el-table-column prop="spent" label="總花費" width="100" />
+          <el-table-column prop="enquiries" label="總詢問" width="100" />
 
-          <el-table-column prop="reach" label="總觸及" />
-          <el-table-column prop="impressions" label="總曝光" />
-          <el-table-column prop="clicks" label="總點擊" />
+          <el-table-column prop="reach" label="總觸及" width="100" />
+          <el-table-column prop="impressions" label="總曝光" width="100" />
+          <el-table-column prop="clicks" label="總點擊" width="100" />
         </el-table>
       </el-tab-pane>
     </el-tabs>


### PR DESCRIPTION
## Summary
- unify column width across all tables in `AdData.vue`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de71686ec8329b15d563ee7debbf9