### PR TITLE
sanitize adDaily numbers

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -1,9 +1,17 @@
 import mongoose from 'mongoose'
 import AdDaily from '../models/adDaily.model.js'
 
+const sanitizeNumber = val =>
+  parseFloat(String(val).replace(/[^\d.]/g, '')) || 0
+
 export const createAdDaily = async (req, res) => {
   const rec = await AdDaily.create({
     ...req.body,
+    spent: sanitizeNumber(req.body.spent),
+    enquiries: sanitizeNumber(req.body.enquiries),
+    reach: sanitizeNumber(req.body.reach),
+    impressions: sanitizeNumber(req.body.impressions),
+    clicks: sanitizeNumber(req.body.clicks),
     clientId: req.params.clientId,
     platformId: req.params.platformId
   })

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -79,4 +79,24 @@ describe('Client and AdDaily', () => {
       .expect(200)
     expect(res.body[0].spent).toBe(70)
   })
+
+  it('create adDaily with currency string', async () => {
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        date: new Date('2024-02-01').toISOString(),
+        spent: '$10',
+        enquiries: '5件',
+        reach: '1,000',
+        impressions: '2,000',
+        clicks: '7'
+      })
+      .expect(201)
+    expect(res.body.spent).toBe(10)
+    expect(res.body.enquiries).toBe(5)
+    expect(res.body.reach).toBe(1000)
+    expect(res.body.impressions).toBe(2000)
+    expect(res.body.clicks).toBe(7)
+  })
 })


### PR DESCRIPTION
## Summary
- sanitize numeric fields in adDaily controller
- add test ensuring currency strings handled

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de71391d88329a9d83ca373b62242