### PR TITLE
Add caching to dashboard summary

### DIFF
--- a/server/src/controllers/dashboard.controller.js
+++ b/server/src/controllers/dashboard.controller.js
@@ -1,8 +1,14 @@
 import Asset from '../models/asset.model.js'
 import ReviewRecord from '../models/reviewRecord.model.js'
 import AdDaily from '../models/adDaily.model.js'
+import { getCache, setCache } from '../utils/cache.js'
 
 export const getSummary = async (req, res) => {
+  const cacheKey = `dashboard:${req.user._id}`
+  const cached = await getCache(cacheKey)
+  if (cached) {
+    return res.json(cached)
+  }
   const assetLimit = 7
   const reviewLimit = 7
 
@@ -60,5 +66,7 @@ export const getSummary = async (req, res) => {
 
   const adSummary = adAgg[0] || { spent: 0, enquiries: 0, reach: 0, impressions: 0, clicks: 0 }
 
-  res.json({ recentAssets, recentReviews, adSummary })
+  const result = { recentAssets, recentReviews, adSummary }
+  await setCache(cacheKey, result, 60)
+  res.json(result)
 }


### PR DESCRIPTION
## Summary
- cache dashboard summary data to reduce database load

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581657a7a48329afbd26c6ffbdcb34