### PR TITLE
Add platform custom fields

### DIFF
--- a/client/src/services/platforms.js
+++ b/client/src/services/platforms.js
@@ -11,3 +11,6 @@ export const updatePlatform = (clientId, id, data) =>
 
 export const deletePlatform = (clientId, id) =>
   api.delete(`/clients/${clientId}/platforms/${id}`).then(r => r.data)
+
+export const getPlatform = (clientId, id) =>
+  api.get(`/clients/${clientId}/platforms/${id}`).then(r => r.data)

--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -195,6 +195,7 @@ import {
 import {
   fetchWeeklyNote, createWeeklyNote, updateWeeklyNote
 } from '../services/weeklyNotes'
+import { getPlatform } from '../services/platforms'
 import {
   Chart, LineController, LineElement,
   PointElement, LinearScale, Title, CategoryScale
@@ -212,6 +213,7 @@ const excelDialog   = ref(false)
 
 /* 自訂欄位列表 */
 const customColumns = ref([])
+const platform = ref(null)
 
 /* ===== 每日 ===== */
 const dailyData  = ref([])
@@ -244,6 +246,10 @@ const excelSpec = computed(() => [
 
 /* 日期 formatter */
 const dateFmt = row => dayjs(row.date).format('YYYY-MM-DD')
+const loadPlatform = async () => {
+  platform.value = await getPlatform(clientId, platformId)
+  customColumns.value = platform.value.fields || []
+}
 
 /* --------------------------------------------------- 資料載入 --------------------------------------------------- */
 const loadDaily = async () => {
@@ -258,7 +264,7 @@ const loadDaily = async () => {
       avgCost: r.enquiries ? (r.spent / r.enquiries).toFixed(2) : '0.00'
     }
   })
-  customColumns.value = Array.from(cols)
+  customColumns.value = Array.from(new Set([...customColumns.value, ...cols]))
 }
 const loadWeekly = async () => {
   weeklyData.value = await fetchWeekly(clientId, platformId)
@@ -274,8 +280,7 @@ const loadWeekly = async () => {
   )
   drawChart()
 }
-onMounted(async () => { await loadDaily(); await loadWeekly() })
-watch(metric, () => drawChart())
+onMounted(async () => { await loadPlatform(); await loadDaily(); await loadWeekly() })
 
 /* --------------------------------------------------- 折線圖 --------------------------------------------------- */
 const drawChart = () => {

--- a/client/src/views/AdPlatforms.vue
+++ b/client/src/views/AdPlatforms.vue
@@ -10,7 +10,20 @@ const clientId = route.params.clientId
 const platforms = ref([])
 const dialog = ref(false)
 const editing = ref(false)
-const form = ref({ name: '', platformType: '' })
+const form = ref({ name: '', platformType: '', fields: [] })
+const newField = ref('')
+
+const addField = () => {
+  const v = newField.value.trim()
+  if (v && !form.value.fields.includes(v)) {
+    form.value.fields.push(v)
+  }
+  newField.value = ''
+}
+
+const removeField = i => {
+  form.value.fields.splice(i, 1)
+}
 
 const loadPlatforms = async () => {
   platforms.value = await fetchPlatforms(clientId)
@@ -18,13 +31,13 @@ const loadPlatforms = async () => {
 
 const openCreate = () => {
   editing.value = false
-  form.value = { name: '', platformType: '' }
+  form.value = { name: '', platformType: '', fields: [] }
   dialog.value = true
 }
 
 const openEdit = p => {
   editing.value = true
-  form.value = { ...p }
+  form.value = { ...p, fields: p.fields || [] }
   dialog.value = true
 }
 
@@ -78,7 +91,16 @@ onMounted(loadPlatforms)
     <el-dialog v-model="dialog" :title="editing ? '編輯平台' : '新增平台'" width="420px">
       <el-form label-position="top" @submit.prevent>
         <el-form-item label="平台名稱"><el-input v-model="form.name" /></el-form-item>
-        <el-form-item label="類型"><el-input v-model="form.platformType" /></el-form-item>
+      <el-form-item label="類型"><el-input v-model="form.platformType" /></el-form-item>
+      <el-form-item label="自訂欄位">
+        <div class="flex items-center gap-2 mb-2">
+          <el-input v-model="newField" @keyup.enter.native.prevent="addField" placeholder="欄位名稱" class="flex-1" />
+          <el-button type="primary" @click="addField">新增</el-button>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <el-tag v-for="(f,i) in form.fields" :key="i" closable @close="removeField(i)">{{ f }}</el-tag>
+        </div>
+      </el-form-item>
       </el-form>
       <template #footer>
         <el-button @click="dialog=false">取消</el-button>

--- a/server/src/controllers/platform.controller.js
+++ b/server/src/controllers/platform.controller.js
@@ -2,8 +2,11 @@ import Platform from '../models/platform.model.js'
 
 export const createPlatform = async (req, res) => {
   try {
+    const { name, platformType, fields } = req.body
     const platform = await Platform.create({
-      ...req.body,
+      name,
+      platformType,
+      fields,
       clientId: req.params.clientId
     })
     res.status(201).json(platform)
@@ -28,9 +31,10 @@ export const getPlatform = async (req, res) => {
 
 export const updatePlatform = async (req, res) => {
   try {
+    const { name, platformType, fields } = req.body
     const p = await Platform.findOneAndUpdate(
       { _id: req.params.id, clientId: req.params.clientId },
-      req.body,
+      { name, platformType, fields },
       { new: true }
     )
     if (!p) return res.status(404).json({ message: '平台不存在' })

--- a/server/src/models/platform.model.js
+++ b/server/src/models/platform.model.js
@@ -4,7 +4,9 @@ const platformSchema = new mongoose.Schema(
   {
     clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true },
     name: { type: String, required: true },
-    platformType: { type: String, default: '' }
+    platformType: { type: String, default: '' },
+    // 自訂欄位名稱清單
+    fields: { type: [String], default: [] }
   },
   { timestamps: true }
 )

--- a/server/tests/platform.test.js
+++ b/server/tests/platform.test.js
@@ -53,9 +53,10 @@ describe('Platform API', () => {
     const resC = await request(app)
       .post(`/api/clients/${clientId}/platforms`)
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Meta', platformType: 'Meta' })
+      .send({ name: 'Meta', platformType: 'Meta', fields: ['note'] })
       .expect(201)
     platformId = resC.body._id
+    expect(resC.body.fields).toEqual(['note'])
 
     const resG = await request(app)
       .get(`/api/clients/${clientId}/platforms`)
@@ -63,11 +64,12 @@ describe('Platform API', () => {
       .expect(200)
     expect(resG.body.length).toBe(1)
 
-    await request(app)
+    const resU = await request(app)
       .put(`/api/clients/${clientId}/platforms/${platformId}`)
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Meta2' })
+      .send({ name: 'Meta2', fields: ['x','y'] })
       .expect(200)
+    expect(resU.body.fields).toEqual(['x','y'])
 
     await request(app)
       .delete(`/api/clients/${clientId}/platforms/${platformId}`)


### PR DESCRIPTION
## Summary
- add `fields` to Platform model
- allow create/update platform to handle custom fields
- manage fields in platform UI
- show extra data columns based on platform fields
- test platform fields creation and update

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eee16d8188329aed071867a11cdaa