### PR TITLE
Fix library root fetching

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -464,7 +464,7 @@ async function loadData(folderId = null) {
   try {
     const [folderData, assetData, currentFolderData] = await Promise.all([
       fetchFolders(folderId, filterTags.value, 'raw'),
-      folderId ? fetchAssets(folderId, 'raw', filterTags.value) : Promise.resolve([]),
+      fetchAssets(folderId, 'raw', filterTags.value),
       folderId ? getFolder(folderId) : Promise.resolve(null)
     ])
     folders.value = folderData

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -288,7 +288,7 @@ async function loadData(folderId = null) {
   try {
     const [folderData, productData, currentFolderData] = await Promise.all([
       fetchFolders(folderId, filterTags.value, 'edited'),
-      folderId ? fetchProducts(folderId, filterTags.value) : Promise.resolve([]),
+      fetchProducts(folderId, filterTags.value),
       folderId ? getFolder(folderId) : Promise.resolve(null)
     ])
     folders.value = folderData


### PR DESCRIPTION
## Summary
- update AssetLibrary loadData to always fetch assets
- update ProductLibrary loadData to always fetch products

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a1d6e746883298da7303aca54f091