### PR TITLE
Add folder review feature

### DIFF
--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -35,3 +35,6 @@ export const updateFoldersViewers = async (ids, users) => {
   }
 }
 
+export const reviewFolder = (id, status) =>
+  api.put(`/folders/${id}/review`, { reviewStatus: status }).then(res => res.data)
+

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -263,8 +263,12 @@
             cancel-button-text="取消" confirm-button-type="danger" @confirm="handleDelete">
             <template #reference><el-button size="small" type="danger">刪除</el-button></template>
           </el-popconfirm>
-          <el-button v-if="detailType === 'asset' && canReview" size="small" type="warning"
-            @click="review('rejected')">退回</el-button>
+          <el-button
+            v-if="(detailType === 'asset' || detailType === 'folder') && canReview"
+            size="small"
+            type="warning"
+            @click="review('rejected')"
+          >退回</el-button>
 
           <el-button size="small" @click="showDetail = false">取消</el-button>
           <el-button size="small" type="primary" @click="saveDetail">儲存</el-button>
@@ -309,7 +313,15 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
-import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers } from '../services/folders'
+import {
+  fetchFolders,
+  createFolder,
+  updateFolder,
+  getFolder,
+  deleteFolder,
+  updateFoldersViewers,
+  reviewFolder
+} from '../services/folders'
 import { ArrowLeft, Plus, UploadFilled, Grid, Menu, UserFilled, InfoFilled } from '@element-plus/icons-vue'
 import { fetchUsers } from '../services/user'
 import {
@@ -525,8 +537,13 @@ async function uploadRequest({ file, onProgress, onSuccess, onError }) {
 
 
 async function review(status) {
-  if (!previewItem.value) return
-  await reviewAsset(previewItem.value._id, status)
+  if (detailType.value === 'asset' && previewItem.value) {
+    await reviewAsset(previewItem.value._id, status)
+  } else if (detailType.value === 'folder' && editingFolder.value) {
+    await reviewFolder(editingFolder.value._id, status)
+  } else {
+    return
+  }
   ElMessage.success('已更新狀態')
   showDetail.value = false
   loadData(currentFolder.value?._id)

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -69,6 +69,19 @@ export const getFolder = async (req, res) => {
   res.json(folder)
 }
 
+export const reviewFolder = async (req, res) => {
+  const { reviewStatus } = req.body
+  if (!['pending', 'approved', 'rejected'].includes(reviewStatus)) {
+    return res.status(400).json({ message: '狀態錯誤' })
+  }
+  const folder = await Folder.findById(req.params.id)
+  if (!folder) return res.status(404).json({ message: '資料夾不存在' })
+  folder.reviewStatus = reviewStatus
+  await folder.save()
+  await clearCacheByPrefix('folders:')
+  res.json(folder)
+}
+
 export const updateFolder = async (req, res) => {
   if (req.body.tags) req.body.tags = parseTags(req.body.tags)
   if (req.body.type && !['raw', 'edited'].includes(req.body.type)) {

--- a/server/src/models/folder.model.js
+++ b/server/src/models/folder.model.js
@@ -7,6 +7,11 @@ const folderSchema = new mongoose.Schema(
     description: { type: String },
     script: { type: String },
     type: { type: String, enum: ['raw', 'edited'], default: 'raw' },
+    reviewStatus: {
+      type: String,
+      enum: ['pending', 'approved', 'rejected'],
+      default: 'pending'
+    },
 
     /* 可存取使用者 */
     allowedUsers: { type: [mongoose.Schema.Types.ObjectId], ref: 'User', default: [] },

--- a/server/src/routes/folder.routes.js
+++ b/server/src/routes/folder.routes.js
@@ -8,7 +8,8 @@ import {
   getFolder,
   updateFolder,
   deleteFolder,
-  updateFoldersViewers
+  updateFoldersViewers,
+  reviewFolder
 } from '../controllers/folder.controller.js'
 
 const router = Router()
@@ -21,6 +22,12 @@ router.put(
   protect,
   requirePerm(PERMISSIONS.FOLDER_MANAGE),
   updateFoldersViewers
+)
+router.put(
+  '/:id/review',
+  protect,
+  requirePerm(PERMISSIONS.REVIEW_MANAGE),
+  reviewFolder
 )
 router.put('/:id', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), updateFolder)
 router.delete(

--- a/server/tests/folder.test.js
+++ b/server/tests/folder.test.js
@@ -32,7 +32,7 @@ beforeAll(async () => {
 
   const managerRole = await Role.create({
     name: 'manager',
-    permissions: ['folder:manage', 'folder:read']
+    permissions: ['folder:manage', 'folder:read', 'review:manage']
   })
   const empRole = await Role.create({
     name: 'employee',
@@ -157,6 +157,17 @@ describe('Batch update folder viewers', () => {
   const f = await Folder.findById(folderId)
   const ids = f.allowedUsers.map(id => id.toString())
   expect(ids).toContain(newUser._id.toString())
+  })
+})
+
+describe('Folder review', () => {
+  it('update reviewStatus', async () => {
+    const res = await request(app)
+      .put(`/api/folders/${folderId}/review`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ reviewStatus: 'approved' })
+      .expect(200)
+    expect(res.body.reviewStatus).toBe('approved')
   })
 })
 


### PR DESCRIPTION
## Summary
- support reviewStatus on folders
- add folder review controller and route
- enable folder review in ProductLibrary frontend
- update tests for folder review

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579643cbb48329b0afe4a449433ab2