### PR TITLE
新增廣告數據更新及刪除功能

### DIFF
--- a/client/src/services/adDaily.js
+++ b/client/src/services/adDaily.js
@@ -37,3 +37,16 @@ export const bulkCreateDaily = async (clientId, platformId, records) => {
   }
 }
 
+export const updateDaily = (clientId, platformId, id, data) =>
+  api
+    .put(
+      `/clients/${clientId}/platforms/${platformId}/ad-daily/${id}`,
+      data
+    )
+    .then(r => r.data)
+
+export const deleteDaily = (clientId, platformId, id) =>
+  api
+    .delete(`/clients/${clientId}/platforms/${platformId}/ad-daily/${id}`)
+    .then(r => r.data)
+

--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -166,3 +166,26 @@ export const importAdDaily = async (req, res) => {
   const docs = await AdDaily.insertMany(records)
   res.status(201).json({ docs, filePath })
 }
+
+export const updateAdDaily = async (req, res) => {
+  const rec = await AdDaily.findByIdAndUpdate(
+    req.params.id,
+    {
+      date: req.body.date,
+      spent: sanitizeNumber(req.body.spent),
+      enquiries: sanitizeNumber(req.body.enquiries),
+      reach: sanitizeNumber(req.body.reach),
+      impressions: sanitizeNumber(req.body.impressions),
+      clicks: sanitizeNumber(req.body.clicks),
+      extraData: sanitizeExtraData(req.body.extraData)
+    },
+    { new: true }
+  )
+  if (!rec) return res.status(404).json({ message: '紀錄不存在' })
+  res.json(rec)
+}
+
+export const deleteAdDaily = async (req, res) => {
+  await AdDaily.findByIdAndDelete(req.params.id)
+  res.json({ message: '紀錄已刪除' })
+}

--- a/server/src/routes/adDaily.routes.js
+++ b/server/src/routes/adDaily.routes.js
@@ -6,7 +6,9 @@ import {
   getAdDaily,
   getWeeklyData,
   importAdDaily,
-  bulkCreateAdDaily
+  bulkCreateAdDaily,
+  updateAdDaily,
+  deleteAdDaily
 } from '../controllers/adDaily.controller.js'
 
 const router = Router({ mergeParams: true })
@@ -20,5 +22,9 @@ router.route('/')
 router.get('/weekly', getWeeklyData)
 router.post('/import', upload.single('file'), importAdDaily)
 router.post('/bulk', bulkCreateAdDaily)
+
+router.route('/:id')
+  .put(updateAdDaily)
+  .delete(deleteAdDaily)
 
 export default router

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -136,4 +136,33 @@ describe('Client and AdDaily', () => {
     expect(res.body[0].extraData).toEqual({ metric: 1 })
     expect(res.body[1].extraData).toEqual({ metric: 2 })
   })
+
+  it('update and delete adDaily', async () => {
+    const create = await request(app)
+      .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ date: new Date('2024-05-01').toISOString(), spent: 1 })
+      .expect(201)
+    const id = create.body._id
+
+    const updated = await request(app)
+      .put(`/api/clients/${clientId}/platforms/${platformId}/ad-daily/${id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ spent: 20 })
+      .expect(200)
+    expect(updated.body.spent).toBe(20)
+
+    await request(app)
+      .delete(`/api/clients/${clientId}/platforms/${platformId}/ad-daily/${id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    const list = await request(app)
+      .get(
+        `/api/clients/${clientId}/platforms/${platformId}/ad-daily?start=2024-05-01&end=2024-05-01`
+      )
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(list.body.length).toBe(0)
+  })
 })


### PR DESCRIPTION
## Summary
- 後端 AdDaily controller 新增 update 與 delete
- route 新增對應的 PUT 與 DELETE
- 前端 service 新增 updateDaily、deleteDaily
- AdData 視圖提供編輯表單與刪除操作
- 測試新增更新與刪除案例

## Testing
- `npm test --silent --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685693f9ab6c83299777dac0b5b592a6