### PR TITLE
Add router hook to management views

### DIFF
--- a/client/src/views/EmployeeManager.vue
+++ b/client/src/views/EmployeeManager.vue
@@ -57,6 +57,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import { useConfirm } from 'primevue/useconfirm'
 import { fetchUsers, createUser, updateUser, deleteUser } from '../services/user'
@@ -75,6 +76,7 @@ import Password from 'primevue/password'
 
 const toast = useToast()
 const confirm = useConfirm()
+const router = useRouter()
 const authStore = useAuthStore()
 
 if (!authStore.hasPermission('user:manage')) {

--- a/client/src/views/ReviewSettings.vue
+++ b/client/src/views/ReviewSettings.vue
@@ -44,6 +44,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import { useConfirm } from 'primevue/useconfirm'
 import { fetchReviewStages, createReviewStage, updateReviewStage, deleteReviewStage } from '../services/reviewStages'
@@ -62,6 +63,7 @@ import Dropdown from 'primevue/dropdown'
 
 const toast = useToast()
 const confirm = useConfirm()
+const router = useRouter()
 const authStore = useAuthStore()
 
 if (!authStore.hasPermission('review:manage')) {

--- a/client/src/views/RoleSettings.vue
+++ b/client/src/views/RoleSettings.vue
@@ -61,6 +61,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import { useConfirm } from 'primevue/useconfirm'
 import { fetchRoles, createRole, updateRole, deleteRole, fetchPermissions, fetchMenus } from '../services/roles'
@@ -80,6 +81,7 @@ import Tag from 'primevue/tag'
 
 const toast = useToast()
 const confirm = useConfirm()
+const router = useRouter()
 const authStore = useAuthStore()
 
 if (!authStore.hasPermission('role:manage')) {

--- a/client/src/views/TagManager.vue
+++ b/client/src/views/TagManager.vue
@@ -34,6 +34,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import { useConfirm } from 'primevue/useconfirm'
 import { fetchTags, createTag, updateTag, deleteTag } from '../services/tags'
@@ -49,6 +50,7 @@ import InputText from 'primevue/inputtext'
 
 const toast = useToast()
 const confirm = useConfirm()
+const router = useRouter()
 const authStore = useAuthStore()
 
 if (!authStore.hasPermission('tag:manage')) {


### PR DESCRIPTION
## Summary
- import `useRouter` and create router instance in management views
- ensure router navigation like `router.replace('/')` works

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a21a239088329b1a84ffaa8c4694f