### PR TITLE
Add signed URL support for weekly images

### DIFF
--- a/client/src/services/weeklyNotes.js
+++ b/client/src/services/weeklyNotes.js
@@ -28,3 +28,11 @@ export const updateWeeklyNote = (clientId, platformId, week, data) => {
     { headers: { 'Content-Type': 'multipart/form-data' } }
   ).then(r => r.data)
 }
+
+export const getWeeklyNoteImageUrl = (clientId, platformId, path) =>
+  api
+    .get(
+      `/clients/${clientId}/platforms/${platformId}/weekly-notes/image-url`,
+      { params: { path } }
+    )
+    .then(r => r.data.url)

--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -212,7 +212,7 @@ import {
   updateDaily,
   deleteDaily
 } from '@/services/adDaily'
-import { fetchWeeklyNote, fetchWeeklyNotes, createWeeklyNote, updateWeeklyNote } from '@/services/weeklyNotes'
+import { fetchWeeklyNote, fetchWeeklyNotes, createWeeklyNote, updateWeeklyNote, getWeeklyNoteImageUrl } from '@/services/weeklyNotes'
 import { getPlatform } from '@/services/platforms'
 
 /**** ----------------------------- 路由 & 基本狀態 ----------------------------- ****/
@@ -524,7 +524,8 @@ async function exportWeekly() {
     /* 第一張圖片嵌入 */
     if (row.hasImage && row.images[0]) {
       try {
-        const res = await fetch(row.images[0])
+        const signedUrl = await getWeeklyNoteImageUrl(clientId, platformId, row.images[0])
+        const res = await fetch(signedUrl)
         const buf = await res.arrayBuffer()
         const ext = row.images[0].split('.').pop().replace('jpg', 'jpeg')   // exceljs 要用 jpeg / png
         const imgId = wb.addImage({ buffer: buf, extension: ext })

--- a/server/src/controllers/weeklyNote.controller.js
+++ b/server/src/controllers/weeklyNote.controller.js
@@ -1,6 +1,6 @@
 import WeeklyNote from '../models/weeklyNote.model.js'
 import path from 'node:path'
-import { uploadBuffer } from '../utils/gcs.js'
+import { uploadBuffer, getSignedUrl } from '../utils/gcs.js'
 
 const uploadImages = async files => {
   if (!files?.length) return []
@@ -62,4 +62,11 @@ export const getWeeklyNotes = async (req, res) => {
     platformId: req.params.platformId
   })
   res.json(notes)
+}
+
+export const getWeeklyImageUrl = async (req, res) => {
+  const filePath = req.query.path
+  if (!filePath) return res.status(400).json({ message: '缺少 path 參數' })
+  const url = await getSignedUrl(filePath)
+  res.json({ url })
 }

--- a/server/src/routes/weeklyNote.routes.js
+++ b/server/src/routes/weeklyNote.routes.js
@@ -5,7 +5,8 @@ import {
   createWeeklyNote,
   getWeeklyNote,
   getWeeklyNotes,
-  updateWeeklyNote
+  updateWeeklyNote,
+  getWeeklyImageUrl
 } from '../controllers/weeklyNote.controller.js'
 
 const router = Router({ mergeParams: true })
@@ -14,6 +15,7 @@ router.use(protect)
 
 router.get('/', getWeeklyNotes)
 router.post('/', upload.array('images'), createWeeklyNote)
+router.get('/image-url', getWeeklyImageUrl)
 router.route('/:week')
   .get(getWeeklyNote)
   .put(upload.array('images'), updateWeeklyNote)

--- a/server/tests/weeklyNote.test.js
+++ b/server/tests/weeklyNote.test.js
@@ -93,4 +93,13 @@ describe('WeeklyNote API', () => {
     expect(weeks).toContain('2024-W01')
     expect(weeks).toContain('2024-W02')
   })
+
+  it('get signed url for image', async () => {
+    const res = await request(app)
+      .get(`/api/clients/${clientId}/platforms/${platformId}/weekly-notes/image-url`)
+      .query({ path: 'test/file.txt' })
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(res.body.url).toBe('https://signed.example.com/test/file.txt')
+  })
 })


### PR DESCRIPTION
## Summary
- support signed URLs for weekly note images
- expose new `/image-url` route for weekly notes
- fetch signed URLs when exporting weekly report
- test weekly image URL route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ed4b36b4832996f0fd589ed581a8