### PR TITLE
更新系統名稱顯示為 Golden Goose Media

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>內部系統</title>
+    <title>Golden Goose Media</title>
   </head>
   <body>
     <div id="app"></div>

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -22,7 +22,7 @@
             <i class="pi pi-heart-fill"></i>
           </div>
           <div v-if="!isCollapsed" class="brand-text">
-            <h2>Sister</h2>
+            <h2>Golden Goose Media</h2>
             <span class="brand-subtitle">管理系統</span>
           </div>
         </div>

--- a/client/src/layouts/DashboardLayout.vue
+++ b/client/src/layouts/DashboardLayout.vue
@@ -10,7 +10,7 @@
       <div class="mobile-header-title">
         <div class="mobile-brand">
           <i class="pi pi-heart-fill mobile-brand-icon"></i>
-          <h2 class="mobile-brand-text">Sister</h2>
+          <h2 class="mobile-brand-text">Golden Goose Media</h2>
         </div>
       </div>
       <div class="mobile-header-actions">

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sister-root",
+  "name": "golden-goose-media-root",
   "private": true,
   "engines": {
     "node": "18.x"


### PR DESCRIPTION
## 變更內容
- Sidebar 與 DashboardLayout 的標題改為 `Golden Goose Media`
- index.html 標題更新
- package.json 的專案名稱同步更名

## 測試
- `npm test` *(失敗：`experimental-vm-modules` 參數無法辨識)*

------
https://chatgpt.com/codex/tasks/task_e_688d0b5bfd0083299406afa7fceff789