### PR TITLE
Fix permission middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ GCS_CORS_ORIGIN=http://localhost:5173
 上傳後僅會儲存檔名，需另外呼叫 API 取得 signed URL 才能預覽或下載檔案。
 若需強制瀏覽器下載檔案，可對 `GET /api/assets/:id/url` 加入 `?download=1`
 參數取得下載專用的 URL。
+所有受保護的路由都會檢查使用者是否具有對應權限，
+缺乏權限時伺服器將回傳 `403` 並顯示 `權限不足`。
 3. 執行測試前請先在 `server` 目錄安裝相依套件：
    ```bash
    npm install

--- a/server/src/middleware/permission.js
+++ b/server/src/middleware/permission.js
@@ -10,7 +10,7 @@ export const requirePerm = (...perms) => async (req, res, next) => {
 
   const allowed = role && perms.every(p => role.permissions.includes(p))
   if (!allowed) {
-    // return res.status(403).json({ message: '權限不足' })
+    return res.status(403).json({ message: '權限不足' })
   }
   next()
 }


### PR DESCRIPTION
## Summary
- enforce permission check and return 403
- document permission check in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884db2808b08329aff5b0ea712a9cdd