### PR TITLE
新增儀表板趨勢 API 與折線圖

### DIFF
--- a/client/src/services/dashboard.js
+++ b/client/src/services/dashboard.js
@@ -1,0 +1,4 @@
+import api from './api'
+
+export const fetchDailyData = days =>
+  api.get('/dashboard/daily', { params: { days } }).then(r => r.data)

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -1,12 +1,34 @@
 <!-- Dashboard.vue -->
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import api from '../services/api'
+import { fetchDailyData } from '../services/dashboard'
+import {
+  Chart,
+  LineController,
+  LineElement,
+  PointElement,
+  LinearScale,
+  Title,
+  CategoryScale
+} from 'chart.js'
+Chart.register(
+  LineController,
+  LineElement,
+  PointElement,
+  LinearScale,
+  Title,
+  CategoryScale
+)
 
 /* ===== 響應式狀態 ===== */
 const recentAssets   = ref([])
 const recentReviews  = ref([])
 const adSummary      = ref({})
+const dailyData      = ref([])
+const days           = ref(7)
+let chartCtx = null
+let chart = null
 
 /* ===== API 請求 ===== */
 async function fetchDashboard () {
@@ -16,7 +38,34 @@ async function fetchDashboard () {
   adSummary.value = data.adSummary
 }
 
+async function fetchDaily () {
+  dailyData.value = await fetchDailyData(days.value)
+  drawChart()
+}
+
+function drawChart () {
+  if (!chartCtx) chartCtx = document.getElementById('daily-chart')
+  if (!chartCtx) return
+  const labels = dailyData.value.map(d => d.date)
+  const metrics = ['spent', 'enquiries', 'reach', 'impressions', 'clicks']
+  const colors = ['#409EFF', '#67C23A', '#E6A23C', '#F56C6C', '#909399']
+  const datasets = metrics.map((m, i) => ({
+    label: m,
+    data: dailyData.value.map(d => d[m] ?? 0),
+    borderColor: colors[i],
+    tension: 0.35
+  }))
+  chart && chart.destroy()
+  chart = new Chart(chartCtx, {
+    type: 'line',
+    data: { labels, datasets },
+    options: { responsive: true, maintainAspectRatio: false }
+  })
+}
+
 onMounted(fetchDashboard)
+onMounted(fetchDaily)
+watch(days, fetchDaily)
 </script>
 
 <template>
@@ -101,6 +150,21 @@ onMounted(fetchDashboard)
         <div>點擊<br><b>{{ adSummary.clicks || 0 }}</b></div>
       </el-col>
     </el-row>
+  </el-card>
+
+  <!-- === 廣告指標趨勢 === -->
+  <el-card shadow="hover" class="mt-6">
+    <template #header>
+      <div class="flex items-center justify-between">
+        <span class="text-lg font-semibold">廣告指標趨勢</span>
+        <el-select v-model="days" size="small" style="width: 100px">
+          <el-option label="近 7 天" :value="7" />
+          <el-option label="近 14 天" :value="14" />
+          <el-option label="近 30 天" :value="30" />
+        </el-select>
+      </div>
+    </template>
+    <canvas id="daily-chart" class="w-full" style="height:300px" />
   </el-card>
 </template>
 

--- a/server/src/routes/dashboard.routes.js
+++ b/server/src/routes/dashboard.routes.js
@@ -1,9 +1,10 @@
 import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
-import { getSummary } from '../controllers/dashboard.controller.js'
+import { getSummary, getDaily } from '../controllers/dashboard.controller.js'
 
 const router = Router()
 router.use(protect)
 router.get('/summary', getSummary)
+router.get('/daily', getDaily)
 
 export default router

--- a/server/tests/dashboard.test.js
+++ b/server/tests/dashboard.test.js
@@ -1,0 +1,67 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import dotenv from 'dotenv'
+
+import dashboardRoutes from '../src/routes/dashboard.routes.js'
+import authRoutes from '../src/routes/auth.routes.js'
+import AdDaily from '../src/models/adDaily.model.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/dashboard', dashboardRoutes)
+
+  const role = await Role.create({ name: 'manager' })
+  await User.create({
+    username: 'admin',
+    password: 'pwd',
+    email: 'admin@test.com',
+    roleId: role._id
+  })
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'admin', password: 'pwd' })
+  token = res.body.token
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+describe('GET /api/dashboard/daily', () => {
+  it('aggregates daily ad data', async () => {
+    const clientId = new mongoose.Types.ObjectId()
+    const platformId = new mongoose.Types.ObjectId()
+    const base = new Date('2024-06-10')
+    for (let i = 0; i < 3; i++) {
+      const d = new Date(base)
+      d.setDate(base.getDate() - i)
+      await AdDaily.create({ clientId, platformId, date: d, spent: i + 1 })
+    }
+
+    const res = await request(app)
+      .get('/api/dashboard/daily?days=5')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(res.body.length).toBe(3)
+    expect(res.body[0].date).toBe('2024-06-08')
+    expect(res.body[2].spent).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- 新增 `GET /api/dashboard/daily` 依天數回傳廣告統計
- 前端 Dashboard 導入 Chart.js 繪製趨勢折線圖
- 新增 `client/src/services/dashboard.js` 供前端呼叫
- 補充 dashboard API 的單元測試

## Testing
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581655dfd88329bbdd0028643d836b