### PR TITLE
Replace ADMIN permission check with specific codes

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -142,7 +142,10 @@ const adminMenuItems = computed(() => {
     { path: '/tags', label: '標籤管理', icon: 'pi pi-tags' }
   ]
   
-  if (authStore.hasPermission('ADMIN')) {
+  if (
+    authStore.hasPermission('user:manage') ||
+    authStore.hasPermission('role:manage')
+  ) {
     items.push(
       { path: '/employees', label: '員工管理', icon: 'pi pi-user-edit' },
       { path: '/roles', label: '角色設定', icon: 'pi pi-shield' },


### PR DESCRIPTION
## Summary
- update sidebar permission check to use `user:manage` or `role:manage`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a1d78896c83299ee50b5fa66e81c2