### PR TITLE
Add select-all option in asset and product libraries

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -48,6 +48,7 @@
 
         <!-- ◤ 右側：檢視 / 批次動作 ◢ -->
         <div class="flex items-end gap-3">
+          <el-checkbox v-model="selectAll" v-if="allIds.length">全選</el-checkbox>
 
           <!-- 卡片 / 列表切換 -->
           <el-button-group>
@@ -406,6 +407,11 @@ const isRecent = date => {
 
 const users = ref([])
 const selectedItems = ref([])
+const allIds = computed(() => [...folders.value.map(f => f._id), ...assets.value.map(a => a._id)])
+const selectAll = computed({
+  get: () => allIds.value.length > 0 && selectedItems.value.length === allIds.value.length,
+  set: val => { selectedItems.value = val ? [...allIds.value] : [] }
+})
 const batchDialog = ref(false)
 const batchUsers = ref([])
 const showHelp = ref(false)

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -53,6 +53,7 @@
 
         <!-- ◤ 右側：檢視 / 批次動作 ◢ -->
         <div class="flex items-end gap-3">
+          <el-checkbox v-model="selectAll" v-if="allIds.length">全選</el-checkbox>
           <el-button-group>
             <el-button :type="viewMode === 'card' ? 'primary' : 'default'" @click="viewMode = 'card'">
               <el-icon class="mr-1">
@@ -410,6 +411,11 @@ const filterTags = ref([])
 const allTags = ref([])
 
 const selectedItems = ref([])
+const allIds = computed(() => [...folders.value.map(f => f._id), ...products.value.map(p => p._id)])
+const selectAll = computed({
+  get: () => allIds.value.length > 0 && selectedItems.value.length === allIds.value.length,
+  set: val => { selectedItems.value = val ? [...allIds.value] : [] }
+})
 const batchDialog = ref(false)
 const batchUsers = ref([])
 const showHelp = ref(false)


### PR DESCRIPTION
## Summary
- enable a "select all" checkbox in AssetLibrary and ProductLibrary
- support computed IDs so select-all stays in sync

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68789725aab88329a3d967ca2ef73f18