### PR TITLE
feat: show all edited products on dashboard

### DIFF
--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -52,7 +52,7 @@
             <div class="card-header">
               <div class="card-title">
                 <i class="pi pi-box mr-2"></i>
-                近期成品進度
+                成品進度
               </div>
               <Button 
                 label="查看全部" 
@@ -64,10 +64,9 @@
           </template>
           <template #content>
             <div v-if="!isMobile" class="table-container">
-              <DataTable 
-                :value="recentProducts" 
-                :rows="5" 
-                responsiveLayout="scroll" 
+              <DataTable
+                :value="recentProducts"
+                responsiveLayout="scroll"
                 emptyMessage="尚無成品"
                 class="modern-table"
               >
@@ -423,7 +422,7 @@ async function fetchDashboard() {
   const { data } = await api.get('/dashboard/summary')
   recentAssets.value = structuredClone(data.recentAssets)
   recentReviews.value = structuredClone(data.recentReviews)
-  recentProducts.value = structuredClone(data.recentProducts)
+  recentProducts.value = structuredClone(data.recentProducts) // 取得完整成品列表
   assetStats.value = { ...data.assetStats }
   refreshKey.value++                         // 觸發 DataTable 重繪
 }

--- a/server/src/controllers/dashboard.controller.js
+++ b/server/src/controllers/dashboard.controller.js
@@ -50,7 +50,6 @@ export const getSummary = async (req, res) => {
   /* -------- 最近成品及進度 -------- */
   const productDocs = await Asset.find({ type: 'edited' })
     .sort({ createdAt: -1 })
-    .limit(7)
     .populate('uploadedBy', 'username name')
     .lean()
 


### PR DESCRIPTION
## Summary
- show full edited product list in dashboard API
- display all products and retitle to 成品進度

## Testing
- `node --experimental-vm-modules server/node_modules/.bin/jest` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_688fa5eaf5f0832987a6ac0e2617f665