### PR TITLE
Add weekly note tooltip

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -203,8 +203,24 @@ const drawChart = () => {
   chart && chart.destroy()
   chart = new Chart(ctx, {
     type: 'line',
-    data: { labels, datasets: [{ label: metricLabel[metric.value], data, borderColor: '#409EFF', tension: 0.35 }] },
-    options: { responsive: true, maintainAspectRatio: false }
+    data: {
+      labels,
+      datasets: [{ label: metricLabel[metric.value], data, borderColor: '#409EFF', tension: 0.35 }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        tooltip: {
+          callbacks: {
+            afterLabel: ctx => {
+              const note = weeklyData.value[ctx.dataIndex].note
+              return note ? `備註: ${note}` : ''
+            }
+          }
+        }
+      }
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- show weekly note in tooltip on the weekly chart

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed62a364483298008156f27313a51