### PR TITLE
加入返回按鈕

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -1,6 +1,7 @@
 <!-- src/views/AdData.vue – 修正版：單一 <template>、Dialog 新增、匯入 Excel/CSV -->
 <template>
   <section class="p-6 space-y-6 bg-white text-gray-800">
+    <el-button @click="router.back()">返回上層</el-button>
     <h1 class="text-2xl font-bold">廣告數據</h1>
 
     <el-tabs v-model="activeTab">
@@ -136,7 +137,7 @@
  * 匯入
  * ---------------------------------------------------------------- */
 import { ref, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { InfoFilled } from '@element-plus/icons-vue'
 import * as XLSX from 'xlsx'
@@ -163,6 +164,7 @@ Chart.register(LineController, LineElement, PointElement, LinearScale, Title, Ca
  * 參數與狀態
  * ---------------------------------------------------------------- */
 const route       = useRoute()
+const router      = useRouter()
 const clientId    = route.params.clientId
 const platformId  = route.params.platformId
 

--- a/client/src/views/AdPlatforms.vue
+++ b/client/src/views/AdPlatforms.vue
@@ -56,6 +56,7 @@ onMounted(loadPlatforms)
 
 <template>
   <section class="p-6 space-y-6 bg-white text-gray-800">
+    <el-button @click="router.back()">返回上層</el-button>
     <h1 class="text-2xl font-bold">平台管理</h1>
     <el-button type="primary" @click="openCreate">＋ 新增平台</el-button>
     <el-table :data="platforms" stripe style="width:100%" class="mt-4">


### PR DESCRIPTION
## Summary
- 在 AdPlatforms 與 AdData 頁面最上方加入「返回上層」按鈕
- AdData 新增 router 取得與使用

## Testing
- `npm test` *(失敗：jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea0d32384832995ed79e3eebed2f3