### PR TITLE
移除資料夾下載按鈕與相關邏輯

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -77,8 +77,7 @@
         </div>
         <div class="flex flex-row xl:flex-column align-items-center xl:align-items-end gap-2">
           <Button icon="pi pi-info-circle" class="p-button-rounded p-button-secondary" @click="showDetailFor(item)"></Button>
-          <Button v-if="item.type === 'folder'" icon="pi pi-download" class="p-button-rounded p-button-help" @click="downloadFolderItem(item)"></Button>
-          <Button v-else icon="pi pi-download" class="p-button-rounded p-button-help" @click="downloadSingleItem(item)"></Button>
+          <Button icon="pi pi-download" class="p-button-rounded p-button-help" @click="downloadSingleItem(item)"></Button>
         </div>
       </div>
     </div>
@@ -130,12 +129,11 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import { useConfirm } from 'primevue/useconfirm'
-import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers, startBatchDownload as startFolderBatchDownload, getDownloadProgress as getFolderDownloadProgress } from '../services/folders'
+import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers } from '../services/folders'
 import { fetchAssets, updateAsset, deleteAsset, updateAssetsViewers, getAssetUrl, startBatchDownload as startAssetBatchDownload, getBatchDownloadProgress as getAssetBatchDownloadProgress } from '../services/assets'
 import { useUploadStore } from '../stores/upload'
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
-import { useAuthStore } from '../stores/auth'
 import { useProgressStore } from '../stores/progress'
 
 import Toolbar from 'primevue/toolbar'
@@ -154,7 +152,6 @@ const toast = useToast()
 const confirm = useConfirm()
 const router = useRouter()
 const route = useRoute()
-const authStore = useAuthStore()
 const progressStore = useProgressStore()
 const uploadStore = useUploadStore()
 
@@ -258,8 +255,8 @@ const uploadRequest = async (event) => {
   loadData(currentFolder.value?._id)
 }
 
-async function pollProgress(progressId, name, type) {
-  const getProgress = type === 'folder' ? getFolderDownloadProgress : getAssetBatchDownloadProgress;
+async function pollProgress(progressId, name) {
+  const getProgress = getAssetBatchDownloadProgress;
   const taskId = `dl-${progressId}`;
   progressStore.addTask({ id: taskId, name, status: 'compressing', progress: 0 });
 
@@ -296,14 +293,6 @@ async function pollProgress(progressId, name, type) {
   poll();
 }
 
-async function downloadFolderItem(item) {
-  try {
-    const { progressId } = await startFolderBatchDownload(item._id);
-    pollProgress(progressId, item.name, 'folder');
-  } catch (error) {
-    toast.add({ severity: 'error', summary: 'Error', detail: '無法開始下載', life: 3000 });
-  }
-}
 
 async function downloadSingleItem(item) {
   try {
@@ -329,7 +318,7 @@ async function downloadSelected() {
   if (!selectedAssets.value.length) return;
   try {
     const { progressId } = await startAssetBatchDownload(selectedAssets.value);
-    pollProgress(progressId, '批量下載', 'asset');
+    pollProgress(progressId, '批量下載');
   } catch (error) {
      toast.add({ severity: 'error', summary: 'Error', detail: '無法開始下載', life: 3000 });
   }

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -93,8 +93,7 @@
             class="p-button-sm p-button-secondary"
           ></SplitButton>
           <Button v-else icon="pi pi-info-circle" class="p-button-rounded p-button-secondary" @click.stop="showDetailFor(item)"></Button>
-          <Button v-if="item.type === 'folder'" icon="pi pi-download" class="p-button-rounded p-button-help" @click="downloadFolderItem(item)"></Button>
-          <Button v-else icon="pi pi-download" class="p-button-rounded p-button-help" @click="downloadSingleItem(item)"></Button>
+          <Button icon="pi pi-download" class="p-button-rounded p-button-help" @click="downloadSingleItem(item)"></Button>
         </div>
       </div>
     </div>
@@ -159,7 +158,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import { useConfirm } from 'primevue/useconfirm'
-import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers, reviewFolder, fetchFolderStages, updateFolderStage, startBatchDownload as startFolderBatchDownload, getDownloadProgress as getFolderDownloadProgress } from '../services/folders'
+import { fetchFolders, createFolder, updateFolder, getFolder, deleteFolder, updateFoldersViewers, reviewFolder, fetchFolderStages, updateFolderStage } from '../services/folders'
 import { fetchProducts, updateProduct, deleteProduct, updateProductsViewers, getProductUrl, batchDownloadProducts, deleteProducts, reviewProduct, fetchProductStages, updateProductStage, startBatchDownload as startProductBatchDownload, getBatchDownloadProgress as getProductBatchDownloadProgress } from '../services/products'
 import { useUploadStore } from '../stores/upload'
 import { fetchUsers } from '../services/user'
@@ -342,8 +341,8 @@ const uploadRequest = async (event) => {
   loadData(currentFolder.value?._id)
 }
 
-async function pollProgress(progressId, name, type) {
-  const getProgress = type === 'folder' ? getFolderDownloadProgress : getProductBatchDownloadProgress;
+async function pollProgress(progressId, name) {
+  const getProgress = getProductBatchDownloadProgress;
   const taskId = `dl-${progressId}`;
   progressStore.addTask({ id: taskId, name, status: 'compressing', progress: 0 });
 
@@ -380,14 +379,6 @@ async function pollProgress(progressId, name, type) {
   poll();
 }
 
-async function downloadFolderItem(item) {
-  try {
-    const { progressId } = await startFolderBatchDownload(item._id);
-    pollProgress(progressId, item.name, 'folder');
-  } catch (error) {
-    toast.add({ severity: 'error', summary: 'Error', detail: '無法開始下載', life: 3000 });
-  }
-}
 
 async function downloadSingleItem(item) {
   try {
@@ -402,7 +393,7 @@ async function downloadSelected() {
   if (!selectedProducts.value.length) return;
   try {
     const { progressId } = await startProductBatchDownload(selectedProducts.value);
-    pollProgress(progressId, '批量下載', 'product');
+    pollProgress(progressId, '批量下載');
   } catch (error) {
      toast.add({ severity: 'error', summary: 'Error', detail: '無法開始下載', life: 3000 });
   }


### PR DESCRIPTION
## Summary
- 刪除 `AssetLibrary.vue`、`ProductLibrary.vue` 內資料夾下載按鈕與函式
- 更新下載進度輪詢函式 `pollProgress` 不再區分類型
- 移除不再使用的匯入與變數

## Testing
- `npm run lint` *(失敗：Missing script)*
- `npm test` *(失敗：jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889adf9e3008329accfddf13599bd38