### PR TITLE
Add console logs for Redis operations

### DIFF
--- a/server/src/config/redis.js
+++ b/server/src/config/redis.js
@@ -52,6 +52,7 @@ const redis = new RedisClient(
   },
   redisOptions
 )
+console.log('[Redis] 初始化', REDIS_URL || `${process.env.REDIS_HOST || '127.0.0.1'}:${process.env.REDIS_PORT || 6379}`)
 
 /* ---------- 事件監聽 ---------- */
 redis.on('connect', () => console.log('🟢 Redis 已連線'))

--- a/server/src/utils/cache.js
+++ b/server/src/utils/cache.js
@@ -1,6 +1,7 @@
 import redis, { CACHE_TTL } from '../config/redis.js'
 
 export async function getCache(key) {
+  console.log('[Redis] GET', key)
   const data = await redis.get(key)
   if (!data) return null
   try {
@@ -12,18 +13,23 @@ export async function getCache(key) {
 
 export async function setCache(key, value, ttl = CACHE_TTL) {
   const val = typeof value === 'string' ? value : JSON.stringify(value)
+  console.log('[Redis] SETEX', key, ttl)
   await redis.setex(key, ttl, val)
 }
 
 
 export async function delCache(key) {
-
+  console.log('[Redis] DEL', key)
   await redis.del(key)
 }
 
 export async function clearCacheByPrefix(prefix) {
+  console.log('[Redis] KEYS', `${prefix}*`)
   const keys = await redis.keys(`${prefix}*`)
 
-  if (keys.length) await redis.del(keys)
+  if (keys.length) {
+    console.log('[Redis] DEL', keys)
+    await redis.del(keys)
+  }
 
 }


### PR DESCRIPTION
## Summary
- add log to each cache operation for monitoring Redis usage
- print init info when Redis client is created

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fee958818832987923f81160b3dd8