### PR TITLE
Add folder review stages

### DIFF
--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -38,3 +38,9 @@ export const updateFoldersViewers = async (ids, users) => {
 export const reviewFolder = (id, status) =>
   api.put(`/folders/${id}/review`, { reviewStatus: status }).then(res => res.data)
 
+export const fetchFolderStages = id =>
+  api.get(`/folders/${id}/stages`).then(res => res.data)
+
+export const updateFolderStage = (folderId, stageId, completed) =>
+  api.put(`/folders/${folderId}/stages/${stageId}`, { completed }).then(res => res.data)
+

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -1,5 +1,7 @@
 import Folder from '../models/folder.model.js'
 import Asset from '../models/asset.model.js'
+import ReviewStage from '../models/reviewStage.model.js'
+import FolderReviewRecord from '../models/folderReviewRecord.model.js'
 import { getDescendantFolderIds } from '../utils/folderTree.js'
 import { includeManagers } from '../utils/includeManagers.js'
 import { getCache, setCache, clearCacheByPrefix } from '../utils/cache.js'
@@ -78,6 +80,14 @@ export const reviewFolder = async (req, res) => {
   const folder = await Folder.findById(req.params.id)
   if (!folder) return res.status(404).json({ message: '資料夾不存在' })
   folder.reviewStatus = reviewStatus
+
+  const total = await ReviewStage.countDocuments()
+  if (total) {
+    const done = await FolderReviewRecord.countDocuments({ folderId: folder._id, completed: true })
+    if (done === total) {
+      folder.reviewStatus = 'approved'
+    }
+  }
   await folder.save()
   await clearCacheByPrefix('folders:')
   res.json(folder)

--- a/server/src/controllers/folderReviewRecord.controller.js
+++ b/server/src/controllers/folderReviewRecord.controller.js
@@ -1,0 +1,69 @@
+import ReviewStage from '../models/reviewStage.model.js'
+import FolderReviewRecord from '../models/folderReviewRecord.model.js'
+import Folder from '../models/folder.model.js'
+
+export const getFolderStages = async (req, res) => {
+  const stages = await ReviewStage.find().populate('responsible').sort('order')
+  const records = await FolderReviewRecord.find({ folderId: req.params.id })
+  const map = {}
+  for (const r of records) map[r.stageId.toString()] = r
+  const list = stages.map(s => ({
+    _id: s._id,
+    name: s.name,
+    order: s.order,
+    responsible: s.responsible,
+    completed: map[s._id.toString()]?.completed || false
+  }))
+  res.json(list)
+}
+
+export const updateFolderStageStatus = async (req, res) => {
+  const folderId = req.params.id
+  const stageId = req.params.stageId
+  const completed = !!req.body.completed
+
+  const stage = await ReviewStage.findById(stageId).populate('responsible')
+  if (!stage) return res.status(404).json({ message: '階段不存在' })
+
+  if (String(stage.responsible._id) !== String(req.user._id)) {
+    return res.status(403).json({ message: '無權審核此階段' })
+  }
+
+  if (completed) {
+    const prevStages = await ReviewStage.find({ order: { $lt: stage.order } }, '_id')
+    if (prevStages.length) {
+      const prevIds = prevStages.map(s => s._id)
+      const doneCount = await FolderReviewRecord.countDocuments({
+        folderId,
+        stageId: { $in: prevIds },
+        completed: true
+      })
+      if (doneCount < prevStages.length) {
+        return res.status(400).json({ message: '前置審核未完成' })
+      }
+    }
+  }
+
+  let record = await FolderReviewRecord.findOne({ folderId, stageId })
+  if (!record) {
+    record = await FolderReviewRecord.create({ folderId, stageId, completed, updatedBy: req.user._id })
+  } else {
+    record.completed = completed
+    record.updatedBy = req.user._id
+    await record.save()
+  }
+
+  const total = await ReviewStage.countDocuments()
+  const done = await FolderReviewRecord.countDocuments({ folderId, completed: true })
+  const folder = await Folder.findById(folderId)
+  if (folder) {
+    if (total && done === total) {
+      folder.reviewStatus = 'approved'
+    } else if (done < total && folder.reviewStatus === 'approved') {
+      folder.reviewStatus = 'pending'
+    }
+    await folder.save()
+  }
+
+  res.json(record)
+}

--- a/server/src/models/folderReviewRecord.model.js
+++ b/server/src/models/folderReviewRecord.model.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose'
+
+const folderReviewRecordSchema = new mongoose.Schema(
+  {
+    folderId: { type: mongoose.Schema.Types.ObjectId, ref: 'Folder', required: true },
+    stageId: { type: mongoose.Schema.Types.ObjectId, ref: 'ReviewStage', required: true },
+    completed: { type: Boolean, default: false },
+    updatedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' }
+  },
+  { timestamps: true }
+)
+
+folderReviewRecordSchema.index({ folderId: 1, stageId: 1 }, { unique: true })
+
+export default mongoose.model('FolderReviewRecord', folderReviewRecordSchema)

--- a/server/src/routes/folder.routes.js
+++ b/server/src/routes/folder.routes.js
@@ -11,6 +11,10 @@ import {
   updateFoldersViewers,
   reviewFolder
 } from '../controllers/folder.controller.js'
+import {
+  getFolderStages,
+  updateFolderStageStatus
+} from '../controllers/folderReviewRecord.controller.js'
 
 const router = Router()
 
@@ -29,6 +33,8 @@ router.put(
   requirePerm(PERMISSIONS.REVIEW_MANAGE),
   reviewFolder
 )
+router.get('/:id/stages', protect, getFolderStages)
+router.put('/:id/stages/:stageId', protect, updateFolderStageStatus)
 router.put('/:id', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), updateFolder)
 router.delete(
   '/:id',

--- a/server/tests/folderReviewRecord.test.js
+++ b/server/tests/folderReviewRecord.test.js
@@ -1,0 +1,84 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import folderRoutes from '../src/routes/folder.routes.js'
+import authRoutes from '../src/routes/auth.routes.js'
+import ReviewStage from '../src/models/reviewStage.model.js'
+import Folder from '../src/models/folder.model.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+let folderId
+let stageId1
+let stageId2
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/folders', folderRoutes)
+
+  const role = await Role.create({ name: 'manager' })
+  const user = await User.create({ username: 'admin', password: 'pwd', email: 'a@test', roleId: role._id })
+
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'admin', password: 'pwd' })
+  token = res.body.token
+
+  const s1 = await ReviewStage.create({ name: 'S1', order: 1, responsible: user._id })
+  const s2 = await ReviewStage.create({ name: 'S2', order: 2, responsible: user._id })
+  stageId1 = s1._id
+  stageId2 = s2._id
+
+  const folder = await Folder.create({ name: 'F1', reviewStatus: 'approved' })
+  folderId = folder._id
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+describe('updateFolderStageStatus', () => {
+  it('should fail when previous stages are incomplete', async () => {
+    await request(app)
+      .put(`/api/folders/${folderId}/stages/${stageId2}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ completed: true })
+      .expect(400)
+  })
+
+  it('should set reviewStatus to pending when not all stages done', async () => {
+    await request(app)
+      .put(`/api/folders/${folderId}/stages/${stageId1}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ completed: true })
+      .expect(200)
+
+    const folder = await Folder.findById(folderId)
+    expect(folder.reviewStatus).toBe('pending')
+  })
+
+  it('should set reviewStatus to approved when all stages done', async () => {
+    await request(app)
+      .put(`/api/folders/${folderId}/stages/${stageId2}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ completed: true })
+      .expect(200)
+
+    const folder = await Folder.findById(folderId)
+    expect(folder.reviewStatus).toBe('approved')
+  })
+})


### PR DESCRIPTION
## Summary
- implement folder review stage model and controller
- expose folder review stage APIs
- auto-approve folder when all stages complete
- update frontend to handle folder review stages
- add unit tests for folder stage updates

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a6f428a88329983764d1a18d55b7