### PR TITLE
Implement cascading folder delete

### DIFF
--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -1,4 +1,5 @@
 import Folder from '../models/folder.model.js'
+import Asset from '../models/asset.model.js'
 import { getDescendantFolderIds } from '../utils/folderTree.js'
 import { includeManagers } from '../utils/includeManagers.js'
 import { getCache, setCache, clearCacheByPrefix } from '../utils/cache.js'
@@ -86,8 +87,14 @@ export const updateFolder = async (req, res) => {
 }
 
 export const deleteFolder = async (req, res) => {
-  await Folder.findByIdAndDelete(req.params.id)
+  const folderIds = await getDescendantFolderIds(req.params.id)
+  folderIds.push(req.params.id)
+
+  await Asset.deleteMany({ folderId: { $in: folderIds } })
+  await Folder.deleteMany({ _id: { $in: folderIds } })
+
   await clearCacheByPrefix('folders:')
+  await clearCacheByPrefix('assets:')
   res.json({ message: '資料夾已刪除' })
 }
 


### PR DESCRIPTION
## Summary
- ensure deleting a folder also removes all subfolders and assets
- test cleanup of nested folders and assets

## Testing
- `npm --prefix server install` *(fails: unable to access registry.npmjs.org)*
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579643144c8329b776f424e546aa64