### PR TITLE
Add asset signed URL API

### DIFF
--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -6,7 +6,7 @@ import Folder from '../models/folder.model.js'
 import ReviewStage from '../models/reviewStage.model.js'
 import ReviewRecord from '../models/reviewRecord.model.js'
 import path from 'node:path'
-import { uploadBuffer } from '../utils/gcs.js'
+import { uploadBuffer, getSignedUrl } from '../utils/gcs.js'
 import { getDescendantFolderIds } from '../utils/folderTree.js'
 import { includeManagers } from '../utils/includeManagers.js'
 import { getCache, setCache, clearCacheByPrefix } from '../utils/cache.js'
@@ -199,6 +199,13 @@ export const getRecentAssets = async (req, res) => {
       uploaderName: a.uploadedBy?.name || a.uploadedBy?.username
     }))
   )
+}
+
+export const getAssetSignedUrl = async (req, res) => {
+  const asset = await Asset.findById(req.params.id)
+  if (!asset) return res.status(404).json({ message: '找不到素材' })
+  const url = await getSignedUrl(asset.path)
+  res.json({ url })
 }
 
 /* ---------- PUT /api/assets/viewers ---------- */

--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -11,7 +11,8 @@ import {
     deleteAsset,
     getRecentAssets,
     reviewAsset,
-    updateAssetsViewers
+    updateAssetsViewers,
+    getAssetSignedUrl
 } from '../controllers/asset.controller.js'
 import {
   getAssetStages,
@@ -35,6 +36,7 @@ router.post(
   addComment
 )
 router.get('/recent', protect, requirePerm(PERMISSIONS.ASSET_READ), getRecentAssets)
+router.get('/:id/url', protect, requirePerm(PERMISSIONS.ASSET_READ), getAssetSignedUrl)
 
 /* ★ 新增：更新檔名／描述 */
 

--- a/server/src/utils/gcs.js
+++ b/server/src/utils/gcs.js
@@ -25,4 +25,18 @@ export const uploadBuffer = async (buffer, destination, contentType) => {
   return `https://storage.googleapis.com/${process.env.GCS_BUCKET}/${destination}`
 }
 
+export const getSignedUrl = async (filePath, options = {}) => {
+  if (process.env.NODE_ENV === 'test') {
+    return `https://signed.example.com/${filePath}`
+  }
+  const file = bucket.file(filePath)
+  const opts = {
+    action: 'read',
+    expires: Date.now() + 60 * 60 * 1000,
+    ...options
+  }
+  const [url] = await file.getSignedUrl(opts)
+  return url
+}
+
 export default bucket

--- a/server/tests/asset.test.js
+++ b/server/tests/asset.test.js
@@ -141,3 +141,13 @@ describe('Batch update viewers', () => {
   })
 })
 
+describe('Asset signed url', () => {
+  it('should return signed url', async () => {
+    const res = await request(app)
+      .get(`/api/assets/${assetId}/url`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(res.body.url).toMatch(/^https?:\/\/.*file\.mp4/)
+  })
+})
+


### PR DESCRIPTION
## Summary
- implement `getSignedUrl` in GCS utility
- provide `getAssetSignedUrl` controller
- expose new `/:id/url` asset route
- test signed URL retrieval

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b96562d88329987091403ad2a601