### PR TITLE
Convert key UI text to simplified Chinese

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -23,7 +23,7 @@
           </div>
           <div v-if="!isCollapsed" class="brand-text">
             <h2>Golden Goose Media</h2>
-            <span class="brand-subtitle">管理系統</span>
+            <span class="brand-subtitle">管理系统</span>
           </div>
         </div>
         <Button
@@ -88,8 +88,8 @@
             <div class="user-status"></div>
           </div>
           <div v-if="!isCollapsed" class="user-info">
-            <div class="user-name">{{ authStore.user?.name || '用戶' }}</div>
-            <div class="user-role">{{ authStore.user?.role || '一般用戶' }}</div>
+            <div class="user-name">{{ authStore.user?.name || '用户' }}</div>
+            <div class="user-role">{{ authStore.user?.role || '一般用户' }}</div>
           </div>
           <Button
             v-if="!isCollapsed"
@@ -128,18 +128,18 @@ const isCollapsed = ref(false)
 const isMobile = ref(window.innerWidth <= 991)
 
 const mainMenuItems = [
-  { path: '/dashboard', label: '儀表板', icon: 'pi pi-home', badge: null },
-  { path: '/assets', label: '素材庫', icon: 'pi pi-images', badge: null },
-  { path: '/products', label: '成品區', icon: 'pi pi-box', badge: '3' },
+  { path: '/dashboard', label: '仪表板', icon: 'pi pi-home', badge: null },
+  { path: '/assets', label: '素材库', icon: 'pi pi-images', badge: null },
+  { path: '/products', label: '成品区', icon: 'pi pi-box', badge: '3' },
 
-  // { path: '/ad-data', label: '廣告數據', icon: 'pi pi-chart-line', badge: null }
+  // { path: '/ad-data', label: '广告数据', icon: 'pi pi-chart-line', badge: null }
 ]
 
 const adminMenuItems = computed(() => {
   const items = [
     // 由於沒有獨立路由，統一導向 ad-clients
-    { path: '/ad-clients', label: '廣告數據', icon: 'pi pi-users' },
-    { path: '/tags', label: '標籤管理', icon: 'pi pi-tags' }
+    { path: '/ad-clients', label: '广告数据', icon: 'pi pi-users' },
+    { path: '/tags', label: '标签管理', icon: 'pi pi-tags' }
   ]
   
   if (
@@ -147,9 +147,9 @@ const adminMenuItems = computed(() => {
     authStore.hasPermission('role:manage')
   ) {
     items.push(
-      { path: '/employees', label: '員工管理', icon: 'pi pi-user-edit' },
-      { path: '/roles', label: '角色設定', icon: 'pi pi-shield' },
-      { path: '/review-settings', label: '審查設定', icon: 'pi pi-cog' }
+      { path: '/employees', label: '员工管理', icon: 'pi pi-user-edit' },
+      { path: '/roles', label: '角色设定', icon: 'pi pi-shield' },
+      { path: '/review-settings', label: '审查设定', icon: 'pi pi-cog' }
     )
   }
   

--- a/client/src/menuNames.js
+++ b/client/src/menuNames.js
@@ -1,12 +1,12 @@
 export const MENU_NAMES = {
-  dashboard: '首頁',
-  progress: '進度追踪',
-  assets: '素材庫',
-  products: '成品區',
-  employees: '人員管理',
-  roles: '角色設定',
-  tags: '標籤管理',
-  'review-stages': '審查關卡',
-  'ad-data': '廣告數據',
-  account: '帳號資訊'
+  dashboard: '首页',
+  progress: '进度追踪',
+  assets: '素材库',
+  products: '成品区',
+  employees: '人员管理',
+  roles: '角色设定',
+  tags: '标签管理',
+  'review-stages': '审查关卡',
+  'ad-data': '广告数据',
+  account: '帐号资讯'
 }

--- a/client/src/permissionNames.js
+++ b/client/src/permissionNames.js
@@ -1,14 +1,14 @@
 export const PERMISSION_NAMES = {
-  'asset:create': '素材庫/成品區上傳素材',
+  'asset:create': '素材库/成品区上传素材',
   'asset:read': '素材查看',
-  'asset:update': '編輯素材資訊或設定可查看者',
-  'asset:delete': '刪除素材',
-  'folder:read': '資料夾瀏覽',
-  'folder:manage': '新增、編輯或刪除資料夾及設定可查看者',
-  'user:manage': '管理使用者帳號',
-  'task:manage': '任務建立與追蹤',
-  'review:manage': '成品審查流程',
-  'tag:manage': '標籤管理',
-  'role:manage': '角色權限設定',
-  'analytics:view': '查看統計資料'
+  'asset:update': '编辑素材资讯或设定可查看者',
+  'asset:delete': '删除素材',
+  'folder:read': '资料夹浏览',
+  'folder:manage': '新增、编辑或删除资料夹及设定可查看者',
+  'user:manage': '管理使用者帐号',
+  'task:manage': '任务建立与追踪',
+  'review:manage': '成品审查流程',
+  'tag:manage': '标签管理',
+  'role:manage': '角色权限设定',
+  'analytics:view': '查看统计资料'
 }

--- a/client/src/views/Account.vue
+++ b/client/src/views/Account.vue
@@ -2,12 +2,12 @@
 <template>
   <Card class="w-full md:w-30rem">
     <template #title>
-      <h1 class="text-2xl font-bold">帳號資訊</h1>
+      <h1 class="text-2xl font-bold">帐号资讯</h1>
     </template>
     <template #content>
       <form @submit.prevent="onSubmit" class="p-fluid">
         <div class="field">
-          <label for="username">登入帳號</label>
+          <label for="username">登录帐号</label>
           <InputText id="username" v-model.trim="username" />
         </div>
         <div class="field">
@@ -20,7 +20,7 @@
         </div>
         <div class="field">
           <label for="password">新密碼</label>
-          <Password id="password" v-model="password" placeholder="留空則不變更" :feedback="false" toggleMask />
+          <Password id="password" v-model="password" placeholder="留空则不变更" :feedback="false" toggleMask />
         </div>
         <Button type="submit" label="更新資料" class="w-full mt-4" />
       </form>

--- a/client/src/views/AdClients.vue
+++ b/client/src/views/AdClients.vue
@@ -3,13 +3,13 @@
   <Card>
     <template #title>
       <div class="flex justify-content-between align-items-center">
-        <h1 class="text-2xl font-bold">廣告數據</h1>
-        <Button label="新增客戶" icon="pi pi-plus" @click="openCreate" />
+        <h1 class="text-2xl font-bold">广告数据</h1>
+        <Button label="新增客户" icon="pi pi-plus" @click="openCreate" />
       </div>
     </template>
     <template #content>
       <DataTable :value="clients" :loading="loading" responsiveLayout="scroll">
-        <Column field="name" header="客戶名稱" :sortable="true"></Column>
+        <Column field="name" header="客户名称" :sortable="true"></Column>
         <Column header="操作" :exportable="false" style="min-width:12rem">
           <template #body="{ data }">
             <Button label="平台" icon="pi pi-sitemap" class="p-button-text p-button-info" @click="managePlatforms(data)" />
@@ -21,9 +21,9 @@
     </template>
   </Card>
 
-  <Dialog v-model:visible="dialog" :header="editing ? '編輯客戶' : '新增客戶'" :modal="true" class="p-fluid w-full md:w-20rem">
+  <Dialog v-model:visible="dialog" :header="editing ? '编辑客户' : '新增客户'" :modal="true" class="p-fluid w-full md:w-20rem">
     <div class="field">
-      <label for="name">客戶名稱</label>
+      <label for="name">客户名称</label>
       <InputText id="name" v-model.trim="form.name" required="true" autofocus />
     </div>
     <template #footer>
@@ -108,8 +108,8 @@ const managePlatforms = (client) => {
 
 const confirmDeleteClient = (client) => {
   confirm.require({
-    message: `確定要刪除「${client.name}」嗎？`,
-    header: '刪除確認',
+    message: `确定要删除「${client.name}」吗？`,
+    header: '删除确认',
     icon: 'pi pi-exclamation-triangle',
     acceptClass: 'p-button-danger',
     accept: async () => {

--- a/client/src/views/EmployeeManager.vue
+++ b/client/src/views/EmployeeManager.vue
@@ -3,13 +3,13 @@
   <Card>
     <template #title>
       <div class="flex justify-content-between align-items-center">
-        <h1 class="text-2xl font-bold">員工帳號管理</h1>
-        <Button label="新增帳號" icon="pi pi-plus" @click="openCreate" />
+        <h1 class="text-2xl font-bold">员工帐号管理</h1>
+        <Button label="新增帐号" icon="pi pi-plus" @click="openCreate" />
       </div>
     </template>
     <template #content>
       <DataTable :value="users" :loading="loading" responsiveLayout="scroll">
-        <Column field="username" header="登入帳號" :sortable="true"></Column>
+        <Column field="username" header="登录帐号" :sortable="true"></Column>
         <Column field="name" header="姓名" :sortable="true"></Column>
         <Column field="email" header="Email" :sortable="true"></Column>
         <Column field="role" header="角色" :sortable="true">
@@ -27,9 +27,9 @@
     </template>
   </Card>
 
-  <Dialog v-model:visible="dialog" :header="editing ? '編輯帳號' : '新增帳號'" :modal="true" class="p-fluid w-full md:w-30rem">
+  <Dialog v-model:visible="dialog" :header="editing ? '编辑帐号' : '新增帐号'" :modal="true" class="p-fluid w-full md:w-30rem">
     <div class="field">
-      <label for="username">登入帳號</label>
+      <label for="username">登录帐号</label>
       <InputText id="username" v-model.trim="form.username" required="true" autofocus />
     </div>
     <div class="field">
@@ -46,7 +46,7 @@
     </div>
     <div class="field">
       <label for="password">密碼</label>
-      <Password id="password" v-model="form.password" :placeholder="editing ? '留空則不變' : ''" :feedback="false" toggleMask />
+      <Password id="password" v-model="form.password" :placeholder="editing ? '留空则不变' : ''" :feedback="false" toggleMask />
     </div>
     <template #footer>
       <Button label="取消" icon="pi pi-times" class="p-button-text" @click="dialog = false"/>
@@ -150,8 +150,8 @@ const submit = async () => {
 
 const confirmDeleteUser = (user) => {
   confirm.require({
-    message: `確定要刪除「${user.name}」嗎？`,
-    header: '刪除確認',
+    message: `确定要删除「${user.name}」吗？`,
+    header: '删除确认',
     icon: 'pi pi-exclamation-triangle',
     acceptClass: 'p-button-danger',
     accept: async () => {

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -2,14 +2,14 @@
   <div class="login-page">
     <Card class="login-card">
       <template #title>
-        <div class="text-center text-2xl font-bold">系統登入</div>
+        <div class="text-center text-2xl font-bold">系统登录</div>
       </template>
       <template #content>
         <form @submit.prevent="onSubmit" class="p-fluid">
           <div class="field">
             <span class="p-input-icon-left">
               <i class="pi pi-user" />
-              <InputText id="username" v-model="username" placeholder="使用者名稱" />
+              <InputText id="username" v-model="username" placeholder="使用者名称" />
             </span>
           </div>
           <div class="field">
@@ -18,13 +18,13 @@
               <Password
                 id="password"
                 v-model="password"
-                placeholder="密碼"
+                placeholder="密码"
                 :feedback="false"
                 toggleMask
               />
             </span>
           </div>
-          <Button type="submit" label="登入" class="w-full mt-4" />
+          <Button type="submit" label="登录" class="w-full mt-4" />
         </form>
       </template>
     </Card>
@@ -51,7 +51,7 @@ const onSubmit = async () => {
     await store.login(username.value, password.value)
     router.push(route.query.redirect || '/')
   } catch (e) {
-    // 可以在這裡觸發 PrimeVue 的 Toast 來顯示錯誤
+    // 可以在这里触发 PrimeVue 的 Toast 来显示错误
     console.error('Login failed:', e)
   }
 }

--- a/client/src/views/ReviewSettings.vue
+++ b/client/src/views/ReviewSettings.vue
@@ -3,15 +3,15 @@
   <Card>
     <template #title>
       <div class="flex justify-content-between align-items-center">
-        <h1 class="text-2xl font-bold">審查關卡設定</h1>
-        <Button label="新增關卡" icon="pi pi-plus" @click="openCreate" />
+        <h1 class="text-2xl font-bold">审查关卡设定</h1>
+        <Button label="新增关卡" icon="pi pi-plus" @click="openCreate" />
       </div>
     </template>
     <template #content>
       <DataTable :value="stages" :loading="loading" responsiveLayout="scroll">
-        <Column field="order" header="順序" :sortable="true" style="width: 80px"></Column>
+        <Column field="order" header="顺序" :sortable="true" style="width: 80px"></Column>
         <Column field="name" header="名稱" :sortable="true"></Column>
-        <Column field="responsible.username" header="負責人" :sortable="true"></Column>
+        <Column field="responsible.username" header="负责人" :sortable="true"></Column>
         <Column header="操作" :exportable="false" style="min-width:8rem">
           <template #body="{ data }">
             <Button icon="pi pi-pencil" class="p-button-rounded p-button-success mr-2" @click="openEdit(data)" />
@@ -22,18 +22,18 @@
     </template>
   </Card>
 
-  <Dialog v-model:visible="dialog" :header="editing ? '編輯關卡' : '新增關卡'" :modal="true" class="p-fluid w-full md:w-25rem">
+  <Dialog v-model:visible="dialog" :header="editing ? '编辑关卡' : '新增关卡'" :modal="true" class="p-fluid w-full md:w-25rem">
     <div class="field">
-      <label for="name">名稱</label>
+      <label for="name">名称</label>
       <InputText id="name" v-model.trim="form.name" required="true" autofocus />
     </div>
     <div class="field">
-      <label for="order">順序</label>
+      <label for="order">顺序</label>
       <InputNumber id="order" v-model="form.order" :min="1" />
     </div>
     <div class="field">
-      <label for="responsible">負責人</label>
-      <Dropdown id="responsible" v-model="form.responsible" :options="users" optionLabel="username" optionValue="_id" placeholder="選擇負責人" />
+      <label for="responsible">负责人</label>
+      <Dropdown id="responsible" v-model="form.responsible" :options="users" optionLabel="username" optionValue="_id" placeholder="选择负责人" />
     </div>
     <template #footer>
       <Button label="取消" icon="pi pi-times" class="p-button-text" @click="dialog = false"/>
@@ -132,8 +132,8 @@ const submit = async () => {
 
 const confirmDeleteStage = (stage) => {
   confirm.require({
-    message: `確定要刪除「${stage.name}」嗎？`,
-    header: '刪除確認',
+    message: `确定要删除「${stage.name}」吗？`,
+    header: '删除确认',
     icon: 'pi pi-exclamation-triangle',
     acceptClass: 'p-button-danger',
     accept: async () => {

--- a/client/src/views/RoleSettings.vue
+++ b/client/src/views/RoleSettings.vue
@@ -3,14 +3,14 @@
   <Card>
     <template #title>
       <div class="flex justify-content-between align-items-center">
-        <h1 class="text-2xl font-bold">角色權限管理</h1>
+        <h1 class="text-2xl font-bold">角色权限管理</h1>
         <Button label="新增角色" icon="pi pi-plus" @click="openCreate" />
       </div>
     </template>
     <template #content>
       <DataTable :value="roles" :loading="loading" responsiveLayout="scroll">
-        <Column field="name" header="角色名稱" :sortable="true"></Column>
-        <Column field="permissions" header="權限">
+        <Column field="name" header="角色名称" :sortable="true"></Column>
+        <Column field="permissions" header="权限">
           <template #body="{ data }">
             <div class="flex flex-wrap gap-1">
               <Tag v-for="perm in data.permissions" :key="perm" :value="getPermissionLabel(perm)" />
@@ -27,26 +27,26 @@
     </template>
   </Card>
 
-  <Dialog v-model:visible="dialog" :header="editing ? '編輯角色' : '新增角色'" :modal="true" class="p-fluid w-full md:w-40rem">
+  <Dialog v-model:visible="dialog" :header="editing ? '编辑角色' : '新增角色'" :modal="true" class="p-fluid w-full md:w-40rem">
     <div class="field">
-      <label for="name">角色名稱</label>
+      <label for="name">角色名称</label>
       <InputText id="name" v-model.trim="form.name" required="true" autofocus />
     </div>
     <div class="field">
-      <label>權限</label>
+      <label>权限</label>
       <PickList v-model="permissionsForPickList" listStyle="height:200px" dataKey="value">
-        <template #sourceheader>可選</template>
-        <template #targetheader>已選</template>
+        <template #sourceheader>可选</template>
+        <template #targetheader>已选</template>
         <template #item="slotProps">
           <span>{{ slotProps.item.label }}</span>
         </template>
       </PickList>
     </div>
     <div class="field">
-      <label>選單</label>
+      <label>菜单</label>
        <PickList v-model="menusForPickList" listStyle="height:200px" dataKey="value">
-        <template #sourceheader>可選</template>
-        <template #targetheader>已選</template>
+        <template #sourceheader>可选</template>
+        <template #targetheader>已选</template>
         <template #item="slotProps">
           <span>{{ slotProps.item.label }}</span>
         </template>

--- a/client/src/views/TagManager.vue
+++ b/client/src/views/TagManager.vue
@@ -3,8 +3,8 @@
   <Card>
     <template #title>
       <div class="flex justify-content-between align-items-center">
-        <h1 class="text-2xl font-bold">標籤管理</h1>
-        <Button label="新增標籤" icon="pi pi-plus" @click="openCreate" />
+        <h1 class="text-2xl font-bold">标签管理</h1>
+        <Button label="新增标签" icon="pi pi-plus" @click="openCreate" />
       </div>
     </template>
     <template #content>
@@ -20,9 +20,9 @@
     </template>
   </Card>
 
-  <Dialog v-model:visible="dialog" :header="editing ? '編輯標籤' : '新增標籤'" :modal="true" class="p-fluid w-full md:w-20rem">
+  <Dialog v-model:visible="dialog" :header="editing ? '编辑标签' : '新增标签'" :modal="true" class="p-fluid w-full md:w-20rem">
     <div class="field">
-      <label for="name">標籤名稱</label>
+      <label for="name">标签名称</label>
       <InputText id="name" v-model.trim="form.name" required="true" autofocus />
     </div>
     <template #footer>
@@ -109,8 +109,8 @@ const submit = async () => {
 
 const confirmDeleteTag = (tag) => {
   confirm.require({
-    message: `確定要刪除「${tag.name}」嗎？`,
-    header: '刪除確認',
+    message: `确定要删除「${tag.name}」吗？`,
+    header: '删除确认',
     icon: 'pi pi-exclamation-triangle',
     acceptClass: 'p-button-danger',
     accept: async () => {


### PR DESCRIPTION
## Summary
- update menu labels and permissions to simplified Chinese
- translate login and account pages
- convert employee, client, role, tag, and review setting views
- update sidebar labels

## Testing
- `npm test` *(fails: Unrecognized CLI Parameter)*

------
https://chatgpt.com/codex/tasks/task_e_688d258151d8832990b71f0c4a91df15