### PR TITLE
Add AdDaily import

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ server/  # 後端 API
 此頁面分為「客戶管理 → 平台管理 → 數據管理」三層。路徑分別為：
 `/ad-clients`、`/clients/:clientId/platforms`、`/clients/:clientId/platforms/:platformId/data`。
 後端對應 `/api/clients/:clientId/platforms/:platformId/ad-daily`，`/weekly` 回傳週統計。
+若需批次匯入，可 POST 至 `/api/clients/:clientId/platforms/:platformId/ad-daily/import` 上傳 CSV 或 Excel。
 
 
 

--- a/client/src/services/adDaily.js
+++ b/client/src/services/adDaily.js
@@ -10,3 +10,13 @@ export const createDaily = (clientId, platformId, data) =>
 export const fetchWeekly = (clientId, platformId) =>
   api.get(`/clients/${clientId}/platforms/${platformId}/ad-daily/weekly`).then(r => r.data)
 
+export const importDaily = (clientId, platformId, file) => {
+  const formData = new FormData()
+  formData.append('file', file)
+  return api.post(
+    `/clients/${clientId}/platforms/${platformId}/ad-daily/import`,
+    formData,
+    { headers: { 'Content-Type': 'multipart/form-data' } }
+  ).then(r => r.data)
+}
+

--- a/server/README.md
+++ b/server/README.md
@@ -106,4 +106,12 @@ POST /api/user { username, password }
 # 取得廣告成效摘要
 GET /api/analytics
 ```
+新增廣告每日資料可呼叫：
+```bash
+POST /api/clients/:clientId/platforms/:platformId/ad-daily { date, spent, ... }
+```
+批次匯入：
+```bash
+POST /api/clients/:clientId/platforms/:platformId/ad-daily/import (multipart/form-data)
+```
 目前不需額外的環境變數即可使用。

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,8 @@
     "mongoose": "^8.3.1",
     "jsonwebtoken": "^9.0.2",
     "bcryptjs": "^2.4.3",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "nodemon": "^3.1.0",

--- a/server/src/routes/adDaily.routes.js
+++ b/server/src/routes/adDaily.routes.js
@@ -1,9 +1,11 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
+import { upload } from '../middleware/upload.js'
 import {
   createAdDaily,
   getAdDaily,
-  getWeeklyData
+  getWeeklyData,
+  importAdDaily
 } from '../controllers/adDaily.controller.js'
 
 const router = Router({ mergeParams: true })
@@ -15,5 +17,6 @@ router.route('/')
   .get(getAdDaily)
 
 router.get('/weekly', getWeeklyData)
+router.post('/import', upload.single('file'), importAdDaily)
 
 export default router


### PR DESCRIPTION
## Summary
- add `/import` API to upload CSV/Excel
- support importing AdDaily data
- add client service function for new endpoint
- document bulk import usage

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e681248d88329808e2b86df38fe73