### PR TITLE
Refactor cache cleaning

### DIFF
--- a/server/tests/clearCachePrefix.test.js
+++ b/server/tests/clearCachePrefix.test.js
@@ -1,0 +1,19 @@
+import { setCache, getCache, clearCacheByPrefix } from '../src/utils/cache.js'
+
+beforeEach(async () => {
+  // ensure clean state
+  await clearCacheByPrefix('test:')
+})
+
+test('clearCacheByPrefix 刪除指定前綴的所有鍵', async () => {
+  await setCache('test:a', '1')
+  await setCache('test:b', '2')
+
+  expect(await getCache('test:a')).toBe('1')
+  expect(await getCache('test:b')).toBe('2')
+
+  await clearCacheByPrefix('test:')
+
+  expect(await getCache('test:a')).toBeNull()
+  expect(await getCache('test:b')).toBeNull()
+})


### PR DESCRIPTION
## Summary
- improve `clearCacheByPrefix` implementation with `SCAN` and pipeline
- add unit test for clearing cache by prefix

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ebf9a77083299fd80d09052126d4