### PR TITLE
Fix currency string parsing in ad data

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -515,13 +515,16 @@ const parseCSV = file => new Promise((res, rej) => {
   })
 })
 
+const sanitizeNumber = val =>
+  parseFloat(String(val).replace(/[^\d.]/g, '')) || 0
+
 const normalize = arr => {
   return arr.map(r => {
     const extraData = {}
     const colors = {}
     customColumns.value.forEach(col => {
       const val = r[col.name] || ''
-      if (col.type === 'number') extraData[col.name] = Number(val) || 0
+      if (col.type === 'number') extraData[col.name] = sanitizeNumber(val)
       else extraData[col.name] = val
       if (r[`color_${col.name}`]) colors[col.name] = r[`color_${col.name}`]
     })

--- a/server/README.md
+++ b/server/README.md
@@ -11,6 +11,8 @@ npm start                 # 啟動伺服器
 伺服器啟動前請在根目錄複製 `.env.example` 為 `.env`，並填入 MongoDB、JWT 及 GCS 設定。
 
 執行 `npm run seed` 可建立預設帳號，方便初次測試。
+若舊有廣告資料含有 "RM" 前綴的數字字串，可執行
+`npm run sanitize-ad-daily` 將其批次轉為數字。
 
 預設登入資訊如下：
 

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "test": "jest --experimental-vm-modules",
-    "seed": "node src/scripts/seedUsers.js"
+    "seed": "node src/scripts/seedUsers.js",
+    "sanitize-ad-daily": "node src/scripts/sanitizeAdDaily.js"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.16.0",

--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -6,7 +6,8 @@ import { uploadBuffer } from '../utils/gcs.js'
 const sanitizeNumber = val =>
   parseFloat(String(val).replace(/[^\d.]/g, '')) || 0
 
-const numericPattern = /^[\d\s,.$]+$/
+// accepts optional currency prefix like RM or USD
+const numericPattern = /^[^\d-]*[\d\s,.$]+$/
 const sanitizeExtraData = obj => {
   const result = {}
   if (!obj) return result

--- a/server/src/scripts/sanitizeAdDaily.js
+++ b/server/src/scripts/sanitizeAdDaily.js
@@ -1,0 +1,63 @@
+import dotenv from 'dotenv'
+import mongoose from 'mongoose'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import AdDaily from '../models/adDaily.model.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+
+const sanitizeNumber = val =>
+  parseFloat(String(val).replace(/[^\d.]/g, '')) || 0
+
+const numericPattern = /^[^\d-]*[\d\s,.$]+$/
+const sanitizeExtraData = obj => {
+  const result = {}
+  if (!obj) return result
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v === 'number') result[k] = v
+    else if (numericPattern.test(String(v))) result[k] = sanitizeNumber(v)
+    else result[k] = v
+  }
+  return result
+}
+
+const run = async () => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI)
+    console.log('✅ MongoDB 已連線')
+
+    const cursor = AdDaily.find().cursor()
+    for await (const doc of cursor) {
+      let updated = false
+      for (const field of [
+        'spent',
+        'enquiries',
+        'reach',
+        'impressions',
+        'clicks'
+      ]) {
+        const val = doc[field]
+        if (typeof val === 'string' && numericPattern.test(val)) {
+          doc[field] = sanitizeNumber(val)
+          updated = true
+        }
+      }
+
+      const extra = sanitizeExtraData(doc.extraData)
+      if (JSON.stringify(extra) !== JSON.stringify(doc.extraData)) {
+        doc.extraData = extra
+        updated = true
+      }
+
+      if (updated) await doc.save()
+    }
+    console.log('🍺 整理完成')
+  } catch (err) {
+    console.error('❌ 處理失敗：', err.message)
+  } finally {
+    await mongoose.disconnect()
+  }
+}
+
+run()

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -122,6 +122,24 @@ describe('Client and AdDaily', () => {
     expect(list.body[0].extraData).toEqual({ metricA: 10, metricB: 5 })
   })
 
+  it('create adDaily with currency prefix in extraData', async () => {
+    const date = new Date('2024-04-03').toISOString()
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ date, extraData: { cost: 'RM500.12' } })
+      .expect(201)
+    expect(res.body.extraData).toEqual({ cost: 500.12 })
+
+    const list = await request(app)
+      .get(
+        `/api/clients/${clientId}/platforms/${platformId}/ad-daily?start=${date}&end=${date}`
+      )
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(list.body[0].extraData).toEqual({ cost: 500.12 })
+  })
+
   it('create adDaily with colors and update it', async () => {
     const res = await request(app)
       .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)


### PR DESCRIPTION
## Summary
- support currency prefixes like `RM` when sanitizing numbers
- parse numbers with prefixes when importing daily ad data
- test extraData with currency prefix values
- add script to sanitize existing adDaily records

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cecb4f564832986dcc086a911556a