### PR TITLE
Update README for signed URL workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ UPLOAD_DIR=uploads
 GCS_PROJECT_ID=
 GCS_BUCKET=
 GCS_KEY_FILE=
+# 簽署網址有效時間（如 15m 或 1h）
+SIGNED_URL_EXPIRES_IN=15m
 
 # 前端 API 基底位址
 VITE_API_BASE=http://localhost:3000/api

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@
    ```bash
    npm start
    ```
- 伺服器啟動後，API 根路徑為 `http://localhost:3000/api`，
- 上傳的檔案會回傳 GCS 連結，可直接於瀏覽器開啟。
+伺服器啟動後，API 根路徑為 `http://localhost:3000/api`，
+上傳後僅會儲存檔名，需另外呼叫 API 取得 signed URL 才能預覽或下載檔案。
 3. 執行測試前請先在 `server` 目錄安裝相依套件：
    ```bash
    npm install

--- a/server/README.md
+++ b/server/README.md
@@ -40,7 +40,8 @@ npm start                 # 啟動伺服器
 
 若要讓某角色具備設定檔案或資料夾「可查看者」的能力，請分別為其啟用 `asset:update` 或 `folder:manage` 權限。
 
-啟動後，上傳檔案會回傳 GCS 連結，API 根路徑為 `/api/*`。
+啟動後僅會儲存檔名，API 根路徑為 `/api/*`，
+預覽或下載請呼叫相應 API 取得 signed URL。
 亦可執行 `GET /api/health` 測試伺服器是否正常連線。
 
 ---


### PR DESCRIPTION
## Summary
- describe signed URL requirement in root README
- adjust server README to match
- add SIGNED_URL_EXPIRES_IN to `.env.example`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b969bf248329969a901ee72e3b66