### PR TITLE
Sanitize custom metrics to numbers

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -5,6 +5,15 @@ import AdDaily from '../models/adDaily.model.js'
 const sanitizeNumber = val =>
   parseFloat(String(val).replace(/[^\d.]/g, '')) || 0
 
+const sanitizeExtraData = obj => {
+  const result = {}
+  if (!obj) return result
+  for (const [k, v] of Object.entries(obj)) {
+    result[k] = sanitizeNumber(v)
+  }
+  return result
+}
+
 export const createAdDaily = async (req, res) => {
   const rec = await AdDaily.create({
     date: req.body.date,
@@ -15,7 +24,7 @@ export const createAdDaily = async (req, res) => {
     clicks: sanitizeNumber(req.body.clicks),
     clientId: req.params.clientId,
     platformId: req.params.platformId,
-    extraData: req.body.extraData
+    extraData: sanitizeExtraData(req.body.extraData)
   })
   res.status(201).json(rec)
 }
@@ -72,9 +81,9 @@ export const bulkCreateAdDaily = async (req, res) => {
 
   const records = req.body
     .map(row => {
-      const extra = { ...(row.extraData || {}) }
+      const extra = sanitizeExtraData({ ...(row.extraData || {}) })
       for (const k of Object.keys(row)) {
-        if (!known.includes(k)) extra[k] = row[k]
+        if (!known.includes(k)) extra[k] = sanitizeNumber(row[k])
       }
       return {
         date: row.date,
@@ -117,9 +126,9 @@ export const importAdDaily = async (req, res) => {
 
   const records = rows
     .map(row => {
-      const extra = { ...(row.extraData || {}) }
+      const extra = sanitizeExtraData({ ...(row.extraData || {}) })
       for (const k of Object.keys(row)) {
-        if (!known.includes(k)) extra[k] = row[k]
+        if (!known.includes(k)) extra[k] = sanitizeNumber(row[k])
       }
       return {
         date: row.date || row.Date || row['日期'],

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -104,14 +104,14 @@ describe('Client and AdDaily', () => {
     const custom = {
       date: new Date('2024-04-01').toISOString(),
       spent: 3,
-      extraData: { note: 'test', metric: 99 }
+      extraData: { metricA: '10', metricB: 5 }
     }
     const res = await request(app)
       .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)
       .set('Authorization', `Bearer ${token}`)
       .send(custom)
       .expect(201)
-    expect(res.body.extraData).toEqual(custom.extraData)
+    expect(res.body.extraData).toEqual({ metricA: 10, metricB: 5 })
 
     const list = await request(app)
       .get(
@@ -119,13 +119,13 @@ describe('Client and AdDaily', () => {
       )
       .set('Authorization', `Bearer ${token}`)
       .expect(200)
-    expect(list.body[0].extraData).toEqual(custom.extraData)
+    expect(list.body[0].extraData).toEqual({ metricA: 10, metricB: 5 })
   })
 
   it('bulk create adDaily', async () => {
     const records = [
-      { date: new Date('2024-03-01').toISOString(), spent: 5, extraData: { tag: 'A' } },
-      { date: new Date('2024-03-02').toISOString(), spent: 7, extraData: { tag: 'B' } }
+      { date: new Date('2024-03-01').toISOString(), spent: 5, extraData: { metric: '1' } },
+      { date: new Date('2024-03-02').toISOString(), spent: 7, extraData: { metric: 2 } }
     ]
     const res = await request(app)
       .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily/bulk`)
@@ -133,7 +133,7 @@ describe('Client and AdDaily', () => {
       .send(records)
       .expect(201)
     expect(res.body.length).toBe(2)
-    expect(res.body[0].extraData).toEqual({ tag: 'A' })
-    expect(res.body[1].extraData).toEqual({ tag: 'B' })
+    expect(res.body[0].extraData).toEqual({ metric: 1 })
+    expect(res.body[1].extraData).toEqual({ metric: 2 })
   })
 })


### PR DESCRIPTION
## Summary
- add sanitizeExtraData helper to ensure custom metrics are stored as numeric values
- sanitize extraData during single, bulk, and file imports
- update tests to expect numeric values for custom metrics

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef87a065483299afb4231594524e6