### PR TITLE
Implement missing AdData features

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,8 @@
     "pinia": "^3.0.3",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "exceljs": "^4.3.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",


### PR DESCRIPTION
## Summary
- show Y-axis metric selector and restore weekly chart
- add image column in weekly table
- export weekly report with embedded images
- add `exceljs` dependency for client build

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1493ba8083299f7c0c159a1ab957