### PR TITLE
update ad data columns from platform fields

### DIFF
--- a/client/src/utils/adData.js
+++ b/client/src/utils/adData.js
@@ -1,0 +1,72 @@
+export const baseSpec = [
+  { field: 'date',        type: '文字 / 日期', sample: '2025-06-01' },
+  { field: 'spent',       type: '數字',         sample: '1200'      },
+  { field: 'enquiries',   type: '數字',         sample: '10'        },
+  { field: 'reach',       type: '數字',         sample: '500'       },
+  { field: 'impressions', type: '數字',         sample: '800'       },
+  { field: 'clicks',      type: '數字',         sample: '23'        }
+]
+
+export const buildExcelSpec = customFields => [
+  ...baseSpec,
+  ...customFields.map(c => ({ field: c, type: '文字', sample: '' }))
+]
+
+export const buildTemplateRow = customFields => {
+  const row = {
+    date: '2025-06-01',
+    spent: 1200,
+    enquiries: 10,
+    reach: 500,
+    impressions: 800,
+    clicks: 23
+  }
+  customFields.forEach(c => {
+    row[c] = ''
+  })
+  return row
+}
+
+export const normalizeRows = (arr, customFields) => arr
+  .map(r => {
+    const obj = {
+      date:        r.date || r.日期,
+      spent:       +(r.spent || r.花費 || 0),
+      enquiries:   +(r.enquiries || r.詢問 || 0),
+      reach:       +(r.reach || r.觸及 || 0),
+      impressions: +(r.impressions || r.曝光 || 0),
+      clicks:      +(r.clicks || r.點擊 || 0)
+    }
+    const extra = {}
+    customFields.forEach(c => {
+      if (r[c] !== undefined) extra[c] = r[c]
+    })
+    const ignore = new Set([
+      'date','日期','spent','花費','enquiries','詢問','reach','觸及',
+      'impressions','曝光','clicks','點擊',
+      ...customFields
+    ])
+    for (const [k, v] of Object.entries(r)) {
+      if (!ignore.has(k)) extra[k] = v
+    }
+    if (Object.keys(extra).length) obj.extraData = extra
+    return obj
+  })
+  .filter(r => r.date)
+
+export const buildExportRows = (dailyData, customFields, dateFmt) =>
+  dailyData.map(r => {
+    const obj = {
+      日期: dateFmt(r),
+      花費: r.spent,
+      詢問: r.enquiries,
+      平均成本: r.avgCost,
+      觸及: r.reach,
+      曝光: r.impressions,
+      點擊: r.clicks
+    }
+    customFields.forEach(c => {
+      obj[c] = r.extraData?.[c] || ''
+    })
+    return obj
+  })

--- a/server/tests/adDataUtils.test.js
+++ b/server/tests/adDataUtils.test.js
@@ -1,0 +1,25 @@
+import { buildExcelSpec, buildTemplateRow, normalizeRows, buildExportRows, baseSpec } from '../../client/src/utils/adData.js'
+import dayjs from 'dayjs'
+
+describe('adData helpers', () => {
+  const fields = ['foo', 'bar']
+
+  test('excel spec and template order', () => {
+    const spec = buildExcelSpec(fields)
+    expect(spec.map(s => s.field)).toEqual([...baseSpec.map(b => b.field), ...fields])
+
+    const sample = buildTemplateRow(fields)
+    expect(Object.keys(sample)).toEqual([...baseSpec.map(b => b.field), ...fields])
+  })
+
+  test('normalizeRows keeps field order', () => {
+    const rows = normalizeRows([{ date:'2025-06-02', foo:'A', bar:'B', spent:100 }], fields)
+    expect(Object.keys(rows[0].extraData)).toEqual(fields)
+  })
+
+  test('export rows follow field order', () => {
+    const daily = [{ date:'2025-06-01', spent:100, enquiries:1, reach:10, impressions:20, clicks:5, avgCost:'100.00', extraData:{ foo:'X', bar:'Y' } }]
+    const rows = buildExportRows(daily, fields, r => dayjs(r.date).format('YYYY-MM-DD'))
+    expect(Object.keys(rows[0])).toEqual(['日期','花費','詢問','平均成本','觸及','曝光','點擊', ...fields])
+  })
+})


### PR DESCRIPTION
## Summary
- extract helpers for excel template & normalization
- rely on platform field list for columns in AdData view
- adjust export/import order logic
- test helper functions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef21f99e08329a91b8fd31ae58902