### PR TITLE
Add Redis caching to more controllers

### DIFF
--- a/server/src/controllers/analytics.controller.js
+++ b/server/src/controllers/analytics.controller.js
@@ -2,7 +2,14 @@
  * \u6b64 controller \u672a\u4f7f\u7528\uff0c\u50c5\u4f5c\u70ba\u65b9\u6848\u4f9d\u4f5c\u8655\u3002
  * \u9019\u88e1\u50c5\u793a\u7bc4\u53d6\u5f97\u5047\u6578\u64da\uff1b\u5be6\u52d9\u4e0a\u53ef\u4e32\u63a5 Facebook / XHS API
  */
+import { getCache, setCache } from '../utils/cache.js'
+
 export const getSummary = async (_req, res) => {
+  const cacheKey = 'analytics:summary'
+  const cached = await getCache(cacheKey)
+  if (cached) return res.json(cached)
   // TODO: 待串接第三方服務取得統計資料
-  res.json([])
+  const data = []
+  await setCache(cacheKey, data)
+  res.json(data)
 }

--- a/server/src/controllers/client.controller.js
+++ b/server/src/controllers/client.controller.js
@@ -1,28 +1,42 @@
 import Client from '../models/client.model.js'
+import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
 
 export const createClient = async (req, res) => {
   const client = await Client.create(req.body)
+  await clearCacheByPrefix('clients:')
   res.status(201).json(client)
 }
 
 export const getClients = async (_req, res) => {
+  const cacheKey = 'clients:all'
+  const cached = await getCache(cacheKey)
+  if (cached) return res.json(cached)
   const clients = await Client.find()
+  await setCache(cacheKey, clients)
   res.json(clients)
 }
 
 export const getClient = async (req, res) => {
+  const cacheKey = `client:${req.params.id}`
+  const cached = await getCache(cacheKey)
+  if (cached) return res.json(cached)
   const client = await Client.findById(req.params.id)
   if (!client) return res.status(404).json({ message: '客戶不存在' })
+  await setCache(cacheKey, client)
   res.json(client)
 }
 
 export const updateClient = async (req, res) => {
   const client = await Client.findByIdAndUpdate(req.params.id, req.body, { new: true })
   if (!client) return res.status(404).json({ message: '客戶不存在' })
+  await clearCacheByPrefix('clients:')
+  await delCache(`client:${req.params.id}`)
   res.json(client)
 }
 
 export const deleteClient = async (req, res) => {
   await Client.findByIdAndDelete(req.params.id)
+  await clearCacheByPrefix('clients:')
+  await delCache(`client:${req.params.id}`)
   res.json({ message: '客戶已刪除' })
 }

--- a/server/src/controllers/reviewStage.controller.js
+++ b/server/src/controllers/reviewStage.controller.js
@@ -1,16 +1,22 @@
 import ReviewStage from '../models/reviewStage.model.js'
 import User from '../models/user.model.js'
+import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
 
 export const createStage = async (req, res) => {
   const user = await User.findById(req.body.responsible)
   if (!user) return res.status(400).json({ message: '找不到使用者' })
 
   const stage = await ReviewStage.create(req.body)
+  await clearCacheByPrefix('reviewStages:')
   res.status(201).json(stage)
 }
 
 export const getStages = async (_, res) => {
+  const cacheKey = 'reviewStages:all'
+  const cached = await getCache(cacheKey)
+  if (cached) return res.json(cached)
   const stages = await ReviewStage.find().populate('responsible').sort('order')
+  await setCache(cacheKey, stages)
   res.json(stages)
 }
 
@@ -22,10 +28,14 @@ export const updateStage = async (req, res) => {
 
   const stage = await ReviewStage.findByIdAndUpdate(req.params.id, req.body, { new: true })
   if (!stage) return res.status(404).json({ message: '階段不存在' })
+  await clearCacheByPrefix('reviewStages:')
+  await delCache(`reviewStage:${req.params.id}`)
   res.json(stage)
 }
 
 export const deleteStage = async (req, res) => {
   await ReviewStage.findByIdAndDelete(req.params.id)
+  await clearCacheByPrefix('reviewStages:')
+  await delCache(`reviewStage:${req.params.id}`)
   res.json({ message: '已刪除' })
 }

--- a/server/src/controllers/tag.controller.js
+++ b/server/src/controllers/tag.controller.js
@@ -1,28 +1,42 @@
 import Tag from '../models/tag.model.js'
+import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
 
 export const createTag = async (req, res) => {
   const tag = await Tag.create({ name: req.body.name })
+  await clearCacheByPrefix('tags:')
   res.status(201).json(tag)
 }
 
 export const getTags = async (_req, res) => {
+  const cacheKey = 'tags:all'
+  const cached = await getCache(cacheKey)
+  if (cached) return res.json(cached)
   const tags = await Tag.find()
+  await setCache(cacheKey, tags)
   res.json(tags)
 }
 
 export const getTag = async (req, res) => {
+  const cacheKey = `tag:${req.params.id}`
+  const cached = await getCache(cacheKey)
+  if (cached) return res.json(cached)
   const tag = await Tag.findById(req.params.id)
   if (!tag) return res.status(404).json({ message: '標籤不存在' })
+  await setCache(cacheKey, tag)
   res.json(tag)
 }
 
 export const updateTag = async (req, res) => {
   const tag = await Tag.findByIdAndUpdate(req.params.id, req.body, { new: true })
   if (!tag) return res.status(404).json({ message: '標籤不存在' })
+  await clearCacheByPrefix('tags:')
+  await delCache(`tag:${req.params.id}`)
   res.json(tag)
 }
 
 export const deleteTag = async (req, res) => {
   await Tag.findByIdAndDelete(req.params.id)
+  await clearCacheByPrefix('tags:')
+  await delCache(`tag:${req.params.id}`)
   res.json({ message: '標籤已刪除' })
 }


### PR DESCRIPTION
## Summary
- integrate Redis caching in controllers not previously cached
- clear related cache on CRUD operations

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2f602f24832986e6b750b7c99610