### PR TITLE
Fix dashboard cache after asset updates

### DIFF
--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -14,6 +14,7 @@ import archiver from 'archiver'
 import { getDescendantFolderIds, getAncestorFolderIds, getRootFolder } from '../utils/folderTree.js'
 import { includeManagers } from '../utils/includeManagers.js'
 import { getCache, setCache, clearCacheByPrefix, delCache } from '../utils/cache.js'
+import { clearDashboardCache } from './dashboard.controller.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -75,12 +76,13 @@ export const uploadFile = async (req, res) => {
       $set: { updatedAt: new Date() }
     })
     const parents = await getAncestorFolderIds(asset.folderId)
-    if (parents.length) {
+  if (parents.length) {
       await Folder.updateMany({ _id: { $in: parents } }, { $set: { updatedAt: new Date() } })
     }
   }
 
   await clearCacheByPrefix('assets:')
+  await clearDashboardCache()
   res.status(201).json(asset)
 }
 
@@ -161,7 +163,7 @@ export const addComment = async (req, res) => {
   if (asset.folderId) {
     await Folder.updateOne({ _id: asset.folderId }, { $set: { updatedAt: new Date() } })
     const parents = await getAncestorFolderIds(asset.folderId)
-    if (parents.length) {
+  if (parents.length) {
       await Folder.updateMany({ _id: { $in: parents } }, { $set: { updatedAt: new Date() } })
     }
   }
@@ -225,6 +227,7 @@ export const reviewAsset = async (req, res) => {
   asset.reviewStatus = reviewStatus
   await asset.save()
   await clearCacheByPrefix('assets:')
+  await clearDashboardCache()
   res.json(asset)
 }
 
@@ -233,11 +236,12 @@ export const deleteAsset = async (req, res) => {
   if (asset?.folderId) {
     await Folder.updateOne({ _id: asset.folderId }, { $set: { updatedAt: new Date() } })
     const parents = await getAncestorFolderIds(asset.folderId)
-    if (parents.length) {
+  if (parents.length) {
       await Folder.updateMany({ _id: { $in: parents } }, { $set: { updatedAt: new Date() } })
     }
   }
   await clearCacheByPrefix('assets:')
+  await clearDashboardCache()
   res.json({ message: '素材已刪除' })
 }
 
@@ -297,6 +301,7 @@ export const updateAssetsViewers = async (req, res) => {
     await asset.save()
   }
   await clearCacheByPrefix('assets:')
+  await clearDashboardCache()
   res.json({ message: '已更新' })
 }
 
@@ -336,12 +341,13 @@ export const createAsset = async (req, res) => {
       $set: { updatedAt: new Date() }
     })
     const parents = await getAncestorFolderIds(asset.folderId)
-    if (parents.length) {
+  if (parents.length) {
       await Folder.updateMany({ _id: { $in: parents } }, { $set: { updatedAt: new Date() } })
     }
   }
 
   await clearCacheByPrefix('assets:')
+  await clearDashboardCache()
   res.status(201).json(asset)
 }
 
@@ -471,5 +477,6 @@ export const deleteAssets = async (req, res) => {
   }
 
   await clearCacheByPrefix('assets:')
+  await clearDashboardCache()
   res.json({ message: '已刪除' })
 }

--- a/server/tests/dashboardAssetCache.test.js
+++ b/server/tests/dashboardAssetCache.test.js
@@ -1,0 +1,65 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import dotenv from 'dotenv'
+
+import dashboardRoutes from '../src/routes/dashboard.routes.js'
+import authRoutes from '../src/routes/auth.routes.js'
+import assetRoutes from '../src/routes/asset.routes.js'
+import Asset from '../src/models/asset.model.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/dashboard', dashboardRoutes)
+  app.use('/api/assets', assetRoutes)
+
+  const role = await Role.create({ name: 'manager', permissions: ['asset:create', 'asset:read'] })
+  await User.create({ username: 'admin', password: 'pwd', email: 'a@test.com', roleId: role._id })
+
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'admin', password: 'pwd' })
+  token = res.body.token
+
+  await Asset.create({ filename: 'a.mp4', path: '/tmp/a.mp4', type: 'raw' })
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+test('summary updates after asset creation', async () => {
+  const res1 = await request(app)
+    .get('/api/dashboard/summary')
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200)
+  expect(res1.body.assetStats.rawTotal).toBe(1)
+
+  await request(app)
+    .post('/api/assets')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ filename: 'b.mp4', path: '/tmp/b.mp4' })
+    .expect(201)
+
+  const res2 = await request(app)
+    .get('/api/dashboard/summary')
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200)
+  expect(res2.body.assetStats.rawTotal).toBe(2)
+})


### PR DESCRIPTION
## Summary
- clear dashboard cache in asset controller when assets are changed
- test that dashboard summary refreshes after creating a new asset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688506ed0da883299a22a2ffa924006f