### PR TITLE
Add platform mode and default fields

### DIFF
--- a/client/src/views/AdPlatforms.vue
+++ b/client/src/views/AdPlatforms.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { fetchPlatforms, createPlatform, updatePlatform, deletePlatform } from '../services/platforms'
@@ -10,7 +10,8 @@ const clientId = route.params.clientId
 const platforms = ref([])
 const dialog = ref(false)
 const editing = ref(false)
-const form = ref({ name: '', platformType: '', fields: [] })
+const form = ref({ name: '', platformType: '', mode: 'custom', fields: [] })
+const defaultFields = ['date','spent','enquiries','reach','impressions','clicks']
 const newField = ref('')
 
 const addField = () => {
@@ -31,13 +32,13 @@ const loadPlatforms = async () => {
 
 const openCreate = () => {
   editing.value = false
-  form.value = { name: '', platformType: '', fields: [] }
+  form.value = { name: '', platformType: '', mode: 'custom', fields: [] }
   dialog.value = true
 }
 
 const openEdit = p => {
   editing.value = true
-  form.value = { ...p, fields: p.fields || [] }
+  form.value = { ...p, fields: p.fields || [], mode: p.mode || 'custom' }
   dialog.value = true
 }
 
@@ -68,6 +69,14 @@ const removePlatform = async p => {
   await loadPlatforms()
 }
 
+watch(
+  () => form.value.mode,
+  m => {
+    if (m === 'default') form.value.fields = [...defaultFields]
+    else if (m === 'custom') form.value.fields = []
+  }
+)
+
 onMounted(loadPlatforms)
 </script>
 
@@ -92,6 +101,12 @@ onMounted(loadPlatforms)
       <el-form label-position="top" @submit.prevent>
         <el-form-item label="平台名稱"><el-input v-model="form.name" /></el-form-item>
       <el-form-item label="類型"><el-input v-model="form.platformType" /></el-form-item>
+      <el-form-item label="模式">
+        <el-select v-model="form.mode">
+          <el-option label="預設" value="default" />
+          <el-option label="自訂" value="custom" />
+        </el-select>
+      </el-form-item>
       <el-form-item label="自訂欄位">
         <div class="flex items-center gap-2 mb-2">
           <el-input v-model="newField" @keyup.enter.native.prevent="addField" placeholder="欄位名稱" class="flex-1" />

--- a/server/src/controllers/platform.controller.js
+++ b/server/src/controllers/platform.controller.js
@@ -2,11 +2,12 @@ import Platform from '../models/platform.model.js'
 
 export const createPlatform = async (req, res) => {
   try {
-    const { name, platformType, fields } = req.body
+    const { name, platformType, fields, mode } = req.body
     const platform = await Platform.create({
       name,
       platformType,
       fields,
+      mode,
       clientId: req.params.clientId
     })
     res.status(201).json(platform)
@@ -31,10 +32,10 @@ export const getPlatform = async (req, res) => {
 
 export const updatePlatform = async (req, res) => {
   try {
-    const { name, platformType, fields } = req.body
+    const { name, platformType, fields, mode } = req.body
     const p = await Platform.findOneAndUpdate(
       { _id: req.params.id, clientId: req.params.clientId },
-      { name, platformType, fields },
+      { name, platformType, fields, mode },
       { new: true }
     )
     if (!p) return res.status(404).json({ message: '平台不存在' })

--- a/server/src/models/platform.model.js
+++ b/server/src/models/platform.model.js
@@ -5,6 +5,7 @@ const platformSchema = new mongoose.Schema(
     clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true },
     name: { type: String, required: true },
     platformType: { type: String, default: '' },
+    mode: { type: String, default: 'custom' },
     // 自訂欄位名稱清單
     fields: { type: [String], default: [] }
   },

--- a/server/tests/platform.test.js
+++ b/server/tests/platform.test.js
@@ -17,6 +17,7 @@ let app
 let token
 let clientId
 let platformId
+const defaultFields = ['date','spent','enquiries','reach','impressions','clicks']
 
 beforeAll(async () => {
   mongo = await MongoMemoryServer.create()
@@ -53,7 +54,7 @@ describe('Platform API', () => {
     const resC = await request(app)
       .post(`/api/clients/${clientId}/platforms`)
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Meta', platformType: 'Meta', fields: ['note'] })
+      .send({ name: 'Meta', platformType: 'Meta', fields: ['note'], mode:'custom' })
       .expect(201)
     platformId = resC.body._id
     expect(resC.body.fields).toEqual(['note'])
@@ -75,6 +76,16 @@ describe('Platform API', () => {
       .delete(`/api/clients/${clientId}/platforms/${platformId}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200)
+  })
+
+  it('create platform with default mode', async () => {
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/platforms`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Def', platformType: 'Meta', mode: 'default', fields: defaultFields })
+      .expect(201)
+    expect(res.body.mode).toBe('default')
+    expect(res.body.fields).toEqual(defaultFields)
   })
 
   it('duplicate platform name returns 409', async () => {


### PR DESCRIPTION
## Summary
- add mode selector and default field autofill in AdPlatforms form
- store mode in Platform model and controller
- test platform API with mode variations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef2214f6483299f9e9b2aef10f2a2