### PR TITLE
實作 Dashboard 批次儲存關卡

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ server/  # 後端 API
 若需批次匯入，可 POST 至 `/api/clients/:clientId/platforms/:platformId/ad-daily/import` 上傳 CSV 或 Excel。
 
 儀表板會列出近期上傳的成品及其審查進度。
+在此可一次勾選多個關卡，點擊「儲存」後會依序更新並重新載入資料。
 
 ### 週備註圖片管理
 


### PR DESCRIPTION
## Summary
- 在 Dashboard 的審查對話框以本地狀態記錄勾選結果
- 新增「儲存」按鈕，可一次更新多個審查關卡
- 更新 README 描述 Dashboard 新行為

## Testing
- `npm test --prefix server` *(fails: jest not found)*
- `npm install --prefix server` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884d7a64cfc83299e9ef24dd11599dd