### PR TITLE
Implement periodic dashboard refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ server/  # 後端 API
 若需批次匯入，可 POST 至 `/api/clients/:clientId/platforms/:platformId/ad-daily/import` 上傳 CSV 或 Excel。
 
 儀表板會列出近期上傳的成品及其審查進度。
+儀表板資料會每 30 秒自動重新載入，以保持最新狀態。
 在此可一次勾選多個關卡，點擊「儲存」後會依序更新並重新載入資料。
 
 ### 週備註圖片管理

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -183,7 +183,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import api from '../services/api'
 import { fetchProducts, fetchProductStages, updateProductStage, updateProduct } from '../services/products'
 
@@ -207,6 +207,7 @@ const assetStats = ref({})
 const stageDialogVisible = ref(false)
 const stageList = ref([])
 let currentProductId = null
+let dashboardTimer = null
 
 const editDialogVisible = ref(false)
 const editItem = ref({})
@@ -315,5 +316,12 @@ async function saveStages () {
 onMounted(() => {
   loadLists()
   fetchDashboard()
+  dashboardTimer = setInterval(fetchDashboard, 30000)
+})
+
+onUnmounted(() => {
+  if (dashboardTimer) {
+    clearInterval(dashboardTimer)
+  }
 })
 </script>


### PR DESCRIPTION
## Summary
- auto-refresh dashboard data every 30 seconds
- add cleanup for the timer on component unmount
- document dashboard auto-sync in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850fda43788329a4e1183a2fd8672c