### PR TITLE
Handle duplicate platform names with error 409

### DIFF
--- a/client/src/views/AdPlatforms.vue
+++ b/client/src/views/AdPlatforms.vue
@@ -29,15 +29,19 @@ const openEdit = p => {
 }
 
 const submit = async () => {
-  if (editing.value) {
-    await updatePlatform(clientId, form.value._id, form.value)
-    ElMessage.success('已更新平台')
-  } else {
-    await createPlatform(clientId, form.value)
-    ElMessage.success('已新增平台')
+  try {
+    if (editing.value) {
+      await updatePlatform(clientId, form.value._id, form.value)
+      ElMessage.success('已更新平台')
+    } else {
+      await createPlatform(clientId, form.value)
+      ElMessage.success('已新增平台')
+    }
+    dialog.value = false
+    await loadPlatforms()
+  } catch (e) {
+    ElMessage.error(e.response?.data?.message || e.message)
   }
-  dialog.value = false
-  await loadPlatforms()
 }
 
 const manageData = p => {

--- a/server/src/controllers/platform.controller.js
+++ b/server/src/controllers/platform.controller.js
@@ -1,11 +1,18 @@
 import Platform from '../models/platform.model.js'
 
 export const createPlatform = async (req, res) => {
-  const platform = await Platform.create({
-    ...req.body,
-    clientId: req.params.clientId
-  })
-  res.status(201).json(platform)
+  try {
+    const platform = await Platform.create({
+      ...req.body,
+      clientId: req.params.clientId
+    })
+    res.status(201).json(platform)
+  } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ message: '平台名稱重複' })
+    }
+    throw err
+  }
 }
 
 export const getPlatforms = async (req, res) => {
@@ -20,13 +27,20 @@ export const getPlatform = async (req, res) => {
 }
 
 export const updatePlatform = async (req, res) => {
-  const p = await Platform.findOneAndUpdate(
-    { _id: req.params.id, clientId: req.params.clientId },
-    req.body,
-    { new: true }
-  )
-  if (!p) return res.status(404).json({ message: '平台不存在' })
-  res.json(p)
+  try {
+    const p = await Platform.findOneAndUpdate(
+      { _id: req.params.id, clientId: req.params.clientId },
+      req.body,
+      { new: true }
+    )
+    if (!p) return res.status(404).json({ message: '平台不存在' })
+    res.json(p)
+  } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ message: '平台名稱重複' })
+    }
+    throw err
+  }
 }
 
 export const deletePlatform = async (req, res) => {

--- a/server/tests/platform.test.js
+++ b/server/tests/platform.test.js
@@ -74,4 +74,19 @@ describe('Platform API', () => {
       .set('Authorization', `Bearer ${token}`)
       .expect(200)
   })
+
+  it('duplicate platform name returns 409', async () => {
+    await request(app)
+      .post(`/api/clients/${clientId}/platforms`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Dup', platformType: 'Meta' })
+      .expect(201)
+
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/platforms`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Dup', platformType: 'Meta' })
+      .expect(409)
+    expect(res.body.message).toBe('平台名稱重複')
+  })
 })


### PR DESCRIPTION
## Summary
- add duplicate name check for `createPlatform` and `updatePlatform`
- show API errors on `AdPlatforms` page with `ElMessage.error`
- test duplicate platform names return HTTP 409

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed629217083299e073ac4596baa21