### PR TITLE
Add asset creation endpoint

### DIFF
--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -13,7 +13,8 @@ import {
     reviewAsset,
     updateAssetsViewers,
     getAssetSignedUrl,
-    presign
+    presign,
+    createAsset
 } from '../controllers/asset.controller.js'
 import {
   getAssetStages,
@@ -35,6 +36,7 @@ router.post(
   requirePerm(PERMISSIONS.ASSET_CREATE),
   presign
 )
+router.post('/', protect, requirePerm(PERMISSIONS.ASSET_CREATE), createAsset)
 router.get('/', protect, requirePerm(PERMISSIONS.ASSET_READ), getAssets)
 router.post(
   '/:id/comment',

--- a/server/tests/asset.test.js
+++ b/server/tests/asset.test.js
@@ -32,7 +32,7 @@ beforeAll(async () => {
   app.use('/api/auth', authRoutes)
   app.use('/api/assets', assetRoutes)
 
-  const managerRole = await Role.create({ name: 'manager', permissions: ['review:manage', 'asset:read'] })
+  const managerRole = await Role.create({ name: 'manager', permissions: ['review:manage', 'asset:read', 'asset:create'] })
   const empRole = await Role.create({ name: 'employee', permissions: ['asset:read'] })
 
   const admin = await User.create({
@@ -148,6 +148,19 @@ describe('Asset signed url', () => {
       .set('Authorization', `Bearer ${token}`)
       .expect(200)
     expect(res.body.url).toMatch(/^https?:\/\/.*file\.mp4/)
+  })
+})
+
+describe('Create asset record', () => {
+  it('should create asset with path', async () => {
+    const res = await request(app)
+      .post('/api/assets')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ filename: 'big.mp4', path: '/tmp/big.mp4' })
+      .expect(201)
+    expect(res.body.filename).toBe('big.mp4')
+    const exist = await Asset.findById(res.body._id)
+    expect(exist).not.toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary
- add POST /api/assets to store large upload metadata
- wire up asset creation route
- adjust asset tests for create permission
- test creating asset record

## Testing
- `npm --prefix server test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776b2934508329913f10dfffc791c4