### PR TITLE
Fix cache import in product controller

### DIFF
--- a/server/src/controllers/product.controller.js
+++ b/server/src/controllers/product.controller.js
@@ -5,7 +5,7 @@ import fs from "node:fs/promises"
 import { createWriteStream } from "node:fs"
 import archiver from "archiver"
 import gcsUtil from "../utils/gcs.js"
-import cache from "../utils/cache.js"
+import * as cache from "../utils/cache.js"
 
 export const getProducts = async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- fix cache util import to use named exports

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a0b8903948329914866a7b0a55b22