### PR TITLE
Fix currency string parsing in ad data

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -515,13 +515,16 @@ const parseCSV = file => new Promise((res, rej) => {
   })
 })
 
+const sanitizeNumber = val =>
+  parseFloat(String(val).replace(/[^\d.]/g, '')) || 0
+
 const normalize = arr => {
   return arr.map(r => {
     const extraData = {}
     const colors = {}
     customColumns.value.forEach(col => {
       const val = r[col.name] || ''
-      if (col.type === 'number') extraData[col.name] = Number(val) || 0
+      if (col.type === 'number') extraData[col.name] = sanitizeNumber(val)
       else extraData[col.name] = val
       if (r[`color_${col.name}`]) colors[col.name] = r[`color_${col.name}`]
     })

--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -6,7 +6,8 @@ import { uploadBuffer } from '../utils/gcs.js'
 const sanitizeNumber = val =>
   parseFloat(String(val).replace(/[^\d.]/g, '')) || 0
 
-const numericPattern = /^[\d\s,.$]+$/
+// accepts optional currency prefix like RM or USD
+const numericPattern = /^[^\d-]*[\d\s,.$]+$/
 const sanitizeExtraData = obj => {
   const result = {}
   if (!obj) return result

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -122,6 +122,24 @@ describe('Client and AdDaily', () => {
     expect(list.body[0].extraData).toEqual({ metricA: 10, metricB: 5 })
   })
 
+  it('create adDaily with currency prefix in extraData', async () => {
+    const date = new Date('2024-04-03').toISOString()
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ date, extraData: { cost: 'RM500.12' } })
+      .expect(201)
+    expect(res.body.extraData).toEqual({ cost: 500.12 })
+
+    const list = await request(app)
+      .get(
+        `/api/clients/${clientId}/platforms/${platformId}/ad-daily?start=${date}&end=${date}`
+      )
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(list.body[0].extraData).toEqual({ cost: 500.12 })
+  })
+
   it('create adDaily with colors and update it', async () => {
     const res = await request(app)
       .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)


### PR DESCRIPTION
## Summary
- support currency prefixes like `RM` when sanitizing numbers
- parse numbers with prefixes when importing daily ad data
- test extraData with currency prefix values

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cecb4f564832986dcc086a911556a