### PR TITLE
fix folder creation cache clearing

### DIFF
--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -27,6 +27,7 @@ export const createFolder = async (req, res) => {
     tags: parseTags(req.body.tags),
     allowedUsers: await includeManagers(baseUsers)
   })
+  await clearCacheByPrefix('folders:')
   res.status(201).json(folder)
 }
 


### PR DESCRIPTION
## Summary
- clear `folders:` cache prefix after creating a folder

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff41da2288329b8e5e7568a742513