### PR TITLE
新增 bulkCreateDaily 函式

### DIFF
--- a/client/src/services/adDaily.js
+++ b/client/src/services/adDaily.js
@@ -20,3 +20,17 @@ export const importDaily = (clientId, platformId, file) => {
   ).then(r => r.data)
 }
 
+export const bulkCreateDaily = async (clientId, platformId, records) => {
+  try {
+    const res = await api.post(
+      `/clients/${clientId}/platforms/${platformId}/ad-daily/bulk`,
+      records
+    )
+    return res.data
+  } catch (e) {
+    return Promise.all(
+      records.map(r => createDaily(clientId, platformId, r))
+    )
+  }
+}
+


### PR DESCRIPTION
## Summary
- adDaily 服務加入 `bulkCreateDaily` 方法，支援批次建立或在無路由時逐筆建立

## Testing
- `npm --prefix server test` *(fails: jest not found)*
- `npm run dev` *(fails: concurrently not found)*
- `npm --prefix client run dev` *(fails: vite not found)*
- `npm --prefix server run dev` *(fails: nodemon not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7dcef3e883298e733f5e505bc891