### PR TITLE
Implement message i18n module

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import mongoose from 'mongoose'
 import AdDaily from '../models/adDaily.model.js'
 import path from 'node:path'
@@ -99,7 +100,7 @@ export const getWeeklyData = async (req, res) => {
 
 export const bulkCreateAdDaily = async (req, res) => {
   if (!Array.isArray(req.body)) {
-    return res.status(400).json({ message: '資料格式錯誤' })
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
   }
 
   const known = ['date', 'spent', 'enquiries', 'reach', 'impressions', 'clicks', 'extraData', 'colors']
@@ -141,7 +142,7 @@ export const bulkCreateAdDaily = async (req, res) => {
 
 export const importAdDaily = async (req, res) => {
   if (!req.file) {
-    return res.status(400).json({ message: '未上傳檔案' })
+    return res.status(400).json({ message: t('FILE_NOT_UPLOADED') })
   }
 
   const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
@@ -223,7 +224,7 @@ export const updateAdDaily = async (req, res) => {
     },
     { new: true }
   )
-  if (!rec) return res.status(404).json({ message: '紀錄不存在' })
+  if (!rec) return res.status(404).json({ message: t('RECORD_NOT_FOUND') })
   await clearCacheByPrefix('adDaily:')
   res.json(rec)
 }
@@ -231,5 +232,5 @@ export const updateAdDaily = async (req, res) => {
 export const deleteAdDaily = async (req, res) => {
   await AdDaily.findByIdAndDelete(req.params.id)
   await clearCacheByPrefix('adDaily:')
-  res.json({ message: '紀錄已刪除' })
+  res.json({ message: t('RECORD_DELETED') })
 }

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import User from '../models/user.model.js'
 import Role from '../models/role.model.js'
 import { generateToken } from '../utils/generateToken.js'
@@ -9,7 +10,7 @@ export const login = async (req, res) => {
     .select('+password')
     .populate('roleId')
   if (!user || !(await user.matchPassword(password))) {
-    return res.status(401).json({ message: '\u5e33\u865f\u6216\u5bc6\u78bc\u932f\u8aa4' })
+    return res.status(401).json({ message: t('ACCOUNT_OR_PASSWORD_ERROR') })
   }
   const token = generateToken(user._id)
   res.json({
@@ -28,7 +29,7 @@ export const login = async (req, res) => {
 export const register = async (req, res) => {
   const { username, password, email, role } = req.body
   const exists = await User.findOne({ username })
-  if (exists) return res.status(400).json({ message: '\u4f7f\u7528\u8005\u5df2\u5b58\u5728' })
+  if (exists) return res.status(400).json({ message: t('USER_ALREADY_EXISTS') })
   const roleDoc = await Role.findOne({ name: role })
   const newUser = await User.create({
     username,

--- a/server/src/controllers/client.controller.js
+++ b/server/src/controllers/client.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import Client from '../models/client.model.js'
 import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
 
@@ -21,14 +22,14 @@ export const getClient = async (req, res) => {
   const cached = await getCache(cacheKey)
   if (cached) return res.json(cached)
   const client = await Client.findById(req.params.id)
-  if (!client) return res.status(404).json({ message: '客戶不存在' })
+  if (!client) return res.status(404).json({ message: t('CLIENT_NOT_FOUND') })
   await setCache(cacheKey, client)
   res.json(client)
 }
 
 export const updateClient = async (req, res) => {
   const client = await Client.findByIdAndUpdate(req.params.id, req.body, { new: true })
-  if (!client) return res.status(404).json({ message: '客戶不存在' })
+  if (!client) return res.status(404).json({ message: t('CLIENT_NOT_FOUND') })
   await clearCacheByPrefix('clients:')
   await delCache(`client:${req.params.id}`)
   res.json(client)
@@ -38,5 +39,5 @@ export const deleteClient = async (req, res) => {
   await Client.findByIdAndDelete(req.params.id)
   await clearCacheByPrefix('clients:')
   await delCache(`client:${req.params.id}`)
-  res.json({ message: '客戶已刪除' })
+  res.json({ message: t('CLIENT_DELETED') })
 }

--- a/server/src/controllers/folderReviewRecord.controller.js
+++ b/server/src/controllers/folderReviewRecord.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import ReviewStage from '../models/reviewStage.model.js'
 import FolderReviewRecord from '../models/folderReviewRecord.model.js'
 import Folder from '../models/folder.model.js'
@@ -30,10 +31,10 @@ export const updateFolderStageStatus = async (req, res) => {
   const skipPrevCheck = req.body.skipPrevCheck === true || req.query.skipPrevCheck === '1'
 
   const stage = await ReviewStage.findById(stageId).populate('responsible')
-  if (!stage) return res.status(404).json({ message: '階段不存在' })
+  if (!stage) return res.status(404).json({ message: t('REVIEW_STAGE_NOT_FOUND') })
 
   if (String(stage.responsible._id) !== String(req.user._id)) {
-    return res.status(403).json({ message: '無權審核此階段' })
+    return res.status(403).json({ message: t('REVIEW_STAGE_NOT_ALLOWED') })
   }
 
   if (completed && !skipPrevCheck) {
@@ -46,7 +47,7 @@ export const updateFolderStageStatus = async (req, res) => {
         completed: true
       })
       if (doneCount < prevStages.length) {
-        return res.status(400).json({ message: '前置審核未完成' })
+        return res.status(400).json({ message: t('PRE_REVIEW_UNFINISHED') })
       }
     }
   }

--- a/server/src/controllers/platform.controller.js
+++ b/server/src/controllers/platform.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import Platform from '../models/platform.model.js'
 import AdDaily from '../models/adDaily.model.js'
 import WeeklyNote from '../models/weeklyNote.model.js'
@@ -17,7 +18,7 @@ export const createPlatform = async (req, res) => {
     res.status(201).json(platform)
   } catch (err) {
     if (err.code === 11000) {
-      return res.status(409).json({ message: '平台名稱重複' })
+      return res.status(409).json({ message: t('PLATFORM_NAME_DUPLICATE') })
     }
     throw err
   }
@@ -37,7 +38,7 @@ export const getPlatform = async (req, res) => {
   const cached = await getCache(cacheKey)
   if (cached) return res.json(cached)
   const p = await Platform.findOne({ _id: req.params.id, clientId: req.params.clientId })
-  if (!p) return res.status(404).json({ message: '平台不存在' })
+  if (!p) return res.status(404).json({ message: t('PLATFORM_NOT_FOUND') })
   await setCache(cacheKey, p)
   res.json(p)
 }
@@ -50,13 +51,13 @@ export const updatePlatform = async (req, res) => {
       { name, platformType, fields, mode },
       { new: true }
     )
-    if (!p) return res.status(404).json({ message: '平台不存在' })
+    if (!p) return res.status(404).json({ message: t('PLATFORM_NOT_FOUND') })
     await clearCacheByPrefix('platforms:')
     await delCache(`platform:${req.params.id}`)
     res.json(p)
   } catch (err) {
     if (err.code === 11000) {
-      return res.status(409).json({ message: '平台名稱重複' })
+      return res.status(409).json({ message: t('PLATFORM_NAME_DUPLICATE') })
     }
     throw err
   }
@@ -66,16 +67,16 @@ export const deletePlatform = async (req, res) => {
   await Platform.findOneAndDelete({ _id: req.params.id, clientId: req.params.clientId })
   await clearCacheByPrefix('platforms:')
   await delCache(`platform:${req.params.id}`)
-  res.json({ message: '平台已刪除' })
+  res.json({ message: t('PLATFORM_DELETED') })
 }
 
 export const transferPlatform = async (req, res) => {
   const { clientId } = req.body
   if (!clientId) {
-    return res.status(400).json({ message: '缺少 clientId' })
+    return res.status(400).json({ message: t('MISSING_CLIENT_ID') })
   }
   const platform = await Platform.findById(req.params.id)
-  if (!platform) return res.status(404).json({ message: '平台不存在' })
+  if (!platform) return res.status(404).json({ message: t('PLATFORM_NOT_FOUND') })
   platform.clientId = clientId
   await platform.save()
   await AdDaily.updateMany({ platformId: req.params.id }, { clientId })

--- a/server/src/controllers/product.controller.js
+++ b/server/src/controllers/product.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import Asset from '../models/asset.model.js';
 import { getAssets } from './asset.controller.js';
 import path from 'node:path';
@@ -15,7 +16,7 @@ export const getProducts = async (req, res) => {
 export const batchDownload = async (req, res) => {
   const { ids } = req.body;
   if (!Array.isArray(ids) || !ids.length) {
-    return res.status(400).json({ message: '參數錯誤' });
+    return res.status(400).json({ message: t('PARAMS_ERROR') });
   }
 
   const progressId = Date.now().toString(36) + Math.random().toString(36).slice(2);

--- a/server/src/controllers/reviewRecord.controller.js
+++ b/server/src/controllers/reviewRecord.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import ReviewStage from '../models/reviewStage.model.js'
 import ReviewRecord from '../models/reviewRecord.model.js'
 import Asset from '../models/asset.model.js'
@@ -35,10 +36,10 @@ export const updateStageStatus = async (req, res) => {
   const skipPrevCheck = req.body.skipPrevCheck === true || req.query.skipPrevCheck === '1'
 
   const stage = await ReviewStage.findById(stageId).populate('responsible')
-  if (!stage) return res.status(404).json({ message: '階段不存在' })
+  if (!stage) return res.status(404).json({ message: t('REVIEW_STAGE_NOT_FOUND') })
 
   if (!fromDashboard && String(stage.responsible._id) !== String(req.user._id)) {
-    return res.status(403).json({ message: '無權審核此階段' })
+    return res.status(403).json({ message: t('REVIEW_STAGE_NOT_ALLOWED') })
   }
 
   // 檢查前置審核是否完成
@@ -52,7 +53,7 @@ export const updateStageStatus = async (req, res) => {
         completed: true
       })
       if (doneCount < prevStages.length) {
-        return res.status(400).json({ message: '前置審核未完成' })
+        return res.status(400).json({ message: t('PRE_REVIEW_UNFINISHED') })
       }
     }
   }

--- a/server/src/controllers/reviewStage.controller.js
+++ b/server/src/controllers/reviewStage.controller.js
@@ -1,10 +1,11 @@
+import { t } from '../i18n/messages.js'
 import ReviewStage from '../models/reviewStage.model.js'
 import User from '../models/user.model.js'
 import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
 
 export const createStage = async (req, res) => {
   const user = await User.findById(req.body.responsible)
-  if (!user) return res.status(400).json({ message: '找不到使用者' })
+  if (!user) return res.status(400).json({ message: t('USER_NOT_FOUND') })
 
   const stage = await ReviewStage.create(req.body)
   await clearCacheByPrefix('reviewStages:')
@@ -23,11 +24,11 @@ export const getStages = async (_, res) => {
 export const updateStage = async (req, res) => {
   if (req.body.responsible) {
     const user = await User.findById(req.body.responsible)
-    if (!user) return res.status(400).json({ message: '找不到使用者' })
+    if (!user) return res.status(400).json({ message: t('USER_NOT_FOUND') })
   }
 
   const stage = await ReviewStage.findByIdAndUpdate(req.params.id, req.body, { new: true })
-  if (!stage) return res.status(404).json({ message: '階段不存在' })
+  if (!stage) return res.status(404).json({ message: t('REVIEW_STAGE_NOT_FOUND') })
   await clearCacheByPrefix('reviewStages:')
   await delCache(`reviewStage:${req.params.id}`)
   res.json(stage)
@@ -37,5 +38,5 @@ export const deleteStage = async (req, res) => {
   await ReviewStage.findByIdAndDelete(req.params.id)
   await clearCacheByPrefix('reviewStages:')
   await delCache(`reviewStage:${req.params.id}`)
-  res.json({ message: '已刪除' })
+  res.json({ message: t('DELETED') })
 }

--- a/server/src/controllers/role.controller.js
+++ b/server/src/controllers/role.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import Role from '../models/role.model.js'
 import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
 
@@ -25,7 +26,7 @@ export const getRole = async (req, res) => {
   const cached = await getCache(cacheKey)
   if (cached) return res.json(cached)
   const role = await Role.findById(req.params.id)
-  if (!role) return res.status(404).json({ message: '\u89d2\u8272\u4e0d\u5b58\u5728' })
+  if (!role) return res.status(404).json({ message: t('ROLE_NOT_FOUND') })
   await setCache(cacheKey, role)
   res.json(role)
 }
@@ -40,7 +41,7 @@ export const updateRole = async (req, res) => {
     },
     { new: true }
   )
-  if (!role) return res.status(404).json({ message: '\u89d2\u8272\u4e0d\u5b58\u5728' })
+  if (!role) return res.status(404).json({ message: t('ROLE_NOT_FOUND') })
   await clearCacheByPrefix('roles:')
   await delCache(`role:${req.params.id}`)
   res.json(role)
@@ -50,5 +51,5 @@ export const deleteRole = async (req, res) => {
   await Role.findByIdAndDelete(req.params.id)
   await clearCacheByPrefix('roles:')
   await delCache(`role:${req.params.id}`)
-  res.json({ message: '\u89d2\u8272\u5df2\u522a\u9664' })
+  res.json({ message: t('ROLE_DELETED') })
 }

--- a/server/src/controllers/tag.controller.js
+++ b/server/src/controllers/tag.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import Tag from '../models/tag.model.js'
 import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
 
@@ -21,14 +22,14 @@ export const getTag = async (req, res) => {
   const cached = await getCache(cacheKey)
   if (cached) return res.json(cached)
   const tag = await Tag.findById(req.params.id)
-  if (!tag) return res.status(404).json({ message: '標籤不存在' })
+  if (!tag) return res.status(404).json({ message: t('TAG_NOT_FOUND') })
   await setCache(cacheKey, tag)
   res.json(tag)
 }
 
 export const updateTag = async (req, res) => {
   const tag = await Tag.findByIdAndUpdate(req.params.id, req.body, { new: true })
-  if (!tag) return res.status(404).json({ message: '標籤不存在' })
+  if (!tag) return res.status(404).json({ message: t('TAG_NOT_FOUND') })
   await clearCacheByPrefix('tags:')
   await delCache(`tag:${req.params.id}`)
   res.json(tag)
@@ -38,5 +39,5 @@ export const deleteTag = async (req, res) => {
   await Tag.findByIdAndDelete(req.params.id)
   await clearCacheByPrefix('tags:')
   await delCache(`tag:${req.params.id}`)
-  res.json({ message: '標籤已刪除' })
+  res.json({ message: t('TAG_DELETED') })
 }

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import User from '../models/user.model.js'
 import Role from '../models/role.model.js'
 import { getCache, setCache, clearCacheByPrefix } from '../utils/cache.js'
@@ -31,7 +32,7 @@ export const getAllUsers = async (req,res) => {
 /* 新增 */
 export const createUser = async (req,res) => {
   const { username, name, email, role, password } = req.body
-  if (await User.findOne({ email })) return res.status(400).json({ message:'Email 已存在' })
+  if (await User.findOne({ email })) return res.status(400).json({ message: t('EMAIL_ALREADY_EXISTS') })
   const roleDoc = await Role.findOne({ name: role })
   const u = await User.create({ username, name, email, roleId: roleDoc?._id, password })
   const populated = await u.populate('roleId')
@@ -48,11 +49,11 @@ export const createUser = async (req,res) => {
 export const updateUser = async (req,res) => {
   const { username, name, email, role, password } = req.body
   const u = await User.findById(req.params.id)
-  if (!u) return res.status(404).json({ message:'找不到使用者' })
+  if (!u) return res.status(404).json({ message: t('USER_NOT_FOUND') })
   if (username && username!==u.username && await User.findOne({ username }))
-    return res.status(400).json({ message:'使用者已存在' })
+    return res.status(400).json({ message: t('USER_ALREADY_EXISTS') })
   if (email && email!==u.email && await User.findOne({ email }))
-    return res.status(400).json({ message:'Email 已存在' })
+    return res.status(400).json({ message: t('EMAIL_ALREADY_EXISTS') })
   if (username) u.username = username
   if (name)  u.name  = name
   if (email) u.email = email
@@ -76,7 +77,7 @@ export const updateUser = async (req,res) => {
 export const deleteUser = async (req,res) => {
   await User.findByIdAndDelete(req.params.id)
   await clearCacheByPrefix('users:')
-  res.json({ message:'已刪除' })
+  res.json({ message: t('DELETED') })
 }
 
 /* 取得個人資料 */
@@ -94,11 +95,11 @@ export const getProfile = async (req,res) => {
 export const updateProfile = async (req,res) => {
   const { username, name, email, password } = req.body
   const u = await User.findById(req.user._id)
-  if (!u) return res.status(404).json({ message:'找不到使用者' })
+  if (!u) return res.status(404).json({ message: t('USER_NOT_FOUND') })
   if (username && username!==u.username && await User.findOne({ username }))
-    return res.status(400).json({ message:'使用者已存在' })
+    return res.status(400).json({ message: t('USER_ALREADY_EXISTS') })
   if (email && email!==u.email && await User.findOne({ email }))
-    return res.status(400).json({ message:'Email 已存在' })
+    return res.status(400).json({ message: t('EMAIL_ALREADY_EXISTS') })
   if (username) u.username = username
   if (name)     u.name     = name
   if (email)    u.email    = email

--- a/server/src/controllers/weeklyNote.controller.js
+++ b/server/src/controllers/weeklyNote.controller.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import WeeklyNote from '../models/weeklyNote.model.js'
 import path from 'node:path'
 import { uploadFile, getSignedUrl } from '../utils/gcs.js'
@@ -77,7 +78,7 @@ export const updateWeeklyNote = async (req, res) => {
     update,
     { new: true }
   )
-  if (!note) return res.status(404).json({ message: '備註不存在' })
+  if (!note) return res.status(404).json({ message: t('NOTE_NOT_FOUND') })
   await clearCacheByPrefix('weeklyNotes:')
   await delCache(`weeklyNote:${req.params.clientId}:${req.params.platformId}:${req.params.week}`)
   res.json(note)
@@ -97,7 +98,7 @@ export const getWeeklyNotes = async (req, res) => {
 
 export const getWeeklyImageUrl = async (req, res) => {
   const filePath = req.query.path
-  if (!filePath) return res.status(400).json({ message: '缺少 path 參數' })
+  if (!filePath) return res.status(400).json({ message: t('PATH_MISSING') })
   const url = await getSignedUrl(filePath)
   res.json({ url })
 }

--- a/server/src/i18n/messages.js
+++ b/server/src/i18n/messages.js
@@ -1,0 +1,52 @@
+export const languages = {
+  zhCN: {
+    ACCOUNT_OR_PASSWORD_ERROR: '账号或密码错误',
+    USER_ALREADY_EXISTS: '用户已存在',
+    EMAIL_ALREADY_EXISTS: 'Email 已存在',
+    USER_NOT_FOUND: '找不到用户',
+    TOKEN_INVALID: 'Token 无效',
+    NOT_LOGGED_IN: '未登录或 Token 错误',
+    PERMISSION_DENIED: '权限不足',
+    ROLE_NOT_FOUND: '角色不存在',
+    ROLE_DELETED: '角色已删除',
+    CLIENT_NOT_FOUND: '客户不存在',
+    CLIENT_DELETED: '客户已删除',
+    PLATFORM_NOT_FOUND: '平台不存在',
+    PLATFORM_NAME_DUPLICATE: '平台名称重复',
+    PLATFORM_DELETED: '平台已删除',
+    FOLDER_NOT_FOUND: '资料夹不存在',
+    FOLDER_DELETED: '资料夹已删除',
+    PARENT_FOLDER_NOT_FOUND: '父层资料夹不存在',
+    TARGET_FOLDER_NOT_FOUND: '目标资料夹不存在',
+    ASSET_NOT_FOUND: '找不到素材',
+    ASSET_DELETED: '素材已删除',
+    FILE_NOT_UPLOADED: '未上传档案',
+    STATUS_ERROR: '状态错误',
+    PARAMS_ERROR: '参数错误',
+    RECORD_NOT_FOUND: '记录不存在',
+    RECORD_DELETED: '记录已删除',
+    TAG_NOT_FOUND: '标签不存在',
+    TAG_DELETED: '标签已删除',
+    DATA_FORMAT_ERROR: '资料格式错误',
+    REVIEW_STAGE_NOT_FOUND: '阶段不存在',
+    REVIEW_STAGE_NOT_ALLOWED: '无权审核此阶段',
+    PRE_REVIEW_UNFINISHED: '前置审核未完成',
+    NOTE_NOT_FOUND: '备注不存在',
+    PATH_MISSING: '缺少 path 参数',
+    MISSING_FILENAME: '缺少档名',
+    MISSING_FILENAME_OR_PATH: '缺少档名或路径',
+    MISSING_CLIENT_ID: '缺少 clientId',
+    UPDATED: '已更新',
+    MOVED: '已移动',
+    DELETED: '已删除'
+  },
+  en: {
+    // TODO: add English translations
+  }
+}
+
+export const DEFAULT_LANG = 'zhCN'
+
+export function t(key, lang = DEFAULT_LANG) {
+  return languages[lang]?.[key] || key
+}

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 /**
  * 驗證 JWT，並把登入者寫入 req.user
  */
@@ -15,7 +16,7 @@ export const protect = async (req, res, next) => {
 
   /* 沒帶 Bearer Token */
   if (!authHeader?.startsWith('Bearer ')) {
-    return res.status(401).json({ message: '未登入或 Token 錯誤' });
+    return res.status(401).json({ message: t('NOT_LOGGED_IN') });
   }
 
   try {
@@ -26,12 +27,12 @@ export const protect = async (req, res, next) => {
       .select('-password')
       .populate('roleId');
     if (!user) {
-      return res.status(404).json({ message: '使用者不存在' });
+      return res.status(404).json({ message: t('USER_NOT_FOUND') });
     }
 
     req.user = user;
     next();
   } catch (err) {
-    return res.status(401).json({ message: 'Token 無效' });
+    return res.status(401).json({ message: t('TOKEN_INVALID') });
   }
 };

--- a/server/src/middleware/permission.js
+++ b/server/src/middleware/permission.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 import Role from '../models/role.model.js'
 
 export const requirePerm = (...perms) => async (req, res, next) => {
@@ -10,7 +11,7 @@ export const requirePerm = (...perms) => async (req, res, next) => {
 
   const allowed = role && perms.every(p => role.permissions.includes(p))
   if (!allowed) {
-    return res.status(403).json({ message: '權限不足' })
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
   }
   next()
 }

--- a/server/src/middleware/roleGuard.js
+++ b/server/src/middleware/roleGuard.js
@@ -1,3 +1,4 @@
+import { t } from '../i18n/messages.js'
 /**
  * \u9650\u5236\u7279\u5b9a\u89d2\u8272\u624d\u80fd\u5b58\u53d6
  */
@@ -5,7 +6,7 @@ export const authorize =
   (...roles) =>
   (req, res, next) => {
     if (!roles.includes(req.user.roleId?.name)) {
-      return res.status(403).json({ message: '\u6b0a\u9650\u4e0d\u8db3' })
+      return res.status(403).json({ message: t('PERMISSION_DENIED') })
     }
     next()
   }

--- a/server/tests/platform.test.js
+++ b/server/tests/platform.test.js
@@ -6,6 +6,7 @@ import authRoutes from '../src/routes/auth.routes.js'
 import clientRoutes from '../src/routes/client.routes.js'
 import platformRoutes from '../src/routes/platform.routes.js'
 import platformTransferRoutes from '../src/routes/platformTransfer.routes.js'
+import { t } from '../src/i18n/messages.js'
 import User from '../src/models/user.model.js'
 import Role from '../src/models/role.model.js'
 import dotenv from 'dotenv'
@@ -128,7 +129,7 @@ describe('Platform API', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'Dup', platformType: 'Meta' })
       .expect(409)
-    expect(res.body.message).toBe('平台名稱重複')
+    expect(res.body.message).toBe(t('PLATFORM_NAME_DUPLICATE'))
   })
 
   it('transfer platform to another client', async () => {


### PR DESCRIPTION
## Summary
- add `messages.js` with zhCN messages and translator function
- replace hard-coded Chinese messages in controllers and middleware
- import new messages in tests

## Testing
- `NODE_OPTIONS='--experimental-vm-modules' node server/node_modules/jest/bin/jest.js` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d0b6afc388329816f5a2f750e1972