### PR TITLE
fix: sanitize ad data numbers as integers

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import AdDaily from '../models/adDaily.model.js'
 
 const sanitizeNumber = val =>
-  parseFloat(String(val).replace(/[^\d.]/g, '')) || 0
+  parseInt(String(val).replace(/[^\d-]/g, ''), 10) || 0
 
 const sanitizeExtraData = obj => {
   const result = {}


### PR DESCRIPTION
## Summary
- ensure ad daily records store integers by using `parseInt`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684efe0d140c83299e8751e4dd43ff40