### PR TITLE
Implement upload error tracking

### DIFF
--- a/client/src/components/UploadSnackbar.vue
+++ b/client/src/components/UploadSnackbar.vue
@@ -4,7 +4,7 @@
       <div v-for="(u, id) in ui.uploads" :key="id" class="item">
         <span class="name">{{ u.name }}</span>
         <div class="progress">
-          <div class="bar" :style="{ width: u.percent + '%' }"></div>
+          <div class="bar" :class="{ error: u.error }" :style="{ width: u.percent + '%' }"></div>
         </div>
       </div>
     </div>
@@ -50,6 +50,9 @@ const ui = useUiStore()
   height: 100%;
   background: #4ade80;
   border-radius: 2px;
+}
+.bar.error {
+  background: #f87171;
 }
 .slide-up-enter-active,
 .slide-up-leave-active {

--- a/client/src/stores/ui.js
+++ b/client/src/stores/ui.js
@@ -6,7 +6,7 @@ export const useUiStore = defineStore('ui', {
   }),
   actions: {
     startUpload(uid, name) {
-      this.uploads[uid] = { name, percent: 0 }
+      this.uploads[uid] = { name, percent: 0, error: false }
     },
     updateUpload(uid, percent) {
       if (this.uploads[uid]) this.uploads[uid].percent = percent

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -555,7 +555,8 @@ function handleSuccess(_, file) {
 }
 
 function handleError(_, file) {
-  ui.finishUpload(file.uid)
+  ui.uploads[file.uid].error = true
+  ElMessage.error(`檔案 ${file.name} 上傳失敗`)
 }
 
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -572,7 +572,10 @@ async function createNewFolder() {
 /* ---------- 上傳 ---------- */
 const handleProgress = (evt, f) => ui.updateUpload(f.uid, Math.round(evt.percent))
 const handleSuccess = (_, f) => { ui.updateUpload(f.uid, 100); setTimeout(() => ui.finishUpload(f.uid), 500); ElMessage.success('上傳完成'); loadData(currentFolder.value?._id) }
-const handleError = (_, f) => ui.finishUpload(f.uid)
+const handleError = (_, f) => {
+  ui.uploads[f.uid].error = true
+  ElMessage.error(`檔案 ${f.name} 上傳失敗`)
+}
 async function uploadRequest({ file, onProgress, onSuccess, onError }) {
   ui.startUpload(file.uid, file.name)
   try {


### PR DESCRIPTION
## Summary
- add `error` flag in ui store uploads
- show red progress bar if upload failed
- mark failed uploads in AssetLibrary and ProductLibrary

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687785e3bcf883299ea4369f26f43909