### PR TITLE
Update permission checks

### DIFF
--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -10,7 +10,15 @@ export const useAuthStore = defineStore('auth', {
   }),
   getters: {
     isAuthenticated: (state) => !!state.token,
-    role: (state) => state.user?.role ?? 'guest'
+    role: (state) => state.user?.role ?? 'guest',
+    hasPermission: (state) => (code) => {
+      return Array.isArray(state.user.permissions) &&
+        state.user.permissions.includes(code)
+    },
+    hasPerms: (state) => (codes = []) => {
+      return Array.isArray(codes) &&
+        codes.every(c => state.user.permissions.includes(c))
+    }
   },
   actions: {
     /* ---------- 登入 ---------- */

--- a/client/src/views/EmployeeManager.vue
+++ b/client/src/views/EmployeeManager.vue
@@ -17,7 +17,7 @@ const loadRoles = async () => {
 
 /* ---------- 權限檢查：非 manager 直接跳回首頁 ---------- */
 const store = useAuthStore()
-if (store.role !== 'manager') {
+if (!store.hasPermission('user:manage')) {
   window.location.href = '/'   // 或用 router.replace('/')
 }
 

--- a/client/src/views/ReviewSettings.vue
+++ b/client/src/views/ReviewSettings.vue
@@ -6,7 +6,7 @@ import { fetchUsers } from '../services/user'
 import { useAuthStore } from '../stores/auth'
 
 const store = useAuthStore()
-if (store.role !== 'manager') {
+if (!store.hasPermission('review:manage')) {
   window.location.href = '/'
 }
 

--- a/client/src/views/TagManager.vue
+++ b/client/src/views/TagManager.vue
@@ -5,7 +5,7 @@ import { fetchTags, createTag, updateTag, deleteTag } from '../services/tags'
 import { useAuthStore } from '../stores/auth'
 
 const store = useAuthStore()
-if (store.role !== 'manager') {
+if (!store.hasPermission('tag:manage')) {
   window.location.href = '/'
 }
 


### PR DESCRIPTION
## Summary
- add `hasPermission` and `hasPerms` to auth store
- check permissions instead of roles in TagManager, EmployeeManager, ReviewSettings
- control viewer management via permission checks in AssetLibrary and ProductLibrary
- update review control permission in ProductLibrary

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f201cbb7c83299457cf0e5c011e63