### PR TITLE
Support text fields for ad data

### DIFF
--- a/client/src/utils/adData.js
+++ b/client/src/utils/adData.js
@@ -9,7 +9,11 @@ export const baseSpec = [
 
 export const buildExcelSpec = customFields => [
   ...baseSpec,
-  ...customFields.map(c => ({ field: c, type: '文字', sample: '' }))
+  ...customFields.map(c => ({
+    field: c.name,
+    type: c.type === 'number' ? '數字' : '文字',
+    sample: ''
+  }))
 ]
 
 export const buildTemplateRow = customFields => {
@@ -22,7 +26,7 @@ export const buildTemplateRow = customFields => {
     clicks: 23
   }
   customFields.forEach(c => {
-    row[c] = ''
+    row[c.name] = ''
   })
   return row
 }
@@ -39,12 +43,15 @@ export const normalizeRows = (arr, customFields) => arr
     }
     const extra = {}
     customFields.forEach(c => {
-      if (r[c] !== undefined) extra[c] = r[c]
+      if (r[c.name] !== undefined) {
+        const val = r[c.name]
+        extra[c.name] = c.type === 'number' ? Number(val) || 0 : val
+      }
     })
     const ignore = new Set([
       'date','日期','spent','花費','enquiries','詢問','reach','觸及',
       'impressions','曝光','clicks','點擊',
-      ...customFields
+      ...customFields.map(c => c.name)
     ])
     for (const [k, v] of Object.entries(r)) {
       if (!ignore.has(k)) extra[k] = v
@@ -66,7 +73,7 @@ export const buildExportRows = (dailyData, customFields, dateFmt) =>
       點擊: r.clicks
     }
     customFields.forEach(c => {
-      obj[c] = r.extraData?.[c] || ''
+      obj[c.name] = r.extraData?.[c.name] ?? ''
     })
     return obj
   })

--- a/client/src/views/AdPlatforms.vue
+++ b/client/src/views/AdPlatforms.vue
@@ -11,15 +11,23 @@ const platforms = ref([])
 const dialog = ref(false)
 const editing = ref(false)
 const form = ref({ name: '', platformType: '', mode: 'custom', fields: [] })
