### PR TITLE
Remove axios timeout

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -3,7 +3,6 @@ import Cookies from 'js-cookie'
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE || 'http://localhost:3000/api',
-  timeout: 10000
 })
 
 /* ---------- 請求攔截：帶上 JWT ---------- */


### PR DESCRIPTION
## Summary
- remove default timeout in axios service

## Testing
- `npm --prefix client run build` *(fails: vite not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a64be0dc8329a206ba20b6b97b5a