### PR TITLE
更新進度追蹤器樣式

### DIFF
--- a/client/src/components/ProgressTracker.vue
+++ b/client/src/components/ProgressTracker.vue
@@ -56,8 +56,15 @@ const getStatusText = (status) => {
   position: fixed;
   bottom: 1rem;
   right: 1rem;
-  width: 350px;
-  z-index: 1100; /* Higher than other elements */
+  width: 100%;
+  max-width: 350px;
+  z-index: 1100;
+}
+
+@media (min-width: 576px) {
+  .progress-tracker-container {
+    width: 350px;
+  }
 }
 
 .card-title {


### PR DESCRIPTION
## Summary
- 調整 `ProgressTracker` 位置樣式，改為依螢幕寬度自適應
- 新增媒體查詢，在 576px 以上寬度固定為 350px

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68899bd076388329a44221e621723ad9