### PR TITLE
Implement upload progress tracking

### DIFF
--- a/client/src/components/UploadSnackbar.vue
+++ b/client/src/components/UploadSnackbar.vue
@@ -1,7 +1,12 @@
 <template>
   <transition name="slide-up">
-    <div v-if="ui.uploading > 0" class="snackbar">
-      正在上傳中...
+    <div v-if="Object.keys(ui.uploads).length" class="snackbar">
+      <div v-for="(u, id) in ui.uploads" :key="id" class="item">
+        <span class="name">{{ u.name }}</span>
+        <div class="progress">
+          <div class="bar" :style="{ width: u.percent + '%' }"></div>
+        </div>
+      </div>
     </div>
   </transition>
 </template>
@@ -22,6 +27,29 @@ const ui = useUiStore()
   color: #fff;
   border-radius: 4px;
   z-index: 5000;
+}
+.item {
+  margin-bottom: 4px;
+}
+.name {
+  display: block;
+  font-size: 0.875rem;
+  margin-bottom: 2px;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.progress {
+  width: 200px;
+  height: 4px;
+  background: rgba(255,255,255,0.3);
+  border-radius: 2px;
+}
+.bar {
+  height: 100%;
+  background: #4ade80;
+  border-radius: 2px;
 }
 .slide-up-enter-active,
 .slide-up-leave-active {

--- a/client/src/stores/ui.js
+++ b/client/src/stores/ui.js
@@ -2,14 +2,17 @@ import { defineStore } from 'pinia'
 
 export const useUiStore = defineStore('ui', {
   state: () => ({
-    uploading: 0
+    uploads: {}
   }),
   actions: {
-    startUpload() {
-      this.uploading++
+    startUpload(uid, name) {
+      this.uploads[uid] = { name, percent: 0 }
     },
-    finishUpload() {
-      if (this.uploading > 0) this.uploading--
+    updateUpload(uid, percent) {
+      if (this.uploads[uid]) this.uploads[uid].percent = percent
+    },
+    finishUpload(uid) {
+      delete this.uploads[uid]
     }
   }
 })

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -496,33 +496,29 @@ async function createNewFolder() {
   loadData(currentFolder.value?._id)
 }
 
-const progressList = ref({})
-
 function handleProgress(evt, file) {
-  progressList.value[file.uid] = Math.round(evt.percent)
+  ui.updateUpload(file.uid, Math.round(evt.percent))
 }
 
 function handleSuccess(_, file) {
-  progressList.value[file.uid] = 100
-  setTimeout(() => delete progressList.value[file.uid], 500)
+  ui.updateUpload(file.uid, 100)
+  setTimeout(() => ui.finishUpload(file.uid), 500)
   ElMessage.success('上傳完成')
   loadData(currentFolder.value?._id)
 }
 
 function handleError(_, file) {
-  delete progressList.value[file.uid]
+  ui.finishUpload(file.uid)
 }
 
 
 async function uploadRequest({ file, onProgress, onSuccess, onError }) {
-  ui.startUpload()
+  ui.startUpload(file.uid, file.name)
   try {
     await uploadAsset(file, currentFolder.value?._id, null, onProgress)
     onSuccess()
   } catch (e) {
     onError(e)
-  } finally {
-    ui.finishUpload()
   }
 }
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -522,19 +522,16 @@ async function createNewFolder() {
 }
 
 /* ---------- 上傳 ---------- */
-const progressList = ref({})
-const handleProgress = (evt, f) => progressList.value[f.uid] = Math.round(evt.percent)
-const handleSuccess = (_, f) => { progressList.value[f.uid] = 100; setTimeout(() => delete progressList.value[f.uid], 500); ElMessage.success('上傳完成'); loadData(currentFolder.value?._id) }
-const handleError = (_, f) => delete progressList.value[f.uid]
+const handleProgress = (evt, f) => ui.updateUpload(f.uid, Math.round(evt.percent))
+const handleSuccess = (_, f) => { ui.updateUpload(f.uid, 100); setTimeout(() => ui.finishUpload(f.uid), 500); ElMessage.success('上傳完成'); loadData(currentFolder.value?._id) }
+const handleError = (_, f) => ui.finishUpload(f.uid)
 async function uploadRequest({ file, onProgress, onSuccess, onError }) {
-  ui.startUpload()
+  ui.startUpload(file.uid, file.name)
   try {
     await uploadProduct(file, currentFolder.value?._id, onProgress)
     onSuccess()
   } catch (e) {
     onError(e)
-  } finally {
-    ui.finishUpload()
   }
 }
 


### PR DESCRIPTION
## Summary
- manage uploads with per-file percent info in `ui` store
- update AssetLibrary and ProductLibrary upload handlers to use new actions
- show progress in UploadSnackbar for each file

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a3e8c1cc8329bac5a9767eb71342