### PR TITLE
Add global upload snackbar

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,7 +1,8 @@
 <script setup>
-
+import UploadSnackbar from './components/UploadSnackbar.vue'
 </script>
 
 <template>
   <router-view />
+  <UploadSnackbar />
 </template>

--- a/client/src/components/UploadSnackbar.vue
+++ b/client/src/components/UploadSnackbar.vue
@@ -1,0 +1,35 @@
+<template>
+  <transition name="slide-up">
+    <div v-if="ui.uploading > 0" class="snackbar">
+      正在上傳中...
+    </div>
+  </transition>
+</template>
+
+<script setup>
+import { useUiStore } from '../stores/ui'
+const ui = useUiStore()
+</script>
+
+<style scoped>
+.snackbar {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 16px;
+  background: rgba(55, 65, 81, 0.9);
+  color: #fff;
+  border-radius: 4px;
+  z-index: 5000;
+}
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition: all .3s ease;
+}
+.slide-up-enter-from,
+.slide-up-leave-to {
+  opacity: 0;
+  transform: translateY(20px);
+}
+</style>

--- a/client/src/stores/ui.js
+++ b/client/src/stores/ui.js
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia'
+
+export const useUiStore = defineStore('ui', {
+  state: () => ({
+    uploading: 0
+  }),
+  actions: {
+    startUpload() {
+      this.uploading++
+    },
+    finishUpload() {
+      if (this.uploading > 0) this.uploading--
+    }
+  }
+})

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -26,7 +26,7 @@
           </div>
 
           <!-- 上傳檔案 -->
-          <el-upload v-if="currentFolder" :http-request="uploadRequest" :on-progress="handleProgress"
+          <el-upload v-if="currentFolder" multiple :http-request="uploadRequest" :on-progress="handleProgress"
             :on-success="handleSuccess" :on-error="handleError" :show-file-list="false">
             <el-button type="success">
               <el-icon class="mr-1">
@@ -305,6 +305,7 @@ import { fetchAssets, uploadAsset, updateAsset, deleteAsset, updateAssetsViewers
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
 import { useAuthStore } from '../stores/auth'
+import { useUiStore } from '../stores/ui'
 import { ElMessage } from 'element-plus'
 import { ArrowLeft, Plus, UploadFilled, Grid, Menu, UserFilled, InfoFilled } from '@element-plus/icons-vue'
 
@@ -315,6 +316,7 @@ const editingFolder = ref(null)
 const viewMode = ref('card')
 
 const store = useAuthStore()
+const ui = useUiStore()
 const router = useRouter()
 const route = useRoute()
 const canManageViewers = computed(
@@ -513,11 +515,14 @@ function handleError(_, file) {
 
 
 async function uploadRequest({ file, onProgress, onSuccess, onError }) {
+  ui.startUpload()
   try {
     await uploadAsset(file, currentFolder.value?._id, null, onProgress)
     onSuccess()
   } catch (e) {
     onError(e)
+  } finally {
+    ui.finishUpload()
   }
 }
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -26,7 +26,7 @@
           </div>
 
           <!-- 上傳（產品主圖等資源） -->
-          <el-upload v-if="currentFolder" :http-request="uploadRequest" :on-progress="handleProgress"
+          <el-upload v-if="currentFolder" multiple :http-request="uploadRequest" :on-progress="handleProgress"
             :on-success="handleSuccess" :on-error="handleError" :show-file-list="false">
             <el-button type="success">
               <el-icon class="mr-1">
@@ -326,6 +326,7 @@ import {
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
 import { useAuthStore } from '../stores/auth'
+import { useUiStore } from '../stores/ui'
 import { ElMessage } from 'element-plus'
 import {
   ArrowLeft, Plus, UploadFilled, Grid, Menu, UserFilled, InfoFilled
@@ -356,6 +357,7 @@ const users = ref([])
 const breadcrumb = ref([])
 
 const store = useAuthStore()
+const ui = useUiStore()
 const router = useRouter()
 const route = useRoute()
 const canReview = computed(() => store.hasPermission('review:manage'))
@@ -525,10 +527,15 @@ const handleProgress = (evt, f) => progressList.value[f.uid] = Math.round(evt.pe
 const handleSuccess = (_, f) => { progressList.value[f.uid] = 100; setTimeout(() => delete progressList.value[f.uid], 500); ElMessage.success('上傳完成'); loadData(currentFolder.value?._id) }
 const handleError = (_, f) => delete progressList.value[f.uid]
 async function uploadRequest({ file, onProgress, onSuccess, onError }) {
+  ui.startUpload()
   try {
     await uploadProduct(file, currentFolder.value?._id, onProgress)
     onSuccess()
-  } catch (e) { onError(e) }
+  } catch (e) {
+    onError(e)
+  } finally {
+    ui.finishUpload()
+  }
 }
 
 /* ---------- 預覽 / 下載 ---------- */


### PR DESCRIPTION
## Summary
- show upload snackbar while files are uploading
- allow batch uploads in asset and product libraries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df0938b2c832988e7eb9654e9c446