### PR TITLE
Add dashboard summary API and update dashboard UI

### DIFF
--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -4,12 +4,16 @@ import { ref, onMounted } from 'vue'
 import api from '../services/api'
 
 /* ===== 響應式狀態 ===== */
-const recentAssets   = ref([])  // 近 7 筆素材
+const recentAssets   = ref([])
+const recentReviews  = ref([])
+const adSummary      = ref({})
 
 /* ===== API 請求 ===== */
 async function fetchDashboard () {
-  const { data: assets } = await api.get('/assets/recent?limit=7')
-  recentAssets.value = assets
+  const { data } = await api.get('/dashboard/summary')
+  recentAssets.value = data.recentAssets
+  recentReviews.value = data.recentReviews
+  adSummary.value = data.adSummary
 }
 
 onMounted(fetchDashboard)
@@ -52,6 +56,51 @@ onMounted(fetchDashboard)
 
       <el-table-column prop="uploaderName" label="上傳者" width="120" />
     </el-table>
+  </el-card>
+
+  <!-- === 最近審查結果 === -->
+  <el-card shadow="hover" class="mt-6">
+    <template #header>
+      <span class="text-lg font-semibold">最近審查結果</span>
+    </template>
+    <el-table :data="recentReviews" stripe style="width:100%" empty-text="尚無審查紀錄">
+      <el-table-column label="時間" width="180">
+        <template #default="{ row }">{{ new Date(row.updatedAt).toLocaleString() }}</template>
+      </el-table-column>
+      <el-table-column prop="assetFile" label="素材" />
+      <el-table-column prop="stage" label="階段" />
+      <el-table-column label="狀態" width="100">
+        <template #default="{ row }">
+          <el-tag type="success" v-if="row.completed">完成</el-tag>
+          <el-tag v-else>未完成</el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column prop="updatedBy" label="審核者" width="120" />
+    </el-table>
+  </el-card>
+
+  <!-- === 最新廣告數據 === -->
+  <el-card shadow="hover" class="mt-6">
+    <template #header>
+      <span class="text-lg font-semibold">最新廣告數據 (近 7 天)</span>
+    </template>
+    <el-row :gutter="20" class="text-center">
+      <el-col :span="4">
+        <div>花費<br><b>{{ adSummary.spent || 0 }}</b></div>
+      </el-col>
+      <el-col :span="4">
+        <div>詢問<br><b>{{ adSummary.enquiries || 0 }}</b></div>
+      </el-col>
+      <el-col :span="4">
+        <div>觸及<br><b>{{ adSummary.reach || 0 }}</b></div>
+      </el-col>
+      <el-col :span="4">
+        <div>曝光<br><b>{{ adSummary.impressions || 0 }}</b></div>
+      </el-col>
+      <el-col :span="4">
+        <div>點擊<br><b>{{ adSummary.clicks || 0 }}</b></div>
+      </el-col>
+    </el-row>
   </el-card>
 </template>
 

--- a/server/src/controllers/dashboard.controller.js
+++ b/server/src/controllers/dashboard.controller.js
@@ -1,0 +1,64 @@
+import Asset from '../models/asset.model.js'
+import ReviewRecord from '../models/reviewRecord.model.js'
+import AdDaily from '../models/adDaily.model.js'
+
+export const getSummary = async (req, res) => {
+  const assetLimit = 7
+  const reviewLimit = 7
+
+  const assetDocs = await Asset.find()
+    .sort({ createdAt: -1 })
+    .limit(assetLimit)
+    .populate('uploadedBy', 'username name')
+    .lean()
+
+  const recentAssets = assetDocs
+    .filter(a => !a.allowedUsers?.length || a.allowedUsers.some(id => id.equals(req.user._id)))
+    .map(a => ({
+      _id: a._id,
+      fileName: a.filename,
+      fileType: a.type,
+      uploaderName: a.uploadedBy?.name || a.uploadedBy?.username,
+      createdAt: a.createdAt
+    }))
+
+  const reviewDocs = await ReviewRecord.find()
+    .sort({ updatedAt: -1 })
+    .limit(reviewLimit)
+    .populate('assetId', 'filename allowedUsers')
+    .populate('stageId', 'name')
+    .populate('updatedBy', 'username name')
+    .lean()
+
+  const recentReviews = reviewDocs
+    .filter(r => !r.assetId?.allowedUsers?.length || r.assetId.allowedUsers.some(id => id.equals(req.user._id)))
+    .map(r => ({
+      _id: r._id,
+      assetFile: r.assetId?.filename,
+      stage: r.stageId?.name,
+      completed: r.completed,
+      updatedAt: r.updatedAt,
+      updatedBy: r.updatedBy?.name || r.updatedBy?.username
+    }))
+
+  const end = new Date()
+  const start = new Date()
+  start.setDate(end.getDate() - 6)
+  const adAgg = await AdDaily.aggregate([
+    { $match: { date: { $gte: start, $lte: end } } },
+    {
+      $group: {
+        _id: null,
+        spent: { $sum: '$spent' },
+        enquiries: { $sum: '$enquiries' },
+        reach: { $sum: '$reach' },
+        impressions: { $sum: '$impressions' },
+        clicks: { $sum: '$clicks' }
+      }
+    }
+  ])
+
+  const adSummary = adAgg[0] || { spent: 0, enquiries: 0, reach: 0, impressions: 0, clicks: 0 }
+
+  res.json({ recentAssets, recentReviews, adSummary })
+}

--- a/server/src/routes/dashboard.routes.js
+++ b/server/src/routes/dashboard.routes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express'
+import { protect } from '../middleware/auth.js'
+import { getSummary } from '../controllers/dashboard.controller.js'
+
+const router = Router()
+router.use(protect)
+router.get('/summary', getSummary)
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -106,6 +106,7 @@ import clientRoutes       from './routes/client.routes.js'
 import platformRoutes     from './routes/platform.routes.js'
 import adDailyRoutes      from './routes/adDaily.routes.js'
 import weeklyNoteRoutes   from './routes/weeklyNote.routes.js'
+import dashboardRoutes    from './routes/dashboard.routes.js'
 
 app.use('/api/auth',     authRoutes)
 app.use('/api/user',     userRoutes)
@@ -123,6 +124,7 @@ app.use('/api/permissions', permissionsRoutes)
 app.use('/api/menus', menusRoutes)
 app.use('/api/review-stages', reviewStageRoutes)
 app.use('/api/health', healthRoutes)
+app.use('/api/dashboard', dashboardRoutes)
 
 /* ────────────────────────── 5. 前端靜態檔案 ───────────────────────── */
 const clientDist = path.resolve(__dirname, '../../client/dist')


### PR DESCRIPTION
## Summary
- add dashboard summary controller and routes
- expose `/api/dashboard/summary` on the server
- update dashboard view to show latest assets, review results and ad data

## Testing
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685796472e1c83298b7f5b1a71b337f3