### PR TITLE
Add folderId routing and update libraries

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -12,7 +12,7 @@
     </div>
 
     <!-- ===== 導航選單 ===== -->
-    <el-menu :default-active="route.path" :collapse="isCollapsed" :collapse-transition="false" router
+    <el-menu :default-active="activePath" :collapse="isCollapsed" :collapse-transition="false" router
       class="sidebar__menu" @select="handleSelect" background-color="transparent" text-color="inherit"
       active-text-color="#409EFF">
       <el-menu-item v-for="item in navItems" :key="item.path" :index="item.path">
@@ -59,6 +59,11 @@ const isCollapsed = ref(false)
 const store = useAuthStore()
 const router = useRouter()
 const route = useRoute()
+const activePath = computed(() => {
+  if (route.path.startsWith('/assets')) return '/assets'
+  if (route.path.startsWith('/products')) return '/products'
+  return route.path
+})
 
 /* 全部選單定義 */
 const allMenus = {

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -29,8 +29,8 @@ const routes = [
     children: [
       { path: 'dashboard', name: 'Dashboard', component: Dashboard, meta: { menu: 'dashboard' } },
       { path: 'account', name: 'Account', component: Account, meta: { menu: 'account' } },
-      { path: 'assets', name: 'Assets', component: AssetLibrary, meta: { menu: 'assets' } },
-      { path: 'products', name: 'Products', component: ProductLibrary, meta: { menu: 'products' } },
+      { path: 'assets/:folderId?', name: 'Assets', component: AssetLibrary, meta: { menu: 'assets' } },
+      { path: 'products/:folderId?', name: 'Products', component: ProductLibrary, meta: { menu: 'products' } },
 
       { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { menu: 'employees' } },
       { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { menu: 'roles' } },

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -76,8 +76,10 @@
 
 
       <el-breadcrumb separator="/" class="mb-2" style="font-size: larger;margin: 1rem;">
-        <el-breadcrumb-item v-for="b in breadcrumb" :key="b._id" class="cursor-pointer" @click="loadData(b._id)">{{
-          b.name }}</el-breadcrumb-item>
+        <el-breadcrumb-item v-for="b in breadcrumb" :key="b._id" class="cursor-pointer"
+          @click="router.push({ name: 'Assets', params: { folderId: b._id } })">
+          {{ b.name }}
+        </el-breadcrumb-item>
       </el-breadcrumb>
 
       <!-- 卡片格線 -->
@@ -297,6 +299,7 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers } from '../services/folders'
 import { fetchAssets, uploadAsset, updateAsset, deleteAsset, updateAssetsViewers, getAssetUrl } from '../services/assets'
 import { fetchUsers } from '../services/user'
@@ -312,6 +315,8 @@ const editingFolder = ref(null)
 const viewMode = ref('card')
 
 const store = useAuthStore()
+const router = useRouter()
+const route = useRoute()
 const canManageViewers = computed(
   () => store.hasPermission('asset:update') || store.hasPermission('folder:manage')
 )
@@ -384,14 +389,19 @@ async function loadData(id = null) {
 }
 
 onMounted(() => {
-  loadData()
+  loadData(route.params.folderId || null)
   loadTags()
   if (canManageViewers.value) loadUsers()
 })
 watch(filterTags, () => loadData(currentFolder.value?._id || null))
+watch(() => route.params.folderId, id => loadData(id || null))
 
-function openFolder(f) { loadData(f._id) }
-function goUp() { loadData(currentFolder.value?.parentId || null) }
+function openFolder(f) {
+  router.push({ name: 'Assets', params: { folderId: f._id } })
+}
+function goUp() {
+  router.push({ name: 'Assets', params: { folderId: currentFolder.value?.parentId } })
+}
 
 function openBatchDialog() {
   if (!users.value.length) loadUsers()

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -72,7 +72,8 @@
 
       <!-- □□□ 麵包屑 □□□ -->
       <el-breadcrumb separator="/" class="mb-2" style="font-size:larger; margin:1rem;">
-        <el-breadcrumb-item v-for="b in breadcrumb" :key="b._id" class="cursor-pointer" @click="loadData(b._id)">
+        <el-breadcrumb-item v-for="b in breadcrumb" :key="b._id" class="cursor-pointer"
+          @click="router.push({ name: 'Products', params: { folderId: b._id } })">
           {{ b.name }}
         </el-breadcrumb-item>
       </el-breadcrumb>
@@ -313,6 +314,7 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import {
   fetchFolders, createFolder, updateFolder, getFolder, deleteFolder,
   updateFoldersViewers, reviewFolder, fetchFolderStages, updateFolderStage
@@ -354,6 +356,8 @@ const users = ref([])
 const breadcrumb = ref([])
 
 const store = useAuthStore()
+const router = useRouter()
+const route = useRoute()
 const canReview = computed(() => store.hasPermission('review:manage'))
 const canManageViewers = computed(
   () => store.hasPermission('product:update') || store.hasPermission('folder:manage')
@@ -397,15 +401,18 @@ async function loadData(id = null) {
 
 /* ---------- 監聽 / 初始化 ---------- */
 onMounted(async () => {
-  await loadData()
+  await loadData(route.params.folderId || null)
   await loadTags()
   if (canManageViewers.value) await loadUsers()
 })
 watch(filterTags, () => loadData(currentFolder.value?._id || null))
+watch(() => route.params.folderId, id => loadData(id || null))
 
 /* ---------- 導航 ---------- */
-const openFolder = f => loadData(f._id)
-const goUp = () => loadData(currentFolder.value?.parentId || null)
+const openFolder = f =>
+  router.push({ name: 'Products', params: { folderId: f._id } })
+const goUp = () =>
+  router.push({ name: 'Products', params: { folderId: currentFolder.value?.parentId } })
 
 /* ---------- 批次 ---------- */
 function openBatchDialog() {


### PR DESCRIPTION
## Summary
- handle folder routes in Vue router
- watch folderId param in AssetLibrary and ProductLibrary
- update folder navigation to use router.push
- keep sidebar menu active for asset and product folders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae4184380832991d420b3b67cd1c3