### PR TITLE
Implement global upload queue

### DIFF
--- a/client/src/components/ProgressTracker.vue
+++ b/client/src/components/ProgressTracker.vue
@@ -32,12 +32,12 @@
 
 <script setup>
 import { computed } from 'vue';
-import { useProgressStore } from '../stores/progress';
+import { useUploadStore } from '../stores/upload';
 import Card from 'primevue/card';
 import ProgressBar from 'primevue/progressbar';
 
-const progressStore = useProgressStore();
-const activeTasks = computed(() => progressStore.activeTasks);
+const uploadStore = useUploadStore();
+const activeTasks = computed(() => uploadStore.activeTasks);
 
 const getStatusText = (status) => {
   const statusMap = {

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
+import { useUploadStore } from '../stores/upload'
 
 import Login from '../views/Login.vue'
 import DashboardLayout from '../layouts/DashboardLayout.vue'
@@ -52,6 +53,12 @@ const router = createRouter({
 
 /* -------- 路由守衛：驗證 JWT & 權限 -------- */
 router.beforeEach(async (to) => {
+  const uploadStore = useUploadStore()
+  if (uploadStore.hasPending) {
+    const leave = window.confirm('仍有上傳任務進行中，確定要離開嗎？')
+    if (!leave) return false
+    uploadStore.cancelAll()
+  }
   const store = useAuthStore()
   if (to.meta.public) return true // 公開頁面
 

--- a/client/src/stores/upload.js
+++ b/client/src/stores/upload.js
@@ -1,0 +1,83 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { uploadAssetAuto } from '../services/assets'
+import { useProgressStore } from './progress'
+
+export const useUploadStore = defineStore('upload', () => {
+  const queue = ref({})
+  const progressStore = useProgressStore()
+
+  const activeTasks = computed(() => progressStore.activeTasks)
+
+  const hasPending = computed(() =>
+    Object.values(queue.value).some(task =>
+      ['pending', 'uploading'].includes(task.status)
+    )
+  )
+
+  function addUploadTask(file, options = {}) {
+    const id = `upload-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    queue.value[id] = {
+      id,
+      file,
+      options,
+      status: 'pending',
+      progress: 0,
+      canceled: false
+    }
+    progressStore.addTask({ id, name: file.name, status: 'uploading', progress: 0 })
+    startUpload(id)
+    return id
+  }
+
+  async function startUpload(id) {
+    const task = queue.value[id]
+    if (!task) return
+    task.status = 'uploading'
+    const { file, options } = task
+    const progressCb = evt => {
+      let percent = 0
+      if (evt && typeof evt.percent === 'number') {
+        percent = Math.round(evt.percent)
+      } else if (evt && evt.total) {
+        percent = Math.round((evt.loaded / evt.total) * 100)
+      }
+      task.progress = percent
+      progressStore.updateTaskProgress(id, percent)
+    }
+    try {
+      await uploadAssetAuto(file, options.folderId, options.extraData || null, progressCb)
+      if (task.canceled) {
+        progressStore.updateTaskStatus(id, 'error', '已取消')
+      } else {
+        progressStore.updateTaskStatus(id, 'success')
+        task.status = 'success'
+      }
+    } catch (e) {
+      if (!task.canceled) {
+        task.status = 'error'
+        progressStore.updateTaskStatus(id, 'error', '上傳失敗')
+      } else {
+        progressStore.updateTaskStatus(id, 'error', '已取消')
+      }
+    } finally {
+      setTimeout(() => {
+        delete queue.value[id]
+      }, 5000)
+    }
+  }
+
+  function cancelTask(id) {
+    const task = queue.value[id]
+    if (task) {
+      task.canceled = true
+      task.status = 'canceled'
+    }
+  }
+
+  function cancelAll() {
+    Object.keys(queue.value).forEach(cancelTask)
+  }
+
+  return { queue, activeTasks, addUploadTask, cancelTask, cancelAll, hasPending }
+})


### PR DESCRIPTION
## Summary
- add new Pinia `upload` store to handle upload queue and expose active tasks
- integrate global upload service into Product and Asset libraries
- update router to warn when leaving with ongoing uploads
- use upload store for displaying progress

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889aae4016c83298b9a8c51d400563c