### PR TITLE
Refresh dashboard cache when stages update

### DIFF
--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -146,6 +146,7 @@ async function onStageChange (stage, event) {
   const completed = event.target.checked
   await updateProductStage(currentProductId, stage._id, completed)
   stage.completed = completed
+  await fetchDashboard()
 }
 
 onMounted(fetchDashboard)

--- a/server/src/controllers/dashboard.controller.js
+++ b/server/src/controllers/dashboard.controller.js
@@ -3,7 +3,7 @@ import Asset from '../models/asset.model.js'
 import ReviewRecord from '../models/reviewRecord.model.js'
 import ReviewStage from '../models/reviewStage.model.js'
 import AdDaily from '../models/adDaily.model.js'
-import { getCache, setCache } from '../utils/cache.js'
+import { getCache, setCache, clearCacheByPrefix } from '../utils/cache.js'
 
 export const getSummary = async (req, res) => {
   const cacheKey = `dashboard:${req.user._id}`
@@ -136,4 +136,8 @@ export const getDaily = async (req, res) => {
       clicks: d.clicks
     }))
   )
+}
+
+export const clearDashboardCache = async () => {
+  await clearCacheByPrefix('dashboard:')
 }

--- a/server/src/controllers/reviewRecord.controller.js
+++ b/server/src/controllers/reviewRecord.controller.js
@@ -1,6 +1,7 @@
 import ReviewStage from '../models/reviewStage.model.js'
 import ReviewRecord from '../models/reviewRecord.model.js'
 import Asset from '../models/asset.model.js'
+import { clearDashboardCache } from './dashboard.controller.js'
 
 export const getAssetStages = async (req, res) => {
   const stages = await ReviewStage.find().populate('responsible').sort('order')
@@ -65,6 +66,8 @@ export const updateStageStatus = async (req, res) => {
     }
     await asset.save()
   }
+
+  await clearDashboardCache()
 
   res.json(record)
 }

--- a/server/tests/dashboardSummaryProgress.test.js
+++ b/server/tests/dashboardSummaryProgress.test.js
@@ -1,0 +1,74 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import dotenv from 'dotenv'
+
+import dashboardRoutes from '../src/routes/dashboard.routes.js'
+import authRoutes from '../src/routes/auth.routes.js'
+import assetRoutes from '../src/routes/asset.routes.js'
+import ReviewStage from '../src/models/reviewStage.model.js'
+import Asset from '../src/models/asset.model.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+let assetId
+let stageId
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/dashboard', dashboardRoutes)
+  app.use('/api/assets', assetRoutes)
+
+  const role = await Role.create({ name: 'manager' })
+  const user = await User.create({ username: 'admin', password: 'pwd', email: 'a@test.com', roleId: role._id })
+
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'admin', password: 'pwd' })
+  token = res.body.token
+
+  const asset = await Asset.create({ filename: 'p.mp4', path: '/tmp/p.mp4', type: 'edited' })
+  assetId = asset._id
+
+  const s1 = await ReviewStage.create({ name: 'S1', order: 1, responsible: user._id })
+  stageId = s1._id
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+test('summary reflects stage progress after update', async () => {
+  const res1 = await request(app)
+    .get('/api/dashboard/summary')
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200)
+
+  expect(res1.body.recentProducts[0].progress.done).toBe(0)
+
+  await request(app)
+    .put(`/api/assets/${assetId}/stages/${stageId}`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({ completed: true })
+    .expect(200)
+
+  const res2 = await request(app)
+    .get('/api/dashboard/summary')
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200)
+
+  expect(res2.body.recentProducts[0].progress.done).toBe(1)
+})


### PR DESCRIPTION
## Summary
- refresh dashboard view after updating stage progress
- clear dashboard cache on stage status change
- expose helper to clear dashboard cache
- test that dashboard summary reflects progress updates

## Testing
- `npm test --prefix server` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6884a59c474c832982356beed804b3e5