### PR TITLE
Add skipPrevCheck option for review stages

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -112,9 +112,16 @@ export const reviewAsset = (id, status) =>
 export const fetchAssetStages = id =>
   api.get(`/assets/${id}/stages`).then(res => res.data)
 
-export const updateAssetStage = (assetId, stageId, completed, fromDashboard = false) => {
+export const updateAssetStage = (
+  assetId,
+  stageId,
+  completed,
+  fromDashboard = false,
+  skipPrevCheck = false
+) => {
   const payload = { completed }
   if (fromDashboard) payload.fromDashboard = true
+  if (skipPrevCheck) payload.skipPrevCheck = true
   return api
     .put(`/assets/${assetId}/stages/${stageId}`, payload)
     .then(res => res.data)

--- a/client/src/services/products.js
+++ b/client/src/services/products.js
@@ -36,8 +36,9 @@ export const updateProductStage = (
   productId,
   stageId,
   completed,
-  fromDashboard = false
-) => updateAssetStage(productId, stageId, completed, fromDashboard)
+  fromDashboard = false,
+  skipPrevCheck = false
+) => updateAssetStage(productId, stageId, completed, fromDashboard, skipPrevCheck)
 
 export const updateProductsViewers = (ids, users) =>
   updateAssetsViewers(ids, users)

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -175,6 +175,7 @@ async function saveStages () {
         currentProductId,
         stage._id,
         stage.checked,
+        true,
         true
       )
     }

--- a/server/src/controllers/folderReviewRecord.controller.js
+++ b/server/src/controllers/folderReviewRecord.controller.js
@@ -21,6 +21,7 @@ export const updateFolderStageStatus = async (req, res) => {
   const folderId = req.params.id
   const stageId = req.params.stageId
   const completed = !!req.body.completed
+  const skipPrevCheck = req.body.skipPrevCheck === true || req.query.skipPrevCheck === '1'
 
   const stage = await ReviewStage.findById(stageId).populate('responsible')
   if (!stage) return res.status(404).json({ message: '階段不存在' })
@@ -29,7 +30,7 @@ export const updateFolderStageStatus = async (req, res) => {
     return res.status(403).json({ message: '無權審核此階段' })
   }
 
-  if (completed) {
+  if (completed && !skipPrevCheck) {
     const prevStages = await ReviewStage.find({ order: { $lt: stage.order } }, '_id')
     if (prevStages.length) {
       const prevIds = prevStages.map(s => s._id)

--- a/server/src/controllers/reviewRecord.controller.js
+++ b/server/src/controllers/reviewRecord.controller.js
@@ -26,6 +26,7 @@ export const updateStageStatus = async (req, res) => {
     req.query.dashboard === '1' ||
     req.query.dashboard === 'true' ||
     req.body.fromDashboard
+  const skipPrevCheck = req.body.skipPrevCheck === true || req.query.skipPrevCheck === '1'
 
   const stage = await ReviewStage.findById(stageId).populate('responsible')
   if (!stage) return res.status(404).json({ message: '階段不存在' })
@@ -35,7 +36,7 @@ export const updateStageStatus = async (req, res) => {
   }
 
   // 檢查前置審核是否完成
-  if (completed) {
+  if (completed && !skipPrevCheck && !fromDashboard) {
     const prevStages = await ReviewStage.find({ order: { $lt: stage.order } }, '_id')
     if (prevStages.length) {
       const prevIds = prevStages.map((s) => s._id)

--- a/server/tests/folderReviewRecord.test.js
+++ b/server/tests/folderReviewRecord.test.js
@@ -60,6 +60,15 @@ describe('updateFolderStageStatus', () => {
       .expect(400)
   })
 
+  it('should succeed when skipPrevCheck is true', async () => {
+    const folder = await Folder.create({ name: 'F2', reviewStatus: 'approved' })
+    await request(app)
+      .put(`/api/folders/${folder._id}/stages/${stageId2}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ completed: true, skipPrevCheck: true })
+      .expect(200)
+  })
+
   it('should set reviewStatus to pending when not all stages done', async () => {
     await request(app)
       .put(`/api/folders/${folderId}/stages/${stageId1}`)

--- a/server/tests/reviewRecord.test.js
+++ b/server/tests/reviewRecord.test.js
@@ -67,6 +67,15 @@ describe('updateStageStatus', () => {
       .expect(400)
   })
 
+  it('should succeed when skipPrevCheck is true', async () => {
+    const asset = await Asset.create({ filename: 'g.mp4', path: '/tmp/g.mp4', type: 'edited', reviewStatus: 'approved' })
+    await request(app)
+      .put(`/api/assets/${asset._id}/stages/${stageId2}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ completed: true, skipPrevCheck: true })
+      .expect(200)
+  })
+
   it('should allow dashboard update by non-responsible user', async () => {
     await request(app)
       .put(`/api/assets/${assetId}/stages/${stageId1}?dashboard=1`)


### PR DESCRIPTION
## Summary
- add optional `skipPrevCheck` support in review controllers
- pass `skipPrevCheck` from asset and product services
- enable dashboard bulk update to bypass previous check
- test new option in asset and folder review tests

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884e2467040832982caccca0a515de2