### PR TITLE
Add disk storage uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ JWT_EXPIRES_IN=7d
 # 伺服器監聽埠
 PORT=3000
 
-# 檔案上傳資料夾（自動建立）
+# 檔案上傳暫存資料夾（預設 /tmp/uploads，會自動建立）
 UPLOAD_DIR=uploads
 
 # Google Cloud Storage 設定

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@
 
  ```bash
  GCS_PROJECT_ID=你的專案 ID
- GCS_BUCKET=你的 Bucket 名稱
- GCS_KEY_FILE=service-account.json 路徑
- ```
+GCS_BUCKET=你的 Bucket 名稱
+GCS_KEY_FILE=service-account.json 路徑
+```
+
+此外，可透過 `UPLOAD_DIR` 指定暫存上傳檔案的資料夾，預設為 `/tmp/uploads`。
 
  如未建立過 Bucket，可至 Google Cloud Console：
  1. 建立專案並啟用 **Cloud Storage**。

--- a/server/README.md
+++ b/server/README.md
@@ -10,6 +10,8 @@ npm start                 # 啟動伺服器
 
 伺服器啟動前請在根目錄複製 `.env.example` 為 `.env`，並填入 MongoDB、JWT 及 GCS 設定。
 
+`.env` 中的 `UPLOAD_DIR` 可指定暫存上傳檔案的資料夾，預設值為 `/tmp/uploads`。
+
 執行 `npm run seed` 可建立預設帳號，方便初次測試。
 若舊有廣告資料含有 "RM" 前綴的數字字串，可執行
 `npm run sanitize-ad-daily` 將其批次轉為數字。

--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose'
 import AdDaily from '../models/adDaily.model.js'
 import path from 'node:path'
-import { uploadStream } from '../utils/gcs.js'
+import { uploadFile } from '../utils/gcs.js'
 import fs from 'node:fs/promises'
 
 const sanitizeNumber = val =>
@@ -133,7 +133,7 @@ export const importAdDaily = async (req, res) => {
   const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
   const ext = path.extname(req.file.originalname)
   const filename = unique + ext
-  const filePath = await uploadStream(
+  const filePath = await uploadFile(
     req.file.path,
     filename,
     req.file.mimetype

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -6,7 +6,7 @@ import Folder from '../models/folder.model.js'
 import ReviewStage from '../models/reviewStage.model.js'
 import ReviewRecord from '../models/reviewRecord.model.js'
 import path from 'node:path'
-import { uploadStream, getSignedUrl } from '../utils/gcs.js'
+import { uploadFile as gcsUploadFile, getSignedUrl } from '../utils/gcs.js'
 import fs from 'node:fs/promises'
 import { getDescendantFolderIds, getAncestorFolderIds, getRootFolder } from '../utils/folderTree.js'
 import { includeManagers } from '../utils/includeManagers.js'
@@ -35,8 +35,9 @@ export const uploadFile = async (req, res) => {
   const ext = path.extname(req.file.originalname)
   const filename = unique + ext
 
-  // ✅ 使用記憶體 buffer 串流上傳到 GCS（不落地磁碟）
-  const gcsPath = await uploadStream(req.file.buffer, filename, req.file.mimetype)
+  // 將暫存檔案串流上傳至 GCS
+  const gcsPath = await gcsUploadFile(req.file.path, filename, req.file.mimetype)
+  await fs.unlink(req.file.path)
 
   // ➤ 檔案權限與 folder 設定
   let baseUsers = []

--- a/server/src/controllers/weeklyNote.controller.js
+++ b/server/src/controllers/weeklyNote.controller.js
@@ -1,6 +1,6 @@
 import WeeklyNote from '../models/weeklyNote.model.js'
 import path from 'node:path'
-import { uploadStream, getSignedUrl } from '../utils/gcs.js'
+import { uploadFile, getSignedUrl } from '../utils/gcs.js'
 import fs from 'node:fs/promises'
 
 const uploadImages = async files => {
@@ -10,7 +10,7 @@ const uploadImages = async files => {
       const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
       const ext = path.extname(f.originalname)
       const filename = unique + ext
-      const p = await uploadStream(f.path, filename, f.mimetype)
+      const p = await uploadFile(f.path, filename, f.mimetype)
       await fs.unlink(f.path)
       return p
     })

--- a/server/src/middleware/upload.js
+++ b/server/src/middleware/upload.js
@@ -1,8 +1,13 @@
 /**
- * 檔案上傳設定（使用 memoryStorage 串流不落地）
+ * 檔案上傳設定（使用 diskStorage 暫存檔案）
  */
 import multer from 'multer'
+import fs from 'node:fs'
+
+const uploadDir = process.env.UPLOAD_DIR || '/tmp/uploads'
+fs.mkdirSync(uploadDir, { recursive: true })
 
 export const upload = multer({
-  storage: multer.memoryStorage(),       // ✅ 改為記憶體儲存，不寫磁碟  
+  storage: multer.diskStorage({ destination: uploadDir }),
+  limits: { fileSize: 10 * 1024 * 1024 } // 限制檔案大小為 10MB
 })

--- a/server/src/utils/gcs.js
+++ b/server/src/utils/gcs.js
@@ -2,6 +2,7 @@ import { Storage } from '@google-cloud/storage'
 import path from 'node:path'
 import dotenv from 'dotenv'
 import { fileURLToPath } from 'node:url'
+import fs from 'node:fs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 dotenv.config({ path: path.resolve(__dirname, '../../.env') })
@@ -27,6 +28,24 @@ export const uploadStream = (buffer, destination, contentType) => {
     stream.on('error', reject)
     stream.on('finish', () => resolve(destination))
     stream.end(buffer)
+  })
+}
+
+/**
+ * 直接將檔案路徑內容串流寫入 GCS
+ */
+export const uploadFile = (filePath, destination, contentType) => {
+  return new Promise((resolve, reject) => {
+    const file = bucket.file(destination)
+    const stream = file.createWriteStream({
+      resumable: false,
+      metadata: { contentType }
+    })
+    fs.createReadStream(filePath)
+      .on('error', reject)
+      .pipe(stream)
+      .on('error', reject)
+      .on('finish', () => resolve(destination))
   })
 }
 


### PR DESCRIPTION
## Summary
- store uploads on disk with a 10MB limit
- add uploadFile helper for piping file streams to GCS
- update controllers to use disk-based uploading
- document UPLOAD_DIR usage and default value

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix server install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686f68fba8dc83298dff9c114049f341