### PR TITLE
Update docs for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@
    ```
    伺服器啟動後，API 根路徑為 `http://localhost:3000/api`，
    靜態檔案可自 `/static/<檔名>` 存取。
-3. 進行登入測試：
+3. 執行測試前請先在 `server` 目錄安裝相依套件：
+   ```bash
+   npm install
+   ```
+4. 進行登入測試：
    ```bash
    npm test
    ```

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "server": "npm --prefix server run dev",
     "dev": "concurrently \"npm --prefix client run dev\" \"npm --prefix server run dev\"",
 
+    "test": "npm --prefix server test",
+
     
     "heroku-prebuild": "npm install --prefix server --omit=dev",
 

--- a/server/README.md
+++ b/server/README.md
@@ -56,11 +56,15 @@ npm start                 # 啟動伺服器
      -H "Content-Type: application/json" \
    -d '{"username":"admin","password":"mypwd"}'
    ```
-5. 執行自動化測試：
+5. **安裝相依套件**：若尚未安裝，請先執行
+   ```bash
+   npm install
+   ```
+6. 執行自動化測試：
    ```bash
    npm test
    ```
-透過 Jest 與 Supertest 模擬登入，確認回傳資料包含 `token` 與 `user.role`。
+   透過 Jest 與 Supertest 模擬登入，確認回傳資料包含 `token` 與 `user.role`。
 
 ## 成品審核 API
 素材上傳後若 `type=edited`，預設 `reviewStatus` 為 `pending`。管理者可呼叫


### PR DESCRIPTION
## Summary
- clarify that `npm install` is required before running tests
- add root-level `test` script for convenience

## Testing
- `npm run test` *(fails: jest not found)*
- `npm --prefix server install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684e7dd191548329a65c7574bca34cc5