### PR TITLE
Fix to log GCS public error

### DIFF
--- a/server/src/utils/gcs.js
+++ b/server/src/utils/gcs.js
@@ -19,7 +19,9 @@ export const uploadBuffer = async (buffer, destination, contentType) => {
     resumable: false,
     metadata: { contentType }
   })
-  await file.makePublic().catch(() => {})
+  await file.makePublic().catch(err => {
+    console.error('makePublic error:', err)
+  })
   return `https://storage.googleapis.com/${process.env.GCS_BUCKET}/${destination}`
 }
 


### PR DESCRIPTION
## Summary
- add console error logging when `file.makePublic()` fails

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556846366c832981b7e4f84398108f