-const defaultFields = ['spent','enquiries','reach','impressions','clicks']
-const newField = ref('')
+const defaultFields = [
+  { name: 'spent',       type: 'number' },
+  { name: 'enquiries',   type: 'number' },
+  { name: 'reach',       type: 'number' },
+  { name: 'impressions', type: 'number' },
+  { name: 'clicks',      type: 'number' }
+]
+const newFieldName = ref('')
+const newFieldType = ref('number')
 
 const addField = () => {
-  const v = newField.value.trim()
-  if (v && !form.value.fields.includes(v)) {
-    form.value.fields.push(v)
+  const name = newFieldName.value.trim()
+  const type = newFieldType.value
+  if (name && !form.value.fields.find(f => f.name === name)) {
+    form.value.fields.push({ name, type })
   }
-  newField.value = ''
+  newFieldName.value = ''
 }
 
 const removeField = i => {
@@ -38,7 +46,13 @@ const openCreate = () => {
 
 const openEdit = p => {
   editing.value = true
-  form.value = { ...p, fields: p.fields || [], mode: p.mode || 'custom' }
+  form.value = {
+    ...p,
+    fields: (p.fields || []).map(f =>
+      typeof f === 'string' ? { name: f, type: 'text' } : f
+    ),
+    mode: p.mode || 'custom'
+  }
   dialog.value = true
 }
 
@@ -72,7 +86,8 @@ const removePlatform = async p => {
 watch(
   () => form.value.mode,
   m => {
-    if (m === 'default') form.value.fields = [...defaultFields]
+    if (m === 'default')
+      form.value.fields = defaultFields.map(f => ({ ...f }))
     else if (m === 'custom') form.value.fields = []
   }
 )
@@ -109,11 +124,17 @@ onMounted(loadPlatforms)
       </el-form-item>
       <el-form-item label="自訂欄位">
         <div class="flex items-center gap-2 mb-2">
-          <el-input v-model="newField" @keyup.enter.native.prevent="addField" placeholder="欄位名稱" class="flex-1" />
+          <el-input v-model="newFieldName" @keyup.enter.native.prevent="addField" placeholder="欄位名稱" class="flex-1" />
+          <el-select v-model="newFieldType" style="width:100px">
+            <el-option label="數字" value="number" />
+            <el-option label="文字" value="text" />
+          </el-select>
           <el-button type="primary" @click="addField">新增</el-button>
         </div>
         <div class="flex flex-wrap gap-2">
-          <el-tag v-for="(f,i) in form.fields" :key="i" closable @close="removeField(i)">{{ f }}</el-tag>
+          <el-tag v-for="(f,i) in form.fields" :key="i" closable @close="removeField(i)">
+            {{ f.name }}<span class="ml-1 text-xs">({{ f.type }})</span>
+          </el-tag>
         </div>
       </el-form-item>
       </el-form>

--- a/server/src/models/platform.model.js
+++ b/server/src/models/platform.model.js
@@ -6,8 +6,19 @@ const platformSchema = new mongoose.Schema(
     name: { type: String, required: true },
     platformType: { type: String, default: '' },
     mode: { type: String, default: 'custom' },
-    // 自訂欄位名稱清單
-    fields: { type: [String], default: [] }
+    // 自訂欄位名稱與型別
+    fields: {
+      type: [
+        new mongoose.Schema(
+          {
+            name: { type: String, required: true },
+            type: { type: String, default: 'text' }
+          },
+          { _id: false }
+        )
+      ],
+      default: []
+    }
   },
   { timestamps: true }
 )

--- a/server/tests/adDataUtils.test.js
+++ b/server/tests/adDataUtils.test.js
@@ -2,24 +2,42 @@ import { buildExcelSpec, buildTemplateRow, normalizeRows, buildExportRows, baseS
 import dayjs from 'dayjs'
 
 describe('adData helpers', () => {
-  const fields = ['foo', 'bar']
+  const fields = [
+    { name: 'foo', type: 'number' },
+    { name: 'bar', type: 'text' }
+  ]
 
   test('excel spec and template order', () => {
     const spec = buildExcelSpec(fields)
-    expect(spec.map(s => s.field)).toEqual([...baseSpec.map(b => b.field), ...fields])
+    expect(spec.map(s => s.field)).toEqual([
+      ...baseSpec.map(b => b.field),
+      ...fields.map(f => f.name)
+    ])
 
     const sample = buildTemplateRow(fields)
-    expect(Object.keys(sample)).toEqual([...baseSpec.map(b => b.field), ...fields])
+    expect(Object.keys(sample)).toEqual([
+      ...baseSpec.map(b => b.field),
+      ...fields.map(f => f.name)
+    ])
   })
 
   test('normalizeRows keeps field order', () => {
-    const rows = normalizeRows([{ date:'2025-06-02', foo:'A', bar:'B', spent:100 }], fields)
-    expect(Object.keys(rows[0].extraData)).toEqual(fields)
+    const rows = normalizeRows([
+      { date:'2025-06-02', foo:'A', bar:'B', spent:100 }
+    ], fields)
+    expect(Object.keys(rows[0].extraData)).toEqual(fields.map(f => f.name))
   })
 
   test('export rows follow field order', () => {
     const daily = [{ date:'2025-06-01', spent:100, enquiries:1, reach:10, impressions:20, clicks:5, avgCost:'100.00', extraData:{ foo:'X', bar:'Y' } }]
-    const rows = buildExportRows(daily, fields, r => dayjs(r.date).format('YYYY-MM-DD'))
-    expect(Object.keys(rows[0])).toEqual(['日期','花費','詢問','平均成本','觸及','曝光','點擊', ...fields])
+    const rows = buildExportRows(
+      daily,
+      fields,
+      r => dayjs(r.date).format('YYYY-MM-DD')
+    )
+    expect(Object.keys(rows[0])).toEqual([
+      '日期','花費','詢問','平均成本','觸及','曝光','點擊',
+      ...fields.map(f => f.name)
+    ])
   })
 })

--- a/server/tests/platform.test.js
+++ b/server/tests/platform.test.js
@@ -17,7 +17,14 @@ let app
 let token
 let clientId
 let platformId
-const defaultFields = ['date','spent','enquiries','reach','impressions','clicks']
+const defaultFields = [
+  { name: 'date',        type: 'text' },
+  { name: 'spent',       type: 'number' },
+  { name: 'enquiries',   type: 'number' },
+  { name: 'reach',       type: 'number' },
+  { name: 'impressions', type: 'number' },
+  { name: 'clicks',      type: 'number' }
+]
 
 beforeAll(async () => {
   mongo = await MongoMemoryServer.create()
@@ -54,10 +61,15 @@ describe('Platform API', () => {
     const resC = await request(app)
       .post(`/api/clients/${clientId}/platforms`)
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Meta', platformType: 'Meta', fields: ['note'], mode:'custom' })
+      .send({
+        name: 'Meta',
+        platformType: 'Meta',
+        fields: [{ name: 'note', type: 'text' }],
+        mode: 'custom'
+      })
       .expect(201)
     platformId = resC.body._id
-    expect(resC.body.fields).toEqual(['note'])
+    expect(resC.body.fields).toEqual([{ name: 'note', type: 'text' }])
 
     const resG = await request(app)
       .get(`/api/clients/${clientId}/platforms`)
@@ -68,9 +80,18 @@ describe('Platform API', () => {
     const resU = await request(app)
       .put(`/api/clients/${clientId}/platforms/${platformId}`)
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Meta2', fields: ['x','y'] })
+      .send({
+        name: 'Meta2',
+        fields: [
+          { name: 'x', type: 'number' },
+          { name: 'y', type: 'text' }
+        ]
+      })
       .expect(200)
-    expect(resU.body.fields).toEqual(['x','y'])
+    expect(resU.body.fields).toEqual([
+      { name: 'x', type: 'number' },
+      { name: 'y', type: 'text' }
+    ])
 
     await request(app)
       .delete(`/api/clients/${clientId}/platforms/${platformId}`)
@@ -82,7 +103,12 @@ describe('Platform API', () => {
     const res = await request(app)
       .post(`/api/clients/${clientId}/platforms`)
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Def', platformType: 'Meta', mode: 'default', fields: defaultFields })
+      .send({
+        name: 'Def',
+        platformType: 'Meta',
+        mode: 'default',
+        fields: defaultFields
+      })
       .expect(201)
     expect(res.body.mode).toBe('default')
     expect(res.body.fields).toEqual(defaultFields)


### PR DESCRIPTION
## Summary
- allow custom ad data fields with types on platform setup
- aggregate and export only numeric ad data fields
- keep text values when sanitizing extra ad data
- update ad data utilities for new field structure
- adjust tests for typed fields

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c73bcb28832992a5d96ded6b3924