### PR TITLE
Remove obsolete menu item

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -139,7 +139,6 @@ const adminMenuItems = computed(() => {
   const items = [
     // 由於沒有獨立路由，統一導向 ad-clients
     { path: '/ad-clients', label: '客戶管理', icon: 'pi pi-users' },
-    { path: '/ad-clients', label: '平台管理', icon: 'pi pi-globe' },
     { path: '/tags', label: '標籤管理', icon: 'pi pi-tags' }
   ]
   


### PR DESCRIPTION
## Summary
- update sidebar admin menu to remove Platform Management

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a21a83cb48329879e9da34ae45cc8