### PR TITLE
Implement filename decoding

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -2,6 +2,7 @@ import mongoose from 'mongoose'
 import AdDaily from '../models/adDaily.model.js'
 import path from 'node:path'
 import { uploadFile } from '../utils/gcs.js'
+import { decodeFilename } from '../utils/decodeFilename.js'
 import fs from 'node:fs/promises'
 
 const sanitizeNumber = val =>
@@ -131,7 +132,8 @@ export const importAdDaily = async (req, res) => {
   }
 
   const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
-  const ext = path.extname(req.file.originalname)
+  const originalName = decodeFilename(req.file.originalname)
+  const ext = path.extname(originalName)
   const filename = unique + ext
   const filePath = await uploadFile(
     req.file.path,

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -6,6 +6,7 @@ import Folder from '../models/folder.model.js'
 import ReviewStage from '../models/reviewStage.model.js'
 import ReviewRecord from '../models/reviewRecord.model.js'
 import path from 'node:path'
+import { decodeFilename } from '../utils/decodeFilename.js'
 import bucket, { uploadFile as gcsUploadFile, getSignedUrl } from '../utils/gcs.js'
 import fs from 'node:fs/promises'
 import { createWriteStream } from 'node:fs'
@@ -34,7 +35,8 @@ export const uploadFile = async (req, res) => {
 
   // 產生唯一檔名
   const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
-  const ext = path.extname(req.file.originalname)
+  const originalName = decodeFilename(req.file.originalname)
+  const ext = path.extname(originalName)
   const filename = unique + ext
 
   // 將暫存檔案串流上傳至 GCS
@@ -54,7 +56,7 @@ export const uploadFile = async (req, res) => {
 
   // ➤ 建立 Asset 資料
   const asset = await Asset.create({
-    title: req.file.originalname,
+    title: originalName,
     filename,
     path: gcsPath,
     type: req.body.type || 'raw',

--- a/server/src/controllers/weeklyNote.controller.js
+++ b/server/src/controllers/weeklyNote.controller.js
@@ -1,6 +1,7 @@
 import WeeklyNote from '../models/weeklyNote.model.js'
 import path from 'node:path'
 import { uploadFile, getSignedUrl } from '../utils/gcs.js'
+import { decodeFilename } from '../utils/decodeFilename.js'
 import fs from 'node:fs/promises'
 
 const uploadImages = async files => {
@@ -8,7 +9,8 @@ const uploadImages = async files => {
   const paths = await Promise.all(
     files.map(async f => {
       const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
-      const ext = path.extname(f.originalname)
+      const originalName = decodeFilename(f.originalname)
+      const ext = path.extname(originalName)
       const filename = unique + ext
       const p = await uploadFile(f.path, filename, f.mimetype)
       await fs.unlink(f.path)

--- a/server/src/utils/decodeFilename.js
+++ b/server/src/utils/decodeFilename.js
@@ -1,0 +1,2 @@
+export const decodeFilename = name =>
+  Buffer.from(name, 'latin1').toString('utf8')


### PR DESCRIPTION
## Summary
- add `decodeFilename` utility to convert latin1 to utf8
- use decoded filename when uploading assets
- handle weekly note image names with decoding
- decode ad daily upload filenames

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884999b65f48329bf50d696dd3ce121