### PR TITLE
Update asset download

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
    ```
 伺服器啟動後，API 根路徑為 `http://localhost:3000/api`，
 上傳後僅會儲存檔名，需另外呼叫 API 取得 signed URL 才能預覽或下載檔案。
+若需強制瀏覽器下載檔案，可對 `GET /api/assets/:id/url` 加入 `?download=1`
+參數取得下載專用的 URL。
 3. 執行測試前請先在 `server` 目錄安裝相依套件：
    ```bash
    npm install

--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -71,7 +71,9 @@ export const updateAssetsViewers = async (ids, users) => {
   }
 }
 
-export const getAssetUrl = id =>
-  api.get(`/assets/${id}/url`).then(res => res.data.url)
+export const getAssetUrl = (id, download = false) =>
+  api
+    .get(`/assets/${id}/url`, { params: download ? { download: 1 } : {} })
+    .then(res => res.data.url)
 
 

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -479,7 +479,7 @@ async function previewAsset(a) {
 }
 
 async function downloadAsset(asset) {
-  const url = await getAssetUrl(asset._id)
+  const url = await getAssetUrl(asset._id, true)
   const link = document.createElement('a')
   link.href = url
   link.download = asset.title || asset.filename

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -544,7 +544,7 @@ async function previewAsset(a) {
 }
 
 async function downloadAsset(asset) {
-  const url = await getAssetUrl(asset._id)
+  const url = await getAssetUrl(asset._id, true)
   const link = document.createElement('a')
   link.href = url
   link.download = asset.title || asset.filename

--- a/server/README.md
+++ b/server/README.md
@@ -41,7 +41,9 @@ npm start                 # 啟動伺服器
 若要讓某角色具備設定檔案或資料夾「可查看者」的能力，請分別為其啟用 `asset:update` 或 `folder:manage` 權限。
 
 啟動後僅會儲存檔名，API 根路徑為 `/api/*`，
-預覽或下載請呼叫相應 API 取得 signed URL。
+預覽或下載請呼叫相應 API 取得 signed URL。若欲直接下載檔案，可在
+`GET /api/assets/:id/url` 後加入 `?download=1`，回傳的 URL 將強制瀏覽器
+下載檔案。
 亦可執行 `GET /api/health` 測試伺服器是否正常連線。
 
 ---

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -207,7 +207,14 @@ export const getRecentAssets = async (req, res) => {
 export const getAssetSignedUrl = async (req, res) => {
   const asset = await Asset.findById(req.params.id)
   if (!asset) return res.status(404).json({ message: '找不到素材' })
-  const url = await getSignedUrl(asset.path)
+
+  const options = {}
+  if (req.query.download === '1') {
+    const name = encodeURIComponent(asset.title || asset.filename)
+    options.responseDisposition = `attachment; filename="${name}"`
+  }
+
+  const url = await getSignedUrl(asset.path, options)
   res.json({ url })
 }
 


### PR DESCRIPTION
## Summary
- support direct download signed URLs
- add `download` parameter to asset service
- use download flag in asset and product views
- document download option in READMEs

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685646a71b288329856bf2719b79323c