### PR TITLE
Add asset URL fetcher

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -71,4 +71,7 @@ export const updateAssetsViewers = async (ids, users) => {
   }
 }
 
+export const getAssetUrl = id =>
+  api.get(`/assets/${id}/url`).then(res => res.data.url)
+
 

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -279,7 +279,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers } from '../services/folders'
-import { fetchAssets, uploadAsset, updateAsset, deleteAsset, updateAssetsViewers } from '../services/assets'
+import { fetchAssets, uploadAsset, updateAsset, deleteAsset, updateAssetsViewers, getAssetUrl } from '../services/assets'
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
 import { useAuthStore } from '../stores/auth'
@@ -471,15 +471,17 @@ async function uploadRequest({ file, onProgress, onSuccess, onError }) {
   }
 }
 
-function previewAsset(a) {
-  previewItem.value = { ...a, url: a.url }
-  console.log('[預覽素材]', a.url)
+async function previewAsset(a) {
+  const url = await getAssetUrl(a._id)
+  previewItem.value = { ...a, url }
+  console.log('[預覽素材]', url)
   previewVisible.value = true
 }
 
-function downloadAsset(asset) {
+async function downloadAsset(asset) {
+  const url = await getAssetUrl(asset._id)
   const link = document.createElement('a')
-  link.href = asset.url
+  link.href = url
   link.download = asset.title || asset.filename
   document.body.appendChild(link)
   link.click()

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -315,7 +315,8 @@ import {
   reviewAsset,
   fetchAssetStages,
   updateAssetStage,
-  updateAssetsViewers
+  updateAssetsViewers,
+  getAssetUrl
 } from '../services/assets'
 import { fetchTags } from '../services/tags'
 import { useAuthStore } from '../stores/auth'
@@ -535,15 +536,17 @@ async function toggleStage(stage) {
 }
 
 
-function previewAsset(a) {
-  previewItem.value = { ...a, url: a.url }
-  console.log('[預覽素材]', a.url)
+async function previewAsset(a) {
+  const url = await getAssetUrl(a._id)
+  previewItem.value = { ...a, url }
+  console.log('[預覽素材]', url)
   previewVisible.value = true
 }
 
-function downloadAsset(asset) {
+async function downloadAsset(asset) {
+  const url = await getAssetUrl(asset._id)
   const link = document.createElement('a')
-  link.href = asset.url
+  link.href = url
   link.download = asset.title || asset.filename
   document.body.appendChild(link)
   link.click()


### PR DESCRIPTION
## Summary
- add `getAssetUrl` service to retrieve asset urls on demand
- use the new function in `AssetLibrary` and `ProductLibrary`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b96740d4832998338036b6f07fdc