### PR TITLE
Add weekly note image clearing test

### DIFF
--- a/server/src/controllers/weeklyNote.controller.js
+++ b/server/src/controllers/weeklyNote.controller.js
@@ -15,6 +15,12 @@ const uploadImages = async files => {
   return paths
 }
 
+const parseKeepImages = value => {
+  if (value === undefined) return undefined
+  const arr = Array.isArray(value) ? value : [value]
+  return arr.filter(Boolean)
+}
+
 export const createWeeklyNote = async (req, res) => {
   const note = await WeeklyNote.create({
     clientId: req.params.clientId,
@@ -40,8 +46,15 @@ export const updateWeeklyNote = async (req, res) => {
   const update = {
     text: req.body.text
   }
+  const keep = parseKeepImages(req.body.keepImages)
+  let newImages = []
+  if (keep !== undefined) newImages = keep
   if (req.files?.length) {
-    update.images = await uploadImages(req.files)
+    const uploaded = await uploadImages(req.files)
+    newImages = [...newImages, ...uploaded]
+  }
+  if (keep !== undefined || req.files?.length) {
+    update.images = newImages
   }
   const note = await WeeklyNote.findOneAndUpdate(
     {

--- a/server/tests/weeklyNote.test.js
+++ b/server/tests/weeklyNote.test.js
@@ -94,6 +94,27 @@ describe('WeeklyNote API', () => {
     expect(weeks).toContain('2024-W02')
   })
 
+  it('clear images when keepImages empty and no new upload', async () => {
+    const week = '2024-W02'
+    const res = await request(app)
+      .put(
+        `/api/clients/${clientId}/platforms/${platformId}/weekly-notes/${week}`
+      )
+      .set('Authorization', `Bearer ${token}`)
+      .field('text', '')
+      .field('keepImages', '')
+      .expect(200)
+    expect(res.body.images).toEqual([])
+
+    const resG = await request(app)
+      .get(
+        `/api/clients/${clientId}/platforms/${platformId}/weekly-notes/${week}`
+      )
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(resG.body.images).toEqual([])
+  })
+
   it('get signed url for image', async () => {
     const res = await request(app)
       .get(`/api/clients/${clientId}/platforms/${platformId}/weekly-notes/image-url`)


### PR DESCRIPTION
## Summary
- support keepImages when updating weekly notes
- clear images when keepImages is empty
- test weekly note image clearing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b799051cc832993c0f0d8bd77d66d