### PR TITLE
Improve concurrent uploads

### DIFF
--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -334,22 +334,28 @@ async function createNewFolder() {
 }
 
 const uploadRequest = async (event) => {
-    const files = Array.isArray(event.files) ? event.files : [event.files];
+  const files = Array.isArray(event.files) ? event.files : [event.files];
+  const uploadPromises = files.map(file => {
+    const taskId = `upload-${file.name}-${Date.now()}`;
+    progressStore.addTask({ id: taskId, name: file.name, status: 'uploading', progress: 0 });
 
-    for (const file of files) {
-        const taskId = `upload-${file.name}-${Date.now()}`;
-        progressStore.addTask({ id: taskId, name: file.name, status: 'uploading', progress: 0 });
-        try {
-            await uploadAssetAuto(file, currentFolder.value?._id, { type: 'edited' }, (progressEvent) => {
-                const percent = Math.round((progressEvent.loaded / progressEvent.total) * 100);
-                progressStore.updateTaskProgress(taskId, percent);
-            });
-            progressStore.updateTaskStatus(taskId, 'success');
-        } catch (error) {
-            progressStore.updateTaskStatus(taskId, 'error', '上傳失敗');
-        }
-    }
-    loadData(currentFolder.value?._id);
+    const progressCb = (progressEvent) => {
+      let percent = 0;
+      if (progressEvent && typeof progressEvent.percent === 'number') {
+        percent = Math.round(progressEvent.percent);
+      } else if (progressEvent && progressEvent.total) {
+        percent = Math.round((progressEvent.loaded / progressEvent.total) * 100);
+      }
+      progressStore.updateTaskProgress(taskId, percent);
+    };
+
+    return uploadAssetAuto(file, currentFolder.value?._id, { type: 'edited' }, progressCb)
+      .then(() => progressStore.updateTaskStatus(taskId, 'success'))
+      .catch(() => progressStore.updateTaskStatus(taskId, 'error', '上傳失敗'));
+  });
+
+  await Promise.all(uploadPromises);
+  loadData(currentFolder.value?._id);
 };
 
 async function pollProgress(progressId, name, type) {


### PR DESCRIPTION
## Summary
- refactor AssetLibrary upload handler to run uploads concurrently
- refactor ProductLibrary upload handler to run uploads concurrently
- handle progress callbacks that may return `percent`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885c29a4fbc83299d906c1c4eee4c35