### PR TITLE
Integrate Google Cloud Storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ PORT=3000
 # 檔案上傳資料夾（自動建立）
 UPLOAD_DIR=uploads
 
+# Google Cloud Storage 設定
+GCS_PROJECT_ID=
+GCS_BUCKET=
+GCS_KEY_FILE=
+
 # 前端 API 基底位址
 VITE_API_BASE=http://localhost:3000/api
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,26 @@
    ```bash
    npm install
    ```
-   伺服器啟動前，請在根目錄複製 `.env.example` 為 `.env`，並依需求調整 MongoDB、JWT 等設定。
+伺服器啟動前，請在根目錄複製 `.env.example` 為 `.env`，並依需求調整 MongoDB、JWT、GCS 等設定。
+ `.env` 中需填入以下 GCS 相關欄位：
+
+ ```bash
+ GCS_PROJECT_ID=你的專案 ID
+ GCS_BUCKET=你的 Bucket 名稱
+ GCS_KEY_FILE=service-account.json 路徑
+ ```
+
+ 如未建立過 Bucket，可至 Google Cloud Console：
+ 1. 建立專案並啟用 **Cloud Storage**。
+ 2. 在 Storage 中建立 Bucket，名稱需與 `GCS_BUCKET` 相同。
+ 3. 建立服務帳戶並賦予 **Storage Admin** 權限，下載金鑰檔。
+ 4. 將金鑰檔路徑填入 `GCS_KEY_FILE`。
 2. 啟動 API：
    ```bash
    npm start
    ```
-   伺服器啟動後，API 根路徑為 `http://localhost:3000/api`，
-   靜態檔案可自 `/static/<檔名>` 存取。
+ 伺服器啟動後，API 根路徑為 `http://localhost:3000/api`，
+ 上傳的檔案會回傳 GCS 連結，可直接於瀏覽器開啟。
 3. 執行測試前請先在 `server` 目錄安裝相依套件：
    ```bash
    npm install

--- a/server/README.md
+++ b/server/README.md
@@ -8,7 +8,7 @@ npm install
 npm start                 # 啟動伺服器
 ```
 
-伺服器啟動前請在根目錄複製 `.env.example` 為 `.env`，並修改 MongoDB、JWT 等設定。
+伺服器啟動前請在根目錄複製 `.env.example` 為 `.env`，並填入 MongoDB、JWT 及 GCS 設定。
 
 執行 `npm run seed` 可建立預設帳號，方便初次測試。
 
@@ -40,13 +40,13 @@ npm start                 # 啟動伺服器
 
 若要讓某角色具備設定檔案或資料夾「可查看者」的能力，請分別為其啟用 `asset:update` 或 `folder:manage` 權限。
 
-啟動後，可透過 `/static/<檔名>` 存取上傳檔案，API 根路徑為 `/api/*`。
+啟動後，上傳檔案會回傳 GCS 連結，API 根路徑為 `/api/*`。
 亦可執行 `GET /api/health` 測試伺服器是否正常連線。
 
 ---
 
 ## 啟動與測試
-1. **設定 `.env`**：複製 `.env.example`，填入正確的 `MONGODB_URI` 與 `JWT_SECRET`。
+1. **設定 `.env`**：複製 `.env.example`，填入 `MONGODB_URI`、`JWT_SECRET` 以及 GCS 相關參數。
 2. **啟動 MongoDB**（本機或 Atlas）。
 3. 執行 `npm start`，若看到 `✅ MongoDB 已連線` 與 `🚀 Server running` 即成功。
 4. 使用 Postman 或 cURL 測試：

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "jsonwebtoken": "^9.0.2",
     "bcryptjs": "^2.4.3",
     "multer": "^1.4.5-lts.1",
+    "@google-cloud/storage": "^7.26.0",
     "xlsx": "^0.18.5",
     "ioredis": "^5.3.2"
   },

--- a/server/src/middleware/upload.js
+++ b/server/src/middleware/upload.js
@@ -2,21 +2,8 @@
  * \u6a94\u6848\u4e0a\u50b3\u8a2d\u5b9a\uff08multer\uff09
  */
 import multer from 'multer'
-import path from 'node:path'
-import dotenv from 'dotenv'
-import { fileURLToPath } from 'node:url'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-dotenv.config({ path: path.resolve(__dirname, '../../.env') })
-
-const storage = multer.diskStorage({
-  destination: (_, __, cb) => {
-    cb(null, process.env.UPLOAD_DIR || 'uploads')
-  },
-  filename: (_, file, cb) => {
-    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
-    cb(null, unique + path.extname(file.originalname))
-  }
-})
+// 改為記憶體儲存，檔案將存在 req.file.buffer 中
+const storage = multer.memoryStorage()
 
 export const upload = multer({ storage })

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -6,7 +6,6 @@ import cors           from 'cors'
 import cookieParser   from 'cookie-parser'
 import dotenv         from 'dotenv'
 import path           from 'node:path'
-import fs             from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 import connectDB                    from './config/db.js'
@@ -25,11 +24,8 @@ app.use(express.json())                              // 解析 JSON
 app.use(cookieParser())                              // 解析 Cookie
 
 /* ---------- 靜態檔案（上傳用） ----------
- * 前端存取方式：/static/檔名
+ * 改由 GCS 提供檔案 URL
  */
-const uploadDir = path.resolve(process.cwd(), process.env.UPLOAD_DIR || 'uploads')
-if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true })
-app.use('/static', express.static(uploadDir))
 
 /* ---------- 路由 ---------- */
 import authRoutes     from './routes/auth.routes.js'

--- a/server/src/utils/gcs.js
+++ b/server/src/utils/gcs.js
@@ -1,0 +1,26 @@
+import { Storage } from '@google-cloud/storage'
+import path from 'node:path'
+import dotenv from 'dotenv'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+
+const storage = new Storage({
+  projectId: process.env.GCS_PROJECT_ID,
+  keyFilename: process.env.GCS_KEY_FILE
+})
+
+const bucket = storage.bucket(process.env.GCS_BUCKET)
+
+export const uploadBuffer = async (buffer, destination, contentType) => {
+  const file = bucket.file(destination)
+  await file.save(buffer, {
+    resumable: false,
+    metadata: { contentType }
+  })
+  await file.makePublic().catch(() => {})
+  return `https://storage.googleapis.com/${process.env.GCS_BUCKET}/${destination}`
+}
+
+export default bucket


### PR DESCRIPTION
## Summary
- install `@google-cloud/storage`
- use memory storage middleware
- add utility to upload buffer to GCS
- update asset, adDaily and weeklyNote controllers for GCS uploads
- remove static upload serving
- add GCS env variables and instructions

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852cf559ab883298283adc6fc64fdfd