### PR TITLE
Add public batch download endpoint

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -1,4 +1,5 @@
 import api from './api'
+import Cookies from 'js-cookie'
 
 
 export const fetchAssets = (folderId, type, tags = [], deep = false) => {
@@ -129,8 +130,12 @@ export const getAssetUrl = (id, download = false) =>
     .get(`/assets/${id}/url`, { params: download ? { download: 1 } : {} })
     .then(res => res.data.url)
 
-export const batchDownloadAssets = ids =>
-  api.post('/assets/batch-download', { ids }).then(res => res.data.url)
+export const batchDownloadAssets = ids => {
+  const url = Cookies.get('token')
+    ? '/assets/batch-download'
+    : '/public/assets/batch-download'
+  return api.post(url, { ids }).then(res => res.data.url)
+}
 
 export const deleteAssetsBulk = ids =>
   api.delete('/assets', { data: { ids } }).then(res => res.data)

--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -24,6 +24,7 @@ import {
 } from '../controllers/reviewRecord.controller.js'
 
 const router = Router()
+export const publicRouter = Router()
 
 router.post(
   '/upload',
@@ -40,6 +41,7 @@ router.post(
 )
 router.post('/', protect, requirePerm(PERMISSIONS.ASSET_CREATE), createAsset)
 router.post('/batch-download', protect, batchDownload)
+publicRouter.post('/batch-download', batchDownload)
 router.get('/', protect, requirePerm(PERMISSIONS.ASSET_READ), getAssets)
 router.post(
   '/:id/comment',
@@ -77,3 +79,4 @@ router.delete('/:id', protect, deleteAsset)    // assets
 
 
 export default router
+export { publicRouter }

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -92,7 +92,7 @@ app.use(cookieParser())
 /* ────────────────────────── 4. 路由載入 ───────────────────────── */
 import authRoutes         from './routes/auth.routes.js'
 import userRoutes         from './routes/user.routes.js'
-import assetRoutes        from './routes/asset.routes.js'
+import assetRoutes, { publicRouter as publicAssetRoutes } from './routes/asset.routes.js'
 import productRoutes      from './routes/product.routes.js'
 import folderRoutes       from './routes/folder.routes.js'
 import taskRoutes         from './routes/task.routes.js'
@@ -126,6 +126,7 @@ app.use('/api/permissions', permissionsRoutes)
 app.use('/api/menus', menusRoutes)
 app.use('/api/review-stages', reviewStageRoutes)
 app.use('/api/health', healthRoutes)
+app.use('/public/assets', publicAssetRoutes)
 app.use('/api/dashboard', dashboardRoutes)
 
 /* ────────────────────────── 5. 前端靜態檔案 ───────────────────────── */


### PR DESCRIPTION
## Summary
- add `publicRouter` export and open `/public/assets/batch-download`
- mount public route in main server entry
- call public endpoint on client when no token present

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787ba2ec288329ad684a878021074e