### PR TITLE
Add download guard

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { useUploadStore } from '../stores/upload'
+import { useProgressStore } from '../stores/progress'
 
 import Login from '../views/Login.vue'
 import DashboardLayout from '../layouts/DashboardLayout.vue'
@@ -58,6 +59,12 @@ router.beforeEach(async (to) => {
     const leave = window.confirm('仍有上傳任務進行中，確定要離開嗎？')
     if (!leave) return false
     uploadStore.cancelAll()
+  }
+  const progressStore = useProgressStore()
+  if (progressStore.hasActiveDownloads) {
+    const leave = window.confirm('仍有下載任務進行中，離開會停止下載，確定要離開嗎？')
+    if (!leave) return false
+    progressStore.clearActiveDownloads()
   }
   const store = useAuthStore()
   if (to.meta.public) return true // 公開頁面

--- a/client/src/stores/progress.js
+++ b/client/src/stores/progress.js
@@ -4,8 +4,12 @@ import { ref, computed } from 'vue';
 export const useProgressStore = defineStore('progress', () => {
   const tasks = ref({});
 
-  const activeTasks = computed(() => 
+  const activeTasks = computed(() =>
     Object.values(tasks.value).sort((a, b) => b.startTime - a.startTime)
+  );
+
+  const hasActiveDownloads = computed(() =>
+    Object.values(tasks.value).some(task => task.status === 'compressing')
   );
 
   function addTask({ id, name, status = 'processing', progress = 0 }) {
@@ -42,12 +46,22 @@ export const useProgressStore = defineStore('progress', () => {
     delete tasks.value[id];
   }
 
+  function clearActiveDownloads() {
+    Object.keys(tasks.value).forEach(id => {
+      if (tasks.value[id].status === 'compressing') {
+        delete tasks.value[id];
+      }
+    });
+  }
+
   return {
     tasks,
     activeTasks,
+    hasActiveDownloads,
     addTask,
     updateTaskProgress,
     updateTaskStatus,
     removeTask,
+    clearActiveDownloads,
   };
 });


### PR DESCRIPTION
## Summary
- show confirmation when navigating away during active downloads
- track download tasks in progress store

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a053f2c108329b5a5921ac0f2a3bc