### PR TITLE
feat: 支援廣告日資料排序

### DIFF
--- a/client/src/services/adDaily.js
+++ b/client/src/services/adDaily.js
@@ -1,8 +1,10 @@
 import api from './api'
 
 
-export const fetchDaily = (clientId, platformId) =>
-  api.get(`/clients/${clientId}/platforms/${platformId}/ad-daily`).then(r => r.data)
+export const fetchDaily = (clientId, platformId, params = {}) =>
+  api
+    .get(`/clients/${clientId}/platforms/${platformId}/ad-daily`, { params })
+    .then(r => r.data)
 
 export const createDaily = (clientId, platformId, data) =>
   api.post(

--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -29,14 +29,22 @@
           </div>
         </div>
 
+        <!-- 排序 -->
+        <div class="flex items-center gap-2 mb-2">
+          <Dropdown v-model="sortField" :options="sortOptions" optionLabel="label" optionValue="value"
+            placeholder="排序欄位" class="w-40" showClear />
+          <Button size="small" @click="toggleOrder" :label="sortOrder === 1 ? '升序' : '降序'" />
+        </div>
+
         <!-- 每日表格 -->
-        <DataTable :value="dailyData" :loading="loading" stripedRows style="width:100%" emptyMessage="尚無資料">
-          <Column field="date" header="日期" width="140">
+        <DataTable :value="dailyData" :loading="loading" stripedRows style="width:100%" emptyMessage="尚無資料"
+          :sortField="sortField" :sortOrder="sortOrder">
+          <Column field="date" header="日期" width="140" sortable>
             <template #body="{ data }">
               {{ dateFmt(data) }}
             </template>
           </Column>
-          <Column v-for="field in customColumns" :key="field.name" :header="field.name">
+          <Column v-for="field in customColumns" :key="field.name" :field="'extraData.' + field.name" :header="field.name" sortable>
             <template #body="{ data }">
               <span v-if="field.type === 'date'" :style="{ backgroundColor: data.colors?.[field.name] }">
                 {{ formatExtraDate(data.extraData?.[field.name]) }}
@@ -292,6 +300,17 @@ const numericColumns = computed(() =>
   customColumns.value.filter(f => f.type === 'number').map(f => f.name)
 )
 
+/**** 排序狀態 ****/
+const sortField = ref('')
+const sortOrder = ref(1)
+const sortOptions = computed(() => [
+  { label: '日期', value: 'date' },
+  ...customColumns.value.map(f => ({ label: f.name, value: f.name }))
+])
+const toggleOrder = () => {
+  sortOrder.value = sortOrder.value === 1 ? -1 : 1
+}
+
 /**** 每日資料 ****/
 const dailyData = ref([])         // [{ date:'2025-06-16', extraData:{ 花費:100, 詢問:5 } }]
 const recordForm = ref({ date: '', extraData: {}, colors: {} })
@@ -448,7 +467,12 @@ const loadPlatform = async () => {
 }
 
 const loadDaily = async () => {
-  const list = await fetchDaily(clientId, platformId)
+  const params = {}
+  if (sortField.value) {
+    params.sort = sortField.value
+    params.order = sortOrder.value === 1 ? 'asc' : 'desc'
+  }
+  const list = await fetchDaily(clientId, platformId, params)
   dailyData.value = list
 }
 
@@ -459,6 +483,10 @@ const loadWeeklyNotes = async () => {
     return acc
   }, {})
 }
+
+watch([sortField, sortOrder], () => {
+  loadDaily()
+})
 
 /**** --------------------------------------------------- 折線圖繪製 --------------------------------------------------- ****/
 const drawChart = () => {

--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -50,11 +50,16 @@ export const getAdDaily = async (req, res) => {
   if (req.query.start && req.query.end) {
     query.date = { $gte: new Date(req.query.start), $lte: new Date(req.query.end) }
   }
-  const cacheKey = `adDaily:${req.params.clientId}:${req.params.platformId}:${JSON.stringify(query)}`
+  const sortFields = ['date', 'spent', 'enquiries', 'reach', 'impressions', 'clicks']
+  let sortObj = { date: 1 }
+  if (req.query.sort && sortFields.includes(req.query.sort)) {
+    sortObj = { [req.query.sort]: req.query.order === 'desc' ? -1 : 1 }
+  }
+  const cacheKey = `adDaily:${req.params.clientId}:${req.params.platformId}:${JSON.stringify(query)}:${JSON.stringify(sortObj)}`
   const cached = await getCache(cacheKey)
   if (cached) return res.json(cached)
 
-  const list = await AdDaily.find(query).sort({ date: 1 })
+  const list = await AdDaily.find(query).sort(sortObj)
   await setCache(cacheKey, list)
   res.json(list)
 }

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -175,6 +175,30 @@ describe('Client and AdDaily', () => {
     expect(res.body[1].extraData).toEqual({ metric: 2 })
   })
 
+  it('sort adDaily by spent desc', async () => {
+    const records = [
+      { date: new Date('2024-06-01').toISOString(), spent: 5 },
+      { date: new Date('2024-06-02').toISOString(), spent: 20 },
+      { date: new Date('2024-06-03').toISOString(), spent: 10 }
+    ]
+    for (const r of records) {
+      await request(app)
+        .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)
+        .set('Authorization', `Bearer ${token}`)
+        .send(r)
+        .expect(201)
+    }
+
+    const res = await request(app)
+      .get(
+        `/api/clients/${clientId}/platforms/${platformId}/ad-daily?start=2024-06-01&end=2024-06-03&sort=spent&order=desc`
+      )
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    const spent = res.body.map(r => r.spent)
+    expect(spent).toEqual([20, 10, 5])
+  })
+
   it('update and delete adDaily', async () => {
     const create = await request(app)
       .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)


### PR DESCRIPTION
## Summary
- 允許後端依指定欄位與順序排序廣告每日資料
- 前端服務與畫面支援 sort/order 參數並提供排序 UI
- 新增測試驗證 spent 欄位的降冪排序

## Testing
- `node --experimental-vm-modules server/node_modules/jest/bin/jest.js server/tests/clientAdDaily.test.js` (失敗：A bucket name is needed to use Cloud Storage.)
- `node --experimental-vm-modules server/node_modules/jest/bin/jest.js server/tests/platform.test.js` (失敗：libcrypto.so.1.1 缺失)
- `apt-get update` (失敗：403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_688fbbfd01588329b2b4b4bcdcb0edfd