### PR TITLE
Add dashboard fields

### DIFF
--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -172,7 +172,18 @@ export const addComment = async (req, res) => {
 /* ---------- PUT /api/assets/:id ---------- */
 /* 允許更新：title、description */
 export const updateAsset = async (req, res) => {
-  const { title, description, allowedUsers } = req.body
+  const {
+    title,
+    description,
+    allowedUsers,
+    editor,
+    editCompletedAt,
+    xhsStatus,
+    scheduledPublishAt,
+    finalChecked,
+    fbSynced,
+    fbResponsible
+  } = req.body
 
   const asset = await Asset.findById(req.params.id)
   if (!asset) return res.status(404).json({ message: '找不到素材' })
@@ -183,6 +194,13 @@ export const updateAsset = async (req, res) => {
   if (Array.isArray(allowedUsers)) {
     asset.allowedUsers = await includeManagers(allowedUsers)
   }
+  if (editor !== undefined) asset.editor = editor
+  if (editCompletedAt !== undefined) asset.editCompletedAt = editCompletedAt ? new Date(editCompletedAt) : null
+  if (xhsStatus !== undefined) asset.xhsStatus = xhsStatus
+  if (scheduledPublishAt !== undefined) asset.scheduledPublishAt = scheduledPublishAt ? new Date(scheduledPublishAt) : null
+  if (finalChecked !== undefined) asset.finalChecked = finalChecked
+  if (fbSynced !== undefined) asset.fbSynced = fbSynced
+  if (fbResponsible !== undefined) asset.fbResponsible = fbResponsible
   // filename 不可修改，故不處理
 
   await asset.save()

--- a/server/src/controllers/dashboard.controller.js
+++ b/server/src/controllers/dashboard.controller.js
@@ -77,6 +77,14 @@ export const getSummary = async (req, res) => {
       fileType: p.type,
       uploaderName: p.uploadedBy?.name || p.uploadedBy?.username,
       createdAt: p.createdAt,
+      title: p.title,
+      editor: p.editor,
+      editCompletedAt: p.editCompletedAt,
+      xhsStatus: p.xhsStatus,
+      scheduledPublishAt: p.scheduledPublishAt,
+      finalChecked: p.finalChecked,
+      fbSynced: p.fbSynced,
+      fbResponsible: p.fbResponsible,
       progress: { done, total: totalStages },
       pendingStage
     }

--- a/server/src/models/asset.model.js
+++ b/server/src/models/asset.model.js
@@ -27,6 +27,15 @@ const assetSchema = new mongoose.Schema(
     reviewStatus: { type: String, enum: ['pending', 'approved', 'rejected'], default: 'pending' },
     description:  { type: String, default: '' },
 
+    // ===== 新增進度與發布相關欄位 =====
+    editor:             { type: String, default: '' },               // 剪輯師
+    editCompletedAt:    { type: Date },                               // 完成剪輯日期
+    xhsStatus:          { type: String, enum: ['published', 'unpublished'], default: 'unpublished' },
+    scheduledPublishAt: { type: Date },                               // 設定發佈日期
+    finalChecked:       { type: Boolean, default: false },            // 最終檢查
+    fbSynced:           { type: Boolean, default: false },            // Facebook 同步
+    fbResponsible:      { type: String, default: '' },                // FB 負責人
+
     uploadedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     folderId:   { type: mongoose.Schema.Types.ObjectId, ref: 'Folder', default: null },
 


### PR DESCRIPTION
## Summary
- extend Asset model with publish tracking fields
- allow updating new fields via updateAsset controller
- expose these fields in dashboard summary
- show and edit product info on dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fd65e9ac8329b866119d5cb0519d