### PR TITLE
更新載入函式以清空資料

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -431,6 +431,8 @@ const detailTitle = computed(() =>
     : currentFolder.value?.name || '資訊')
 
 async function loadData(id = null) {
+  folders.value = []
+  assets.value = []
   folders.value = await fetchFolders(id, filterTags.value, 'raw')
   assets.value = id ? await fetchAssets(id, 'raw', filterTags.value) : []
   currentFolder.value = id ? await getFolder(id) : null

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -445,6 +445,8 @@ async function buildBreadcrumb(folder) {
   return chain
 }
 async function loadData(id = null) {
+  folders.value = []
+  products.value = []
   folders.value = await fetchFolders(id, filterTags.value, 'edited', false, true)
   products.value = id ? await fetchProducts(id, filterTags.value) : []
   currentFolder.value = id ? await getFolder(id) : null


### PR DESCRIPTION
## Summary
- 於 AssetLibrary 與 ProductLibrary 的 `loadData()` 開頭先清空 `folders` 與對應項目
- 避免畫面殘留先前資料

## Testing
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877810ba7c883299a5b08f7ac5bce8c