### PR TITLE
Add draggable fields in AdPlatforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ server/  # 後端 API
 後端對應 `/api/clients/:clientId/platforms/:platformId/ad-daily`，`/weekly` 回傳週統計。
 若需批次匯入，可 POST 至 `/api/clients/:clientId/platforms/:platformId/ad-daily/import` 上傳 CSV 或 Excel。
 
+在「平台管理」的自訂欄位區塊，可拖曳標籤調整顯示順序。
+
 
 
 ## Heroku 部署

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,8 @@
     "pinia": "^3.0.3",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "vuedraggable": "^4.1.2"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/client/src/views/AdPlatforms.vue
+++ b/client/src/views/AdPlatforms.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, watch } from 'vue'
+import draggable from 'vuedraggable'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { fetchPlatforms, createPlatform, updatePlatform, deletePlatform } from '../services/platforms'
@@ -133,11 +134,14 @@ onMounted(loadPlatforms)
             <el-button type="primary" @click="addField">新增</el-button>
           </div>
           <!-- 自訂欄位 tag 容器加個 class -->
-          <div class="tag-wrap flex flex-wrap gap-2">
-            <el-tag v-for="(f, i) in form.fields" :key="i" closable @close="removeField(i)">
-              {{ f.name }}<span class="ml-1 text-xs">({{ f.type }})</span>
-            </el-tag>
-          </div>
+          <draggable v-model="form.fields" item-key="name" class="tag-wrap flex flex-wrap gap-2" handle=".drag-handle">
+            <template #item="{ element, index }">
+              <el-tag closable @close="removeField(index)">
+                <span class="drag-handle mr-1 cursor-move">☰</span>
+                {{ element.name }}<span class="ml-1 text-xs">({{ element.type }})</span>
+              </el-tag>
+            </template>
+          </draggable>
         </el-form-item>
       </el-form>
       <template #footer>
@@ -155,5 +159,8 @@ onMounted(loadPlatforms)
   display: flex;
   flex-wrap: wrap;
   gap: .5rem;          /* 與 template 的 gap-2 對應 */
+}
+.drag-handle {
+  cursor: move;
 }
 </style>


### PR DESCRIPTION
## Summary
- install `vuedraggable` in client package.json
- allow custom field tags to be reordered with drag and drop
- show a small handle icon on each tag
- document that field order can be changed by dragging

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a85c7c448329aa8e0107f6a084d8