### PR TITLE
Fix weekly note image clearing

### DIFF
--- a/client/src/services/weeklyNotes.js
+++ b/client/src/services/weeklyNotes.js
@@ -22,6 +22,13 @@ export const updateWeeklyNote = (clientId, platformId, week, data) => {
   const formData = new FormData()
   formData.append('text', data.text || '')
   ;(data.images || []).forEach(f => formData.append('images', f))
+  if (Array.isArray(data.keepImages)) {
+    if (data.keepImages.length) {
+      data.keepImages.forEach(i => formData.append('keepImages', i))
+    } else {
+      formData.append('keepImages', '')
+    }
+  }
   return api.put(
     `/clients/${clientId}/platforms/${platformId}/weekly-notes/${week}`,
     formData,


### PR DESCRIPTION
## Summary
- send `keepImages` in `updateWeeklyNote` even when empty

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b75f42d748329aa0dbefb7116c05c