### PR TITLE
Add batch download progress with archiver

### DIFF
--- a/client/src/components/UploadSnackbar.vue
+++ b/client/src/components/UploadSnackbar.vue
@@ -1,10 +1,16 @@
 <template>
   <transition name="slide-up">
-    <div v-if="Object.keys(ui.uploads).length" class="snackbar">
-      <div v-for="(u, id) in ui.uploads" :key="id" class="item">
+    <div v-if="Object.keys(ui.uploads).length || Object.keys(ui.downloads).length" class="snackbar">
+      <div v-for="(u, id) in ui.uploads" :key="'u' + id" class="item">
         <span class="name">{{ u.name }}</span>
         <div class="progress">
           <div class="bar" :class="{ error: u.error }" :style="{ width: u.percent + '%' }"></div>
+        </div>
+      </div>
+      <div v-for="(d, id) in ui.downloads" :key="'d' + id" class="item">
+        <span class="name">{{ d.name }}</span>
+        <div class="progress">
+          <div class="bar" :style="{ width: d.percent + '%' }"></div>
         </div>
       </div>
     </div>

--- a/client/src/stores/ui.js
+++ b/client/src/stores/ui.js
@@ -2,7 +2,8 @@ import { defineStore } from 'pinia'
 
 export const useUiStore = defineStore('ui', {
   state: () => ({
-    uploads: {}
+    uploads: {},
+    downloads: {}
   }),
   actions: {
     startUpload(uid, name) {
@@ -13,6 +14,15 @@ export const useUiStore = defineStore('ui', {
     },
     finishUpload(uid) {
       delete this.uploads[uid]
+    },
+    startDownload(id, name) {
+      this.downloads[id] = { name, percent: 0 }
+    },
+    updateDownload(id, percent) {
+      if (this.downloads[id]) this.downloads[id].percent = percent
+    },
+    finishDownload(id) {
+      delete this.downloads[id]
     }
   }
 })

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -483,13 +483,16 @@ async function applyBatch() {
 async function downloadSelected() {
   const ids = selectedItems.value.filter(id => assets.value.some(a => a._id === id))
   if (!ids.length) return
-  const url = await batchDownloadAssets(ids)
+  const uid = 'd-' + Date.now()
+  ui.startDownload(uid, '壓縮下載')
+  const url = await batchDownloadAssets(ids, p => ui.updateDownload(uid, p))
   const link = document.createElement('a')
   link.href = url
   link.download = 'assets.zip'
   document.body.appendChild(link)
   link.click()
   document.body.removeChild(link)
+  ui.finishDownload(uid)
 }
 
 async function deleteSelected() {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.3.1",
         "multer": "^1.4.5-lts.1",
+        "archiver": "^5.3.2",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.3.1",
     "multer": "^1.4.5-lts.1",
+    "archiver": "^5.3.2",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -16,6 +16,7 @@ import {
     presign,
     createAsset,
     batchDownload,
+    getBatchDownloadProgress,
     deleteAssets
 } from '../controllers/asset.controller.js'
 import {
@@ -40,6 +41,7 @@ router.post(
 )
 router.post('/', protect, requirePerm(PERMISSIONS.ASSET_CREATE), createAsset)
 router.post('/batch-download', protect, batchDownload)
+router.get('/batch-download/:id', protect, getBatchDownloadProgress)
 router.get('/', protect, requirePerm(PERMISSIONS.ASSET_READ), getAssets)
 router.post(
   '/:id/comment',


### PR DESCRIPTION
## Summary
- switch server ZIP creation to `archiver` and track progress
- add polling endpoint for batch download progress
- show compression progress bar on frontend
- extend UI store and snackbar to handle download progress

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68788b4d7f4c83299f523aee515c990d