### PR TITLE
Update dashboard cache after asset update

### DIFF
--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -214,6 +214,7 @@ export const updateAsset = async (req, res) => {
     }
   }
   await clearCacheByPrefix('assets:')
+  await clearDashboardCache()
   res.json(asset)
 }
 


### PR DESCRIPTION
## Summary
- clear dashboard cache when updating an asset
- expand permissions in dashboard asset cache test
- test dashboard summary after updating an asset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688598a460408329949eb4194fdc95d9