### PR TITLE
Add folder tree cache

### DIFF
--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -47,6 +47,7 @@ export const createFolder = async (req, res) => {
     allowedUsers: await includeManagers(baseUsers)
   })
   await clearCacheByPrefix('folders:')
+  await clearCacheByPrefix('folderTree:')
   res.status(201).json(folder)
 }
 
@@ -187,6 +188,7 @@ export const updateFolder = async (req, res) => {
   }
   await clearCacheByPrefix('folders:')
   await clearCacheByPrefix('assets:')
+  await clearCacheByPrefix('folderTree:')
   res.json(folder)
 }
 
@@ -199,6 +201,7 @@ export const deleteFolder = async (req, res) => {
 
   await clearCacheByPrefix('folders:')
   await clearCacheByPrefix('assets:')
+  await clearCacheByPrefix('folderTree:')
   res.json({ message: '資料夾已刪除' })
 }
 
@@ -226,6 +229,7 @@ export const updateFoldersViewers = async (req, res) => {
     }
   }
   await clearCacheByPrefix('folders:')
+  await clearCacheByPrefix('folderTree:')
   res.json({ message: '已更新' })
 }
 

--- a/server/src/utils/folderTree.js
+++ b/server/src/utils/folderTree.js
@@ -1,6 +1,16 @@
 import Folder from '../models/folder.model.js'
+import { getCache, setCache } from './cache.js'
+
+const DESC_PREFIX = 'folderTree:desc'
+const ANCE_PREFIX  = 'folderTree:anc'
+const ROOT_PREFIX  = 'folderTree:root'
+const TTL = 300
 
 export const getDescendantFolderIds = async (parentId = null) => {
+  const cacheKey = `${DESC_PREFIX}:${parentId || 'root'}`
+  const cached = await getCache(cacheKey)
+  if (cached) return cached
+
   const ids = []
   const queue = [parentId]
   while (queue.length) {
@@ -11,10 +21,15 @@ export const getDescendantFolderIds = async (parentId = null) => {
       queue.push(child._id)
     }
   }
+  await setCache(cacheKey, ids, TTL)
   return ids
 }
 
 export const getAncestorFolderIds = async (folderId = null) => {
+  const cacheKey = `${ANCE_PREFIX}:${folderId || 'root'}`
+  const cached = await getCache(cacheKey)
+  if (cached) return cached
+
   const ids = []
   let current = folderId
   while (current) {
@@ -23,10 +38,15 @@ export const getAncestorFolderIds = async (folderId = null) => {
     ids.push(folder.parentId)
     current = folder.parentId
   }
+  await setCache(cacheKey, ids, TTL)
   return ids
 }
 
 export const getRootFolder = async (folderId) => {
+  const cacheKey = `${ROOT_PREFIX}:${folderId || 'root'}`
+  const cached = await getCache(cacheKey)
+  if (cached) return cached
+
   let currentId = folderId
   let folder = null
   while (currentId) {
@@ -34,5 +54,6 @@ export const getRootFolder = async (folderId) => {
     if (!folder || !folder.parentId) break
     currentId = folder.parentId
   }
+  await setCache(cacheKey, folder, TTL)
   return folder
 }


### PR DESCRIPTION
## Summary
- cache results for folder tree utils
- purge folderTree cache on folder CRUD events

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ecb6dcac8329b32f27f32da1de8f