### PR TITLE
Add folder download feature

### DIFF
--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -52,3 +52,9 @@ export const fetchFolderStages = id =>
 export const updateFolderStage = (folderId, stageId, completed) =>
   api.put(`/folders/${folderId}/stages/${stageId}`, { completed }).then(res => res.data)
 
+export const downloadFolder = (id, deep = false) => {
+  const params = {}
+  if (deep) params.deep = 'true'
+  return api.get(`/folders/${id}/download`, { params }).then(res => res.data.url)
+}
+

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -40,6 +40,10 @@
             <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
           </el-select>
 
+          <el-button v-if="currentFolder" @click="downloadCurrentFolder">
+            <el-icon class="mr-1"><Download /></el-icon> 下載資料夾
+          </el-button>
+
         </div>
 
         <!-- ◤ 右側：檢視 / 批次動作 ◢ -->
@@ -347,7 +351,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers } from '../services/folders'
+import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers, downloadFolder } from '../services/folders'
 import { fetchAssets, uploadAssetAuto, updateAsset, deleteAsset, updateAssetsViewers, getAssetUrl, batchDownloadAssets, deleteAssetsBulk } from '../services/assets'
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
@@ -487,6 +491,17 @@ async function downloadSelected() {
   const link = document.createElement('a')
   link.href = url
   link.download = 'assets.zip'
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}
+
+async function downloadCurrentFolder() {
+  if (!currentFolder.value) return
+  const url = await downloadFolder(currentFolder.value._id, true)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `${currentFolder.value.name}.zip`
   document.body.appendChild(link)
   link.click()
   document.body.removeChild(link)

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -40,6 +40,10 @@
             <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
           </el-select>
 
+          <el-button v-if="currentFolder" @click="downloadCurrentFolder">
+            <el-icon class="mr-1"><Download /></el-icon> 下載資料夾
+          </el-button>
+
           <el-button link size="small" class="absolute top-2 right-2" @click="showHelp = true">
             <el-icon>
               <InfoFilled />
@@ -366,7 +370,8 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
   fetchFolders, createFolder, updateFolder, getFolder, deleteFolder,
-  updateFoldersViewers, reviewFolder, fetchFolderStages, updateFolderStage
+  updateFoldersViewers, reviewFolder, fetchFolderStages, updateFolderStage,
+  downloadFolder
 } from '../services/folders'
 import {
   fetchProducts, updateProduct, deleteProduct,
@@ -500,6 +505,17 @@ async function downloadSelected() {
   const link = document.createElement('a')
   link.href = url
   link.download = 'products.zip'
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}
+
+async function downloadCurrentFolder() {
+  if (!currentFolder.value) return
+  const url = await downloadFolder(currentFolder.value._id, true)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `${currentFolder.value.name}.zip`
   document.body.appendChild(link)
   link.click()
   document.body.removeChild(link)

--- a/server/src/routes/folder.routes.js
+++ b/server/src/routes/folder.routes.js
@@ -9,7 +9,8 @@ import {
   updateFolder,
   deleteFolder,
   updateFoldersViewers,
-  reviewFolder
+  reviewFolder,
+  downloadFolder
 } from '../controllers/folder.controller.js'
 import {
   getFolderStages,
@@ -21,6 +22,12 @@ const router = Router()
 router.post('/', protect, requirePerm(PERMISSIONS.FOLDER_MANAGE), createFolder)
 router.get('/', protect, requirePerm(PERMISSIONS.FOLDER_READ), getFolders) // GET  /api/folders?progress=true 可取得進度
 router.get('/:id', protect, requirePerm(PERMISSIONS.FOLDER_READ), getFolder)
+router.get(
+  '/:id/download',
+  protect,
+  requirePerm(PERMISSIONS.FOLDER_READ),
+  downloadFolder
+)
 router.put(
   '/viewers',
   protect,


### PR DESCRIPTION
## Summary
- 新增後端功能：資料夾打包下載
- 新增 `/api/folders/:id/download` 路由
- 前端 `AssetLibrary` 與 `ProductLibrary` 增加下載資料夾按鈕
- `folders` service 加入 `downloadFolder` 方法

## Testing
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68788b4f6f6c83299592db40e547d419