### PR TITLE
加入描述多行顯示與條列功能

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -49,7 +49,14 @@
             </div>
           </template>
           <el-scrollbar max-height="60">
-            <div class="desc-line">{{ f.description || '—' }}</div>
+            <div class="desc-line">
+              <template v-if="f.description && f.description.includes('\n')">
+                <ul>
+                  <li v-for="(line, i) in f.description.split('\n')" :key="i">{{ line }}</li>
+                </ul>
+              </template>
+              <template v-else>{{ f.description || '—' }}</template>
+            </div>
           </el-scrollbar>
           <div v-if="f.tags?.length" class="tag-list mt-1">
             <el-tag v-for="tag in f.tags" :key="tag" size="small" class="mr-1">{{ tag }}</el-tag>
@@ -72,7 +79,14 @@
             </div>
           </template>
           <el-scrollbar max-height="60">
-            <div class="desc-line">{{ a.description || '—' }}</div>
+            <div class="desc-line">
+              <template v-if="a.description && a.description.includes('\n')">
+                <ul>
+                  <li v-for="(line, i) in a.description.split('\n')" :key="i">{{ line }}</li>
+                </ul>
+              </template>
+              <template v-else>{{ a.description || '—' }}</template>
+            </div>
           </el-scrollbar>
           <div v-if="a.tags?.length" class="tag-list mt-1">
             <el-tag v-for="tag in a.tags" :key="tag" size="small" class="mr-1">{{ tag }}</el-tag>
@@ -418,6 +432,7 @@ function downloadAsset(asset) {
 .desc-line {
   font-size: .75rem;
   line-height: 1.1rem;
+  white-space: pre-line;
 }
 
 .tag-list {

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -53,7 +53,14 @@
             </div>
           </template>
           <el-scrollbar max-height="60">
-            <div class="desc-line">{{ f.description || '—' }}</div>
+            <div class="desc-line">
+              <template v-if="f.description && f.description.includes('\n')">
+                <ul>
+                  <li v-for="(line, i) in f.description.split('\n')" :key="i">{{ line }}</li>
+                </ul>
+              </template>
+              <template v-else>{{ f.description || '—' }}</template>
+            </div>
           </el-scrollbar>
           <div v-if="f.tags?.length" class="tag-list mt-1">
             <el-tag v-for="tag in f.tags" :key="tag" size="small" class="mr-1">{{ tag }}</el-tag>
@@ -476,6 +483,7 @@ function downloadAsset(asset) {
 .desc-line {
   font-size: .75rem;
   line-height: 1.1rem;
+  white-space: pre-line;
 }
 
 .tag-list {


### PR DESCRIPTION
## Summary
- 支援 AssetLibrary 與 ProductLibrary 的描述欄位換行顯示
- 若描述包含換行可自動產生條列清單
- 更新 `.desc-line` 樣式讓文字保留換行

## Testing
- `npm test` *(失敗：jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee75bc0ec83298b6469c624134d05