### PR TITLE
顯示資料夾進度

### DIFF
--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -1,11 +1,18 @@
 import api from './api'
 
-export const fetchFolders = (parentId = null, tags = [], type, deep = false) => {
+export const fetchFolders = (
+  parentId = null,
+  tags = [],
+  type,
+  deep = false,
+  withProgress = false
+) => {
   const params = {}
   if (parentId) params.parentId = parentId
   if (tags.length) params.tags = tags
   if (type) params.type = type
   if (deep) params.deep = 'true'
+  if (withProgress) params.progress = 'true'
   return api.get('/folders', { params }).then((res) => res.data)
 }
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -108,6 +108,9 @@
           <div v-if="f.tags?.length" class="tag-list mt-1">
             <el-tag v-for="tag in f.tags" :key="tag" size="small" class="mr-1">{{ tag }}</el-tag>
           </div>
+          <el-tag v-if="f.progress" size="small" class="progress-tag mt-1">
+            {{ f.progress.done }}/{{ f.progress.total }}
+          </el-tag>
         </el-card>
 
         <!-- □□□ Product Card □□□ -->
@@ -131,7 +134,7 @@
           <!-- 顯示進度或價錢等資訊 -->
           <el-scrollbar max-height="60">
             <div class="desc-line">
-              {{ p.progress ? `${p.progress.done}/${p.progress.total} 流程完成` : (p.price ? `RM ${p.price}` : '—') }}
+              {{ p.price ? `RM ${p.price}` : '—' }}
             </div>
           </el-scrollbar>
 
@@ -152,6 +155,9 @@
           <div v-if="f.tags?.length" class="mr-2">
             <el-tag v-for="tag in f.tags" :key="tag" size="small" class="mr-1">{{ tag }}</el-tag>
           </div>
+          <el-tag v-if="f.progress" size="small" class="progress-tag mr-2">
+            {{ f.progress.done }}/{{ f.progress.total }}
+          </el-tag>
           <el-button link size="small" @click="showDetailFor(f, 'folder')">
             <el-icon>
               <InfoFilled />
@@ -356,7 +362,7 @@ async function buildBreadcrumb(folder) {
   return chain
 }
 async function loadData(id = null) {
-  folders.value = await fetchFolders(id, filterTags.value, 'edited')
+  folders.value = await fetchFolders(id, filterTags.value, 'edited', false, true)
   products.value = id ? await fetchProducts(id, filterTags.value, true) : []
   currentFolder.value = id ? await getFolder(id) : null
   breadcrumb.value = currentFolder.value ? await buildBreadcrumb(currentFolder.value) : []
@@ -534,6 +540,11 @@ const docPreviewUrl = a => `https://docs.google.com/gview?embedded=1&url=${encod
 
 .tag-list .el-tag {
   margin-bottom: .25rem;
+}
+
+.progress-tag {
+  font-size: .75rem;
+  line-height: 1.1rem;
 }
 
 :not(.dark) .desc-line,


### PR DESCRIPTION
## Summary
- product card no longer shows process progress
- display progress for folders in cards and list rows
- support folder progress fetching via API
- request folder progress when loading data

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ca394a288329a5d1e4a153ed2d4f