### PR TITLE
Add extraData field for ad daily

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -7,14 +7,15 @@ const sanitizeNumber = val =>
 
 export const createAdDaily = async (req, res) => {
   const rec = await AdDaily.create({
-    ...req.body,
+    date: req.body.date,
     spent: sanitizeNumber(req.body.spent),
     enquiries: sanitizeNumber(req.body.enquiries),
     reach: sanitizeNumber(req.body.reach),
     impressions: sanitizeNumber(req.body.impressions),
     clicks: sanitizeNumber(req.body.clicks),
     clientId: req.params.clientId,
-    platformId: req.params.platformId
+    platformId: req.params.platformId,
+    extraData: req.body.extraData
   })
   res.status(201).json(rec)
 }
@@ -67,22 +68,31 @@ export const bulkCreateAdDaily = async (req, res) => {
     return res.status(400).json({ message: '資料格式錯誤' })
   }
 
+  const known = ['date', 'spent', 'enquiries', 'reach', 'impressions', 'clicks', 'extraData']
+
   const records = req.body
-    .map(row => ({
-      date: row.date,
-      spent: sanitizeNumber(row.spent),
-      enquiries: sanitizeNumber(row.enquiries),
-      reach: sanitizeNumber(row.reach),
-      impressions: sanitizeNumber(row.impressions),
-      clicks: sanitizeNumber(row.clicks),
-      clientId: req.params.clientId,
-      platformId: req.params.platformId
-    }))
+    .map(row => {
+      const extra = { ...(row.extraData || {}) }
+      for (const k of Object.keys(row)) {
+        if (!known.includes(k)) extra[k] = row[k]
+      }
+      return {
+        date: row.date,
+        spent: sanitizeNumber(row.spent),
+        enquiries: sanitizeNumber(row.enquiries),
+        reach: sanitizeNumber(row.reach),
+        impressions: sanitizeNumber(row.impressions),
+        clicks: sanitizeNumber(row.clicks),
+        clientId: req.params.clientId,
+        platformId: req.params.platformId,
+        extraData: Object.keys(extra).length ? extra : undefined
+      }
+    })
     .filter(r => r.date)
     .map(r => ({ ...r, date: new Date(r.date) }))
 
   const docs = await AdDaily.insertMany(records)
-  res.status(201).json({ count: docs.length })
+  res.status(201).json(docs)
 }
 
 export const importAdDaily = async (req, res) => {
@@ -95,21 +105,38 @@ export const importAdDaily = async (req, res) => {
   const sheet = wb.Sheets[wb.SheetNames[0]]
   const rows = xlsx.utils.sheet_to_json(sheet)
 
+  const known = [
+    'date', 'Date', '日期',
+    'spent', 'Spent', '花費',
+    'enquiries', 'Enquiries', '詢問',
+    'reach', 'Reach', '觸及',
+    'impressions', 'Impressions', '曝光',
+    'clicks', 'Clicks', '點擊',
+    'extraData'
+  ]
+
   const records = rows
-    .map(row => ({
-      date: row.date || row.Date || row['日期'],
-      spent: sanitizeNumber(row.spent || row.Spent || row['花費']),
-      enquiries: sanitizeNumber(row.enquiries || row.Enquiries || row['詢問']),
-      reach: sanitizeNumber(row.reach || row.Reach || row['觸及']),
-      impressions: sanitizeNumber(row.impressions || row.Impressions || row['曝光']),
-      clicks: sanitizeNumber(row.clicks || row.Clicks || row['點擊']),
-      clientId: req.params.clientId,
-      platformId: req.params.platformId
-    }))
+    .map(row => {
+      const extra = { ...(row.extraData || {}) }
+      for (const k of Object.keys(row)) {
+        if (!known.includes(k)) extra[k] = row[k]
+      }
+      return {
+        date: row.date || row.Date || row['日期'],
+        spent: sanitizeNumber(row.spent || row.Spent || row['花費']),
+        enquiries: sanitizeNumber(row.enquiries || row.Enquiries || row['詢問']),
+        reach: sanitizeNumber(row.reach || row.Reach || row['觸及']),
+        impressions: sanitizeNumber(row.impressions || row.Impressions || row['曝光']),
+        clicks: sanitizeNumber(row.clicks || row.Clicks || row['點擊']),
+        clientId: req.params.clientId,
+        platformId: req.params.platformId,
+        extraData: Object.keys(extra).length ? extra : undefined
+      }
+    })
     .filter(r => r.date)
     .map(r => ({ ...r, date: new Date(r.date) }))
 
   const docs = await AdDaily.insertMany(records)
   fs.unlink(req.file.path, () => {})
-  res.status(201).json({ count: docs.length })
+  res.status(201).json(docs)
 }

--- a/server/src/models/adDaily.model.js
+++ b/server/src/models/adDaily.model.js
@@ -9,7 +9,8 @@ const adDailySchema = new mongoose.Schema(
     enquiries: { type: Number, default: 0 },
     reach: { type: Number, default: 0 },
     impressions: { type: Number, default: 0 },
-    clicks: { type: Number, default: 0 }
+    clicks: { type: Number, default: 0 },
+    extraData: { type: mongoose.Schema.Types.Mixed }
   },
   { timestamps: true }
 )

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -100,16 +100,40 @@ describe('Client and AdDaily', () => {
     expect(res.body.clicks).toBe(7)
   })
 
+  it('create adDaily with extraData and read it', async () => {
+    const custom = {
+      date: new Date('2024-04-01').toISOString(),
+      spent: 3,
+      extraData: { note: 'test', metric: 99 }
+    }
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)
+      .set('Authorization', `Bearer ${token}`)
+      .send(custom)
+      .expect(201)
+    expect(res.body.extraData).toEqual(custom.extraData)
+
+    const list = await request(app)
+      .get(
+        `/api/clients/${clientId}/platforms/${platformId}/ad-daily?start=${custom.date}&end=${custom.date}`
+      )
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(list.body[0].extraData).toEqual(custom.extraData)
+  })
+
   it('bulk create adDaily', async () => {
     const records = [
-      { date: new Date('2024-03-01').toISOString(), spent: 5 },
-      { date: new Date('2024-03-02').toISOString(), spent: 7 }
+      { date: new Date('2024-03-01').toISOString(), spent: 5, extraData: { tag: 'A' } },
+      { date: new Date('2024-03-02').toISOString(), spent: 7, extraData: { tag: 'B' } }
     ]
     const res = await request(app)
       .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily/bulk`)
       .set('Authorization', `Bearer ${token}`)
       .send(records)
       .expect(201)
-    expect(res.body.count).toBe(2)
+    expect(res.body.length).toBe(2)
+    expect(res.body[0].extraData).toEqual({ tag: 'A' })
+    expect(res.body[1].extraData).toEqual({ tag: 'B' })
   })
 })


### PR DESCRIPTION
## Summary
- allow adDaily records to store arbitrary extraData
- parse extraData on single create, bulk create and import
- return inserted documents for bulk and import endpoints
- test creating and reading custom extraData values

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee7514c7c8329808063f4991bba19