### PR TITLE
feat: 優先以 route.meta.menu 取得選單名稱

### DIFF
--- a/client/src/layouts/DashboardLayout.vue
+++ b/client/src/layouts/DashboardLayout.vue
@@ -129,13 +129,17 @@ const showQuickActions = ref(false)
 
 const getPageTitle = () => {
   const path = route.path.substring(1)
-  return MENU_NAMES[path] || '儀表板'
+  const menuKey = route.meta.menu || path
+  return MENU_NAMES[menuKey] || '儀表板'
 }
 
 const getBreadcrumb = () => {
   const path = route.path.substring(1)
   const segments = path.split('/')
-  return segments.length > 1 ? `${MENU_NAMES[segments[0]]} / ${segments[1]}` : MENU_NAMES[path] || '首頁'
+  const menuKey = route.meta.menu || segments[0]
+  return segments.length > 1
+    ? `${MENU_NAMES[menuKey]} / ${segments.slice(1).join('/')}`
+    : MENU_NAMES[menuKey] || '首頁'
 }
 
 const onToggleCollapse = (collapsed) => {

--- a/client/src/menuNames.js
+++ b/client/src/menuNames.js
@@ -7,6 +7,6 @@ export const MENU_NAMES = {
   roles: '角色设定',
   tags: '标签管理',
   'review-stages': '审查关卡',
-  'ad-data': '广告数据',
+  'ad-data': '廣告數據',
   account: '帐号资讯'
 }


### PR DESCRIPTION
## Summary
- 優化 DashboardLayout 的 getPageTitle 及 getBreadcrumb，優先使用 `route.meta.menu`
- menuNames 新增 `ad-data: '廣告數據'`

## Testing
- `npm --prefix server test` (失敗：缺少 libcrypto.so.1.1 等依賴)


------
https://chatgpt.com/codex/tasks/task_e_688fa5f04594832991bbefbc5c6f049f