### PR TITLE
新增 Dashboard 素材統計

### DIFF
--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -7,6 +7,7 @@ import api from '../services/api'
 const recentAssets   = ref([])
 const recentReviews  = ref([])
 const adSummary      = ref({})
+const assetStats     = ref({})
 
 /* ===== API 請求 ===== */
 async function fetchDashboard () {
@@ -14,6 +15,7 @@ async function fetchDashboard () {
   recentAssets.value = data.recentAssets
   recentReviews.value = data.recentReviews
   adSummary.value = data.adSummary
+  assetStats.value = data.assetStats
 }
 
 onMounted(fetchDashboard)
@@ -21,6 +23,30 @@ onMounted(fetchDashboard)
 
 <template>
   <h1 class="text-2xl font-bold mb-6">儀表板</h1>
+
+  <!-- === 素材統計 === -->
+  <el-card shadow="hover" class="mb-6">
+    <template #header>
+      <span class="text-lg font-semibold">素材統計</span>
+    </template>
+    <el-row :gutter="20" class="text-center">
+      <el-col :span="4">
+        <div>素材總數<br><b>{{ assetStats.rawTotal || 0 }}</b></div>
+      </el-col>
+      <el-col :span="4">
+        <div>成品總數<br><b>{{ assetStats.editedTotal || 0 }}</b></div>
+      </el-col>
+      <el-col :span="4">
+        <div>待審<br><b>{{ assetStats.pending || 0 }}</b></div>
+      </el-col>
+      <el-col :span="4">
+        <div>通過<br><b>{{ assetStats.approved || 0 }}</b></div>
+      </el-col>
+      <el-col :span="4">
+        <div>退回<br><b>{{ assetStats.rejected || 0 }}</b></div>
+      </el-col>
+    </el-row>
+  </el-card>
 
 
   <!-- === 最近素材上傳 === -->

--- a/server/src/controllers/dashboard.controller.js
+++ b/server/src/controllers/dashboard.controller.js
@@ -60,5 +60,21 @@ export const getSummary = async (req, res) => {
 
   const adSummary = adAgg[0] || { spent: 0, enquiries: 0, reach: 0, impressions: 0, clicks: 0 }
 
-  res.json({ recentAssets, recentReviews, adSummary })
+  // ===== 素材與成品統計 =====
+  const [rawTotal, editedTotal, pending, approved, rejected] = await Promise.all([
+    Asset.countDocuments({ type: 'raw' }),
+    Asset.countDocuments({ type: 'edited' }),
+    Asset.countDocuments({ type: 'edited', reviewStatus: 'pending' }),
+    Asset.countDocuments({ type: 'edited', reviewStatus: 'approved' }),
+    Asset.countDocuments({ type: 'edited', reviewStatus: 'rejected' })
+  ])
+  const assetStats = {
+    rawTotal,
+    editedTotal,
+    pending,
+    approved,
+    rejected
+  }
+
+  res.json({ recentAssets, recentReviews, adSummary, assetStats })
 }


### PR DESCRIPTION
## Summary
- 後端計算素材與成品數量以及待審等統計
- 回傳 `assetStats` 供前端使用
- 儀表板新增區塊顯示統計資訊

## Testing
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858165b4fbc83299c2652f3935d0b9c