### PR TITLE
Add cache invalidation for assets and folders

### DIFF
--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -7,7 +7,7 @@ import ReviewStage from '../models/reviewStage.model.js'
 import ReviewRecord from '../models/reviewRecord.model.js'
 import { getDescendantFolderIds } from '../utils/folderTree.js'
 import { includeManagers } from '../utils/includeManagers.js'
-import { getCache, setCache } from '../utils/cache.js'
+import { getCache, setCache, clearCacheByPrefix } from '../utils/cache.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -126,6 +126,7 @@ export const addComment = async (req, res) => {
 
   asset.comments.push({ userId: req.user._id, message: req.body.message })
   await asset.save()
+  await clearCacheByPrefix('assets:')
   res.json(asset)
 }
 
@@ -158,11 +159,13 @@ export const reviewAsset = async (req, res) => {
   if (!asset) return res.status(404).json({ message: '找不到素材' })
   asset.reviewStatus = reviewStatus
   await asset.save()
+  await clearCacheByPrefix('assets:')
   res.json(asset)
 }
 
 export const deleteAsset = async (req, res) => {
   await Asset.findByIdAndDelete(req.params.id)
+  await clearCacheByPrefix('assets:')
   res.json({ message: '素材已刪除' })
 }
 
@@ -198,6 +201,7 @@ export const updateAssetsViewers = async (req, res) => {
 
   const users = await includeManagers(allowedUsers)
   await Asset.updateMany({ _id: { $in: ids } }, { allowedUsers: users })
+  await clearCacheByPrefix('assets:')
   res.json({ message: '已更新' })
 }
 

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -1,7 +1,7 @@
 import Folder from '../models/folder.model.js'
 import { getDescendantFolderIds } from '../utils/folderTree.js'
 import { includeManagers } from '../utils/includeManagers.js'
-import { getCache, setCache } from '../utils/cache.js'
+import { getCache, setCache, clearCacheByPrefix } from '../utils/cache.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -80,11 +80,13 @@ export const updateFolder = async (req, res) => {
   }
   const folder = await Folder.findByIdAndUpdate(req.params.id, req.body, { new: true })
   if (!folder) return res.status(404).json({ message: '資料夾不存在' })
+  await clearCacheByPrefix('folders:')
   res.json(folder)
 }
 
 export const deleteFolder = async (req, res) => {
   await Folder.findByIdAndDelete(req.params.id)
+  await clearCacheByPrefix('folders:')
   res.json({ message: '資料夾已刪除' })
 }
 
@@ -95,6 +97,7 @@ export const updateFoldersViewers = async (req, res) => {
   }
   const users = await includeManagers(allowedUsers)
   await Folder.updateMany({ _id: { $in: ids } }, { allowedUsers: users })
+  await clearCacheByPrefix('folders:')
   res.json({ message: '已更新' })
 }
 

--- a/server/src/utils/cache.js
+++ b/server/src/utils/cache.js
@@ -14,3 +14,14 @@ export async function setCache(key, value, ttl = CACHE_TTL) {
   const val = typeof value === 'string' ? value : JSON.stringify(value)
   await redis.setex(key, ttl, val)
 }
+
+export async function deleteCache(key) {
+  await redis.del(key)
+}
+
+export async function clearCacheByPrefix(prefix) {
+  const keys = await redis.keys(`${prefix}*`)
+  if (keys.length) {
+    await redis.del(keys)
+  }
+}


### PR DESCRIPTION
## Summary
- clear redis cache when folders or assets are updated or deleted
- expose cache deletion helpers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe667df348329bb979a8b2d67fc7a