### PR TITLE
Add date custom field for ads

### DIFF
--- a/client/src/utils/adData.js
+++ b/client/src/utils/adData.js
@@ -11,8 +11,10 @@ export const buildExcelSpec = customFields => [
   ...baseSpec,
   ...customFields.map(c => ({
     field: c.name,
-    type: c.type === 'number' ? '數字' : '文字',
-    sample: ''
+    type: c.type === 'number' ? '數字'
+      : c.type === 'date' ? '日期 (YYYY-MM-DD)'
+      : '文字',
+    sample: c.type === 'date' ? '2025-06-01' : ''
   }))
 ]
 
@@ -26,7 +28,7 @@ export const buildTemplateRow = customFields => {
     clicks: 23
   }
   customFields.forEach(c => {
-    row[c.name] = ''
+    row[c.name] = c.type === 'date' ? '2025-06-01' : ''
   })
   return row
 }
@@ -45,7 +47,8 @@ export const normalizeRows = (arr, customFields) => arr
     customFields.forEach(c => {
       if (r[c.name] !== undefined) {
         const val = r[c.name]
-        extra[c.name] = c.type === 'number' ? Number(val) || 0 : val
+        if (c.type === 'number') extra[c.name] = Number(val) || 0
+        else extra[c.name] = val
       }
     })
     const ignore = new Set([
@@ -73,7 +76,10 @@ export const buildExportRows = (dailyData, customFields, dateFmt) =>
       點擊: r.clicks
     }
     customFields.forEach(c => {
-      obj[c.name] = r.extraData?.[c.name] ?? ''
+      const val = r.extraData?.[c.name]
+      obj[c.name] = c.type === 'date'
+        ? (val ? dateFmt({ date: val }) : '')
+        : (val ?? '')
     })
     return obj
   })

--- a/client/src/views/AdPlatforms.vue
+++ b/client/src/views/AdPlatforms.vue
@@ -128,6 +128,7 @@ onMounted(loadPlatforms)
             <el-select v-model="newFieldType" style="width:100px">
               <el-option label="數字" value="number" />
               <el-option label="文字" value="text" />
+              <el-option label="日期" value="date" />
             </el-select>
             <el-button type="primary" @click="addField">新增</el-button>
           </div>

--- a/server/tests/adDataUtils.test.js
+++ b/server/tests/adDataUtils.test.js
@@ -4,7 +4,8 @@ import dayjs from 'dayjs'
 describe('adData helpers', () => {
   const fields = [
     { name: 'foo', type: 'number' },
-    { name: 'bar', type: 'text' }
+    { name: 'bar', type: 'text' },
+    { name: 'baz', type: 'date' }
   ]
 
   test('excel spec and template order', () => {
@@ -23,13 +24,13 @@ describe('adData helpers', () => {
 
   test('normalizeRows keeps field order', () => {
     const rows = normalizeRows([
-      { date:'2025-06-02', foo:'A', bar:'B', spent:100 }
+      { date:'2025-06-02', foo:'A', bar:'B', baz:'2025-06-01', spent:100 }
     ], fields)
     expect(Object.keys(rows[0].extraData)).toEqual(fields.map(f => f.name))
   })
 
   test('export rows follow field order', () => {
-    const daily = [{ date:'2025-06-01', spent:100, enquiries:1, reach:10, impressions:20, clicks:5, avgCost:'100.00', extraData:{ foo:'X', bar:'Y' } }]
+    const daily = [{ date:'2025-06-01', spent:100, enquiries:1, reach:10, impressions:20, clicks:5, avgCost:'100.00', extraData:{ foo:'X', bar:'Y', baz:'2025-06-03' } }]
     const rows = buildExportRows(
       daily,
       fields,


### PR DESCRIPTION
## Summary
- allow selecting date field type when defining ad platform fields
- support date inputs and display in ad data view
- handle date type in ad data utilities
- cover new date type in adDataUtils tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0847d44832982ab935d8b1a8109