### PR TITLE
feat: add date range filter to daily data

### DIFF
--- a/client/src/services/adDaily.js
+++ b/client/src/services/adDaily.js
@@ -1,8 +1,8 @@
 import api from './api'
 
 
-export const fetchDaily = (clientId, platformId) =>
-  api.get(`/clients/${clientId}/platforms/${platformId}/ad-daily`).then(r => r.data)
+export const fetchDaily = (clientId, platformId, params) =>
+  api.get(`/clients/${clientId}/platforms/${platformId}/ad-daily`, { params }).then(r => r.data)
 
 export const createDaily = (clientId, platformId, data) =>
   api.post(

--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -21,8 +21,10 @@
             <Button label="Excel 格式說明" size="small" outlined @click="excelDialog = true" />
           </div>
 
-          <!-- 右：匯出 / 新增 / 說明 -->
+          <!-- 右：日期範圍 / 匯出 / 新增 / 說明 -->
           <div class="flex items-center gap-2">
+            <DatePicker v-model="startDate" placeholder="開始日期" />
+            <DatePicker v-model="endDate" placeholder="結束日期" />
             <Button label="匯出" size="small" @click="exportDaily" />
             <Button label="新增記錄" @click="openCreateDialog" />
             <Button icon="pi pi-info-circle" link size="small" @click="showHelp = true" />
@@ -293,6 +295,8 @@ const numericColumns = computed(() =>
 )
 
 /**** 每日資料 ****/
+const startDate = ref('')
+const endDate = ref('')
 const dailyData = ref([])         // [{ date:'2025-06-16', extraData:{ 花費:100, 詢問:5 } }]
 const recordForm = ref({ date: '', extraData: {}, colors: {} })
 
@@ -448,7 +452,7 @@ const loadPlatform = async () => {
 }
 
 const loadDaily = async () => {
-  const list = await fetchDaily(clientId, platformId)
+  const list = await fetchDaily(clientId, platformId, { start: startDate.value, end: endDate.value })
   dailyData.value = list
 }
 
@@ -459,6 +463,10 @@ const loadWeeklyNotes = async () => {
     return acc
   }, {})
 }
+
+watch([startDate, endDate], async () => {
+  await loadDaily()
+})
 
 /**** --------------------------------------------------- 折線圖繪製 --------------------------------------------------- ****/
 const drawChart = () => {


### PR DESCRIPTION
## Summary
- allow filtering ad daily data by start/end date
- pass start and end params to backend when fetching daily data

## Testing
- `cd server && node --experimental-vm-modules ./node_modules/jest/bin/jest.js 2>&1 | tail -n 20` *(fails: A bucket name is needed to use Cloud Storage)*

------
https://chatgpt.com/codex/tasks/task_e_688fbbee292083298794ffe65b39f52e