### PR TITLE
Implement bulk create route for ad daily

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -62,6 +62,29 @@ export const getWeeklyData = async (req, res) => {
   res.json(result)
 }
 
+export const bulkCreateAdDaily = async (req, res) => {
+  if (!Array.isArray(req.body)) {
+    return res.status(400).json({ message: '資料格式錯誤' })
+  }
+
+  const records = req.body
+    .map(row => ({
+      date: row.date,
+      spent: sanitizeNumber(row.spent),
+      enquiries: sanitizeNumber(row.enquiries),
+      reach: sanitizeNumber(row.reach),
+      impressions: sanitizeNumber(row.impressions),
+      clicks: sanitizeNumber(row.clicks),
+      clientId: req.params.clientId,
+      platformId: req.params.platformId
+    }))
+    .filter(r => r.date)
+    .map(r => ({ ...r, date: new Date(r.date) }))
+
+  const docs = await AdDaily.insertMany(records)
+  res.status(201).json({ count: docs.length })
+}
+
 export const importAdDaily = async (req, res) => {
   if (!req.file) {
     return res.status(400).json({ message: '未上傳檔案' })

--- a/server/src/routes/adDaily.routes.js
+++ b/server/src/routes/adDaily.routes.js
@@ -5,7 +5,8 @@ import {
   createAdDaily,
   getAdDaily,
   getWeeklyData,
-  importAdDaily
+  importAdDaily,
+  bulkCreateAdDaily
 } from '../controllers/adDaily.controller.js'
 
 const router = Router({ mergeParams: true })
@@ -18,5 +19,6 @@ router.route('/')
 
 router.get('/weekly', getWeeklyData)
 router.post('/import', upload.single('file'), importAdDaily)
+router.post('/bulk', bulkCreateAdDaily)
 
 export default router

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -99,4 +99,17 @@ describe('Client and AdDaily', () => {
     expect(res.body.impressions).toBe(2000)
     expect(res.body.clicks).toBe(7)
   })
+
+  it('bulk create adDaily', async () => {
+    const records = [
+      { date: new Date('2024-03-01').toISOString(), spent: 5 },
+      { date: new Date('2024-03-02').toISOString(), spent: 7 }
+    ]
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily/bulk`)
+      .set('Authorization', `Bearer ${token}`)
+      .send(records)
+      .expect(201)
+    expect(res.body.count).toBe(2)
+  })
 })


### PR DESCRIPTION
## Summary
- support new `/bulk` endpoint for daily ad data
- update router to register new path
- test bulk creation via new endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e92ebe9188329bedd08fa413b2e48