### PR TITLE
Update asset URL handling

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -11,7 +11,7 @@ export const fetchAssets = (folderId, type, tags = [], deep = false) => {
   return api.get('/assets', { params }).then(res =>
     res.data.map(a => ({
       ...a,
-      url: a.url || `/static/${a.filename}`
+      url: a.url || null
     }))
   )
 }
@@ -26,7 +26,7 @@ export const fetchProducts = (folderId, tags = [], deep = false, withProgress = 
   return api.get('/products', { params }).then(res =>
     res.data.map(a => ({
       ...a,
-      url: a.url || `/static/${a.filename}`
+      url: a.url || null
     }))
   )
 }


### PR DESCRIPTION
## Summary
- update `fetchAssets` and `fetchProducts` to stop composing `/static/...` paths

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b9690c2883298bc1d0ec56a50f73