### PR TITLE
Add colors field for ad-daily

### DIFF
--- a/client/src/services/adDaily.js
+++ b/client/src/services/adDaily.js
@@ -7,7 +7,7 @@ export const fetchDaily = (clientId, platformId) =>
 export const createDaily = (clientId, platformId, data) =>
   api.post(
     `/clients/${clientId}/platforms/${platformId}/ad-daily`,
-    { ...data, extraData: data.extraData || {} }
+    { ...data, extraData: data.extraData || {}, colors: data.colors || {} }
   ).then(r => r.data)
 
 export const fetchWeekly = (clientId, platformId) =>
@@ -27,7 +27,11 @@ export const bulkCreateDaily = async (clientId, platformId, records) => {
   try {
     const res = await api.post(
       `/clients/${clientId}/platforms/${platformId}/ad-daily/bulk`,
-      records.map(r => ({ ...r, extraData: r.extraData || {} }))
+      records.map(r => ({
+        ...r,
+        extraData: r.extraData || {},
+        colors: r.colors || {}
+      }))
     )
     return res.data
   } catch (e) {
@@ -41,7 +45,7 @@ export const updateDaily = (clientId, platformId, id, data) =>
   api
     .put(
       `/clients/${clientId}/platforms/${platformId}/ad-daily/${id}`,
-      data
+      { ...data, colors: data.colors || {} }
     )
     .then(r => r.data)
 

--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -35,10 +35,16 @@
           <el-table-column prop="date" label="日期" :formatter="dateFmt" width="140" />
           <el-table-column v-for="field in customColumns" :key="field.name" :label="field.name">
             <template #default="{ row }">
-              <span v-if="field.type === 'date'">
+              <span
+                v-if="field.type === 'date'"
+                :style="{ backgroundColor: row.colors?.[field.name] }"
+              >
                 {{ formatExtraDate(row.extraData?.[field.name]) }}
               </span>
-              <span v-else>{{ row.extraData?.[field.name] ?? '' }}</span>
+              <span
+                v-else
+                :style="{ backgroundColor: row.colors?.[field.name] }"
+              >{{ row.extraData?.[field.name] ?? '' }}</span>
             </template>
           </el-table-column>
           <el-table-column label="操作" width="160">
@@ -113,13 +119,16 @@
         </el-form-item>
         <!-- 動態欄位輸入 -->
         <el-form-item v-for="field in customColumns" :key="field.name" :label="field.name">
-          <el-date-picker
-            v-if="field.type === 'date'"
-            v-model="recordForm.extraData[field.name]"
-            type="date"
-            style="width:100%"
-          />
-          <el-input v-else v-model="recordForm.extraData[field.name]" />
+          <div class="flex items-center gap-2 w-full">
+            <el-date-picker
+              v-if="field.type === 'date'"
+              v-model="recordForm.extraData[field.name]"
+              type="date"
+              style="flex:1"
+            />
+            <el-input v-else v-model="recordForm.extraData[field.name]" style="flex:1" />
+            <el-color-picker v-model="recordForm.colors[field.name]" />
+          </div>
         </el-form-item>
       </el-form>
       <template #footer>
@@ -238,7 +247,7 @@ const numericColumns = computed(() =>
 
 /**** 每日資料 ****/
 const dailyData = ref([])         // [{ date:'2025-06-16', extraData:{ 花費:100, 詢問:5 } }]
-const recordForm = ref({ date: '', extraData: {} })
+const recordForm = ref({ date: '', extraData: {}, colors: {} })
 
 /* 週備註狀態 */
 const weeklyNotes = ref({})       // { '2025-W25': { week:'2025-W25', text:'...' } }
@@ -384,7 +393,10 @@ watch(activeTab, tab => {
 onMounted(async () => {
   await loadPlatform()
   // 初始化 recordForm.extraData
-  customColumns.value.forEach(f => (recordForm.value.extraData[f.name] = ''))
+  customColumns.value.forEach(f => {
+    recordForm.value.extraData[f.name] = ''
+    recordForm.value.colors[f.name] = ''
+  })
   await loadDaily()
   await loadWeeklyNotes()
 })
@@ -394,7 +406,10 @@ const openCreateDialog = () => {
   editing.value = false
   editingId.value = ''
   recordForm.value.date = ''
-  customColumns.value.forEach(f => (recordForm.value.extraData[f.name] = ''))
+  customColumns.value.forEach(f => {
+    recordForm.value.extraData[f.name] = ''
+    recordForm.value.colors[f.name] = ''
+  })
   dialogVisible.value = true
 }
 
@@ -422,6 +437,7 @@ const openEdit = row => {
   editingId.value = row._id
   recordForm.value.date = row.date
   recordForm.value.extraData = { ...row.extraData }
+  recordForm.value.colors = { ...row.colors }
   dialogVisible.value = true
 }
 
@@ -475,12 +491,16 @@ const parseCSV = file => new Promise((res, rej) => {
 const normalize = arr => {
   return arr.map(r => {
     const extraData = {}
+    const colors = {}
     customColumns.value.forEach(col => {
       const val = r[col.name] || ''
       if (col.type === 'number') extraData[col.name] = Number(val) || 0
       else extraData[col.name] = val
+      if (r[`color_${col.name}`]) colors[col.name] = r[`color_${col.name}`]
     })
-    return { date: r['日期'] || r.date || '', extraData }
+    const obj = { date: r['日期'] || r.date || '', extraData }
+    if (Object.keys(colors).length) obj.colors = colors
+    return obj
   }).filter(r => r.date)
 }
 
@@ -492,6 +512,9 @@ const exportDaily = () => {
     customColumns.value.forEach(col => {
       const val = r.extraData[col.name]
       row[col.name] = col.type === 'date' ? formatExtraDate(val) : (val ?? '')
+      if (r.colors && r.colors[col.name]) {
+        row[`color_${col.name}`] = r.colors[col.name]
+      }
     })
     return row
   })

--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -28,7 +28,8 @@ export const createAdDaily = async (req, res) => {
     clicks: sanitizeNumber(req.body.clicks),
     clientId: req.params.clientId,
     platformId: req.params.platformId,
-    extraData: sanitizeExtraData(req.body.extraData)
+    extraData: sanitizeExtraData(req.body.extraData),
+    colors: req.body.colors || {}
   }
   const rec = await AdDaily.findOneAndUpdate(
     { clientId: payload.clientId, platformId: payload.platformId, date: payload.date },
@@ -86,7 +87,7 @@ export const bulkCreateAdDaily = async (req, res) => {
     return res.status(400).json({ message: '資料格式錯誤' })
   }
 
-  const known = ['date', 'spent', 'enquiries', 'reach', 'impressions', 'clicks', 'extraData']
+  const known = ['date', 'spent', 'enquiries', 'reach', 'impressions', 'clicks', 'extraData', 'colors']
 
   const records = req.body
     .map(row => {
@@ -105,7 +106,8 @@ export const bulkCreateAdDaily = async (req, res) => {
         clicks: sanitizeNumber(row.clicks),
         clientId: req.params.clientId,
         platformId: req.params.platformId,
-        extraData: Object.keys(extra).length ? extra : undefined
+        extraData: Object.keys(extra).length ? extra : undefined,
+        colors: row.colors || undefined
       }
     })
     .filter(r => r.date)
@@ -147,7 +149,8 @@ export const importAdDaily = async (req, res) => {
     'reach', 'Reach', '觸及',
     'impressions', 'Impressions', '曝光',
     'clicks', 'Clicks', '點擊',
-    'extraData'
+    'extraData',
+    'colors'
   ]
 
   const records = rows
@@ -168,7 +171,8 @@ export const importAdDaily = async (req, res) => {
         clicks: sanitizeNumber(row.clicks || row.Clicks || row['點擊']),
         clientId: req.params.clientId,
         platformId: req.params.platformId,
-        extraData: Object.keys(extra).length ? extra : undefined
+        extraData: Object.keys(extra).length ? extra : undefined,
+        colors: row.colors || undefined
       }
     })
     .filter(r => r.date)
@@ -194,7 +198,8 @@ export const updateAdDaily = async (req, res) => {
       reach: sanitizeNumber(req.body.reach),
       impressions: sanitizeNumber(req.body.impressions),
       clicks: sanitizeNumber(req.body.clicks),
-      extraData: sanitizeExtraData(req.body.extraData)
+      extraData: sanitizeExtraData(req.body.extraData),
+      colors: req.body.colors || {}
     },
     { new: true }
   )

--- a/server/src/models/adDaily.model.js
+++ b/server/src/models/adDaily.model.js
@@ -10,7 +10,8 @@ const adDailySchema = new mongoose.Schema(
     reach: { type: Number, default: 0 },
     impressions: { type: Number, default: 0 },
     clicks: { type: Number, default: 0 },
-    extraData: { type: mongoose.Schema.Types.Mixed }
+    extraData: { type: mongoose.Schema.Types.Mixed },
+    colors: { type: mongoose.Schema.Types.Mixed, default: {} }
   },
   { timestamps: true }
 )

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -122,6 +122,26 @@ describe('Client and AdDaily', () => {
     expect(list.body[0].extraData).toEqual({ metricA: 10, metricB: 5 })
   })
 
+  it('create adDaily with colors and update it', async () => {
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        date: new Date('2024-04-02').toISOString(),
+        colors: { metricA: '#fff' }
+      })
+      .expect(201)
+    expect(res.body.colors).toEqual({ metricA: '#fff' })
+
+    const id = res.body._id
+    const updated = await request(app)
+      .put(`/api/clients/${clientId}/platforms/${platformId}/ad-daily/${id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ colors: { metricA: '#000' } })
+      .expect(200)
+    expect(updated.body.colors).toEqual({ metricA: '#000' })
+  })
+
   it('bulk create adDaily', async () => {
     const records = [
       { date: new Date('2024-03-01').toISOString(), spent: 5, extraData: { metric: '1' } },


### PR DESCRIPTION
## Summary
- support `colors` property in ad-daily model and controller
- allow colors in ad-daily API services
- add color options in AdData view and display colored cells
- keep colors when importing/exporting
- test color handling in ad-daily controller

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba52515948329bbc7841abda31feb