### PR TITLE
Fix asset url usage

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -9,13 +9,10 @@ export const fetchAssets = (folderId, type, tags = [], deep = false) => {
   if (deep) params.deep = 'true'
 
   return api.get('/assets', { params }).then(res =>
-    res.data.map(a => {
-      const hasStatic = /^\/static\//.test(a.url || '')
-      return {
-        ...a,
-        url: hasStatic ? a.url : `/static/${a.filename}`
-      }
-    })
+    res.data.map(a => ({
+      ...a,
+      url: a.url || `/static/${a.filename}`
+    }))
   )
 }
 
@@ -27,13 +24,10 @@ export const fetchProducts = (folderId, tags = [], deep = false, withProgress = 
   if (withProgress) params.progress = 'true'
 
   return api.get('/products', { params }).then(res =>
-    res.data.map(a => {
-      const hasStatic = /^\/static\//.test(a.url || '')
-      return {
-        ...a,
-        url: hasStatic ? a.url : `/static/${a.filename}`
-      }
-    })
+    res.data.map(a => ({
+      ...a,
+      url: a.url || `/static/${a.filename}`
+    }))
   )
 }
 

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -472,19 +472,14 @@ async function uploadRequest({ file, onProgress, onSuccess, onError }) {
 }
 
 function previewAsset(a) {
-  // 如果 url 已經以 /static/ 開頭就不重複加
-  const url = /^\/static\//.test(a.url) ? a.url : `/static/${a.filename}`
-  previewItem.value = { ...a, url }
-  console.log('[預覽素材]', url)
+  previewItem.value = { ...a, url: a.url }
+  console.log('[預覽素材]', a.url)
   previewVisible.value = true
 }
 
 function downloadAsset(asset) {
-  const url = /^\/static\//.test(asset.url)
-    ? asset.url
-    : `/static/${asset.filename}`
   const link = document.createElement('a')
-  link.href = url
+  link.href = asset.url
   link.download = asset.title || asset.filename
   document.body.appendChild(link)
   link.click()

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -536,19 +536,14 @@ async function toggleStage(stage) {
 
 
 function previewAsset(a) {
-  // 如果 url 已經以 /static/ 開頭就不重複加
-  const url = /^\/static\//.test(a.url) ? a.url : `/static/${a.filename}`
-  previewItem.value = { ...a, url }
-  console.log('[預覽素材]', url)
+  previewItem.value = { ...a, url: a.url }
+  console.log('[預覽素材]', a.url)
   previewVisible.value = true
 }
 
 function downloadAsset(asset) {
-  const url = /^\/static\//.test(asset.url)
-    ? asset.url
-    : `/static/${asset.filename}`
   const link = document.createElement('a')
-  link.href = url
+  link.href = asset.url
   link.download = asset.title || asset.filename
   document.body.appendChild(link)
   link.click()


### PR DESCRIPTION
## Summary
- simplify asset url logic
- use asset.url directly in preview/download

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853762e4d18832999b593b7f230b252