### PR TITLE
Fix icon shrink issue

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -46,8 +46,8 @@
                 <span class="font-medium truncate">{{ f.name }}</span>
               </el-checkbox>
 
-              <el-button link size="small" @click.stop="showDetailFor(f, 'folder')">
-                <el-icon style="font-size: 24px;">
+              <el-button link size="small" class="flex-shrink-0" @click.stop="showDetailFor(f, 'folder')">
+                <el-icon style="font-size: 24px;" class="flex-shrink-0">
                   <InfoFilled />
                 </el-icon>
               </el-button>
@@ -81,8 +81,8 @@
               >
                 <span class="font-medium truncate">{{ a.title || a.filename }}</span>
               </el-checkbox>
-              <el-button link size="small" @click.stop="showDetailFor(a, 'asset')">
-                <el-icon style="font-size: 24px;">
+              <el-button link size="small" class="flex-shrink-0" @click.stop="showDetailFor(a, 'asset')">
+                <el-icon style="font-size: 24px;" class="flex-shrink-0">
                   <InfoFilled />
                 </el-icon>
               </el-button>

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -48,8 +48,8 @@
                 </el-icon>
                 <span class="font-medium truncate">{{ f.name }}</span>
               </el-checkbox>
-              <el-button link size="small" @click.stop="showDetailFor(f, 'folder')">
-                <el-icon style="font-size: 24px;">
+              <el-button link size="small" class="flex-shrink-0" @click.stop="showDetailFor(f, 'folder')">
+                <el-icon style="font-size: 24px;" class="flex-shrink-0">
                   <InfoFilled />
                 </el-icon>
               </el-button>
@@ -84,8 +84,8 @@
               >
                 <span class="font-medium truncate">{{ a.title || a.filename }}</span>
               </el-checkbox>
-              <el-button link size="small" @click.stop="showDetailFor(a, 'asset')">
-                <el-icon style="font-size: 24px;">
+              <el-button link size="small" class="flex-shrink-0" @click.stop="showDetailFor(a, 'asset')">
+                <el-icon style="font-size: 24px;" class="flex-shrink-0">
                   <InfoFilled />
                 </el-icon>
               </el-button>


### PR DESCRIPTION
## Summary
- prevent info icons from shrinking by adding `flex-shrink-0`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f22303c988329aab251e38cedcf9c