### PR TITLE
Remove public GCS URLs

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -118,7 +118,11 @@ export const importAdDaily = async (req, res) => {
   const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
   const ext = path.extname(req.file.originalname)
   const filename = unique + ext
-  const fileUrl = await uploadBuffer(req.file.buffer, filename, req.file.mimetype)
+  const filePath = await uploadBuffer(
+    req.file.buffer,
+    filename,
+    req.file.mimetype
+  )
 
   const xlsx = await import('xlsx')
   const wb = xlsx.read(req.file.buffer, { type: 'buffer' })
@@ -160,5 +164,5 @@ export const importAdDaily = async (req, res) => {
     .map(r => ({ ...r, date: new Date(r.date) }))
 
   const docs = await AdDaily.insertMany(records)
-  res.status(201).json({ docs, fileUrl })
+  res.status(201).json({ docs, filePath })
 }

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -32,7 +32,11 @@ export const uploadFile = async (req, res) => {
   const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
   const ext = path.extname(req.file.originalname)
   const filename = unique + ext
-  const url = await uploadBuffer(req.file.buffer, filename, req.file.mimetype)
+  const gcsPath = await uploadBuffer(
+    req.file.buffer,
+    filename,
+    req.file.mimetype
+  )
 
   const baseUsers = Array.isArray(req.body.allowedUsers)
     ? Array.from(new Set([...req.body.allowedUsers, req.user._id]))
@@ -40,8 +44,7 @@ export const uploadFile = async (req, res) => {
   const asset = await Asset.create({
     title: req.file.originalname,     // 顯示用標題
     filename,         // 實際檔名
-    path: filename,
-    url,
+    path: gcsPath,
     type: req.body.type || 'raw',
     reviewStatus: req.body.type === 'edited' ? 'pending' : undefined,
     uploadedBy: req.user._id,

--- a/server/src/controllers/weeklyNote.controller.js
+++ b/server/src/controllers/weeklyNote.controller.js
@@ -4,7 +4,7 @@ import { uploadBuffer } from '../utils/gcs.js'
 
 const uploadImages = async files => {
   if (!files?.length) return []
-  const urls = await Promise.all(
+  const paths = await Promise.all(
     files.map(async f => {
       const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
       const ext = path.extname(f.originalname)
@@ -12,7 +12,7 @@ const uploadImages = async files => {
       return uploadBuffer(f.buffer, filename, f.mimetype)
     })
   )
-  return urls
+  return paths
 }
 
 export const createWeeklyNote = async (req, res) => {

--- a/server/src/utils/gcs.js
+++ b/server/src/utils/gcs.js
@@ -19,10 +19,13 @@ export const uploadBuffer = async (buffer, destination, contentType) => {
     resumable: false,
     metadata: { contentType }
   })
-  await file.makePublic().catch(err => {
-    console.error('makePublic error:', err)
-  })
-  return `https://storage.googleapis.com/${process.env.GCS_BUCKET}/${destination}`
+  return destination
+}
+
+export const getSignedUrl = async (filename, options) => {
+  const file = bucket.file(filename)
+  const [url] = await file.getSignedUrl(options)
+  return url
 }
 
 export default bucket


### PR DESCRIPTION
## Summary
- clean up GCS upload logic
- add helper for signed URLs
- adjust asset, weekly note and ad-daily controllers to store object path

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b96371788329a2e1376d9346c3ff