### PR TITLE
支援 adDaily 自訂欄位

### DIFF
--- a/client/src/services/adDaily.js
+++ b/client/src/services/adDaily.js
@@ -5,7 +5,10 @@ export const fetchDaily = (clientId, platformId) =>
   api.get(`/clients/${clientId}/platforms/${platformId}/ad-daily`).then(r => r.data)
 
 export const createDaily = (clientId, platformId, data) =>
-  api.post(`/clients/${clientId}/platforms/${platformId}/ad-daily`, data).then(r => r.data)
+  api.post(
+    `/clients/${clientId}/platforms/${platformId}/ad-daily`,
+    { ...data, extraData: data.extraData || {} }
+  ).then(r => r.data)
 
 export const fetchWeekly = (clientId, platformId) =>
   api.get(`/clients/${clientId}/platforms/${platformId}/ad-daily/weekly`).then(r => r.data)
@@ -24,7 +27,7 @@ export const bulkCreateDaily = async (clientId, platformId, records) => {
   try {
     const res = await api.post(
       `/clients/${clientId}/platforms/${platformId}/ad-daily/bulk`,
-      records
+      records.map(r => ({ ...r, extraData: r.extraData || {} }))
     )
     return res.data
   } catch (e) {


### PR DESCRIPTION
## Summary
- 支援從 API 回傳的 `extraData` 產生動態欄位
- 讀取/匯出時包含自訂欄位
- 新增紀錄及批次匯入會傳送 `extraData`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee7573aa88329a66a7e57d1f78d13