### PR TITLE
Implement redirect after login

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -55,8 +55,13 @@ router.beforeEach((to) => {
   const store = useAuthStore()
   if (to.meta.public) return true // 公開頁面
 
-  // 若尚未登入，導向 login
-  if (!store.isAuthenticated) return '/login'
+  // 若尚未登入，導向 login 並帶上 redirect
+  if (!store.isAuthenticated) {
+    return {
+      path: '/login',
+      query: { redirect: to.fullPath }
+    }
+  }
   const menus = store.user?.menus || []
   if (to.meta.menu && !menus.includes(to.meta.menu)) return '/'
   return true

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -1,17 +1,18 @@
 <script setup>
 import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 
 const username = ref('')
 const password = ref('')
 const router = useRouter()
+const route = useRoute()
 const store = useAuthStore()
 
 const onSubmit = async () => {
   try {
     await store.login(username.value, password.value)
-    router.push('/') // 轉向首頁
+    router.push(route.query.redirect || '/')
   } catch (e) {
     // 已在 api 攔截器 alert
   }


### PR DESCRIPTION
## Summary
- redirect to `login` with `redirect` path for protected routes
- navigate back to original route after successful login

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae419f84883298c15f6190e9a8706