### PR TITLE
feat: show new edited asset count for folders

### DIFF
--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -13,7 +13,11 @@ export const fetchFolders = (
   if (type) params.type = type
   if (deep) params.deep = 'true'
   if (withProgress) params.progress = 'true'
-  return api.get('/folders', { params }).then((res) => res.data)
+  return api.get('/folders', { params }).then((res) =>
+    Array.isArray(res.data)
+      ? res.data.map(f => ({ ...f, newCount: f.newCount || 0 }))
+      : res.data
+  )
 
 }
 

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -204,7 +204,10 @@
                   <i :class="getItemIcon(item)" class="preview-icon"></i>
                 </div>
                 <div class="item-info">
-                  <h4 class="item-title">{{ item.name }}</h4>
+                  <div class="item-title-wrapper">
+                    <h4 class="item-title">{{ item.name }}</h4>
+                    <Badge v-if="item.type === 'folder' && item.newCount" :value="item.newCount" class="new-count-badge" />
+                  </div>
                   <div class="item-meta">
                     <span class="meta-date">建於: {{ formatDate(item.createdAt) }}</span>
                     <span class="meta-creator">由: {{ item.creatorName || item.uploaderName }}</span>
@@ -259,7 +262,10 @@
               </div>
               <div class="item-details" @click="handleItemClick(item)">
                 <div class="details-main">
-                  <h4 class="item-title">{{ item.name }}</h4>
+                  <div class="item-title-wrapper">
+                    <h4 class="item-title">{{ item.name }}</h4>
+                    <Badge v-if="item.type === 'folder' && item.newCount" :value="item.newCount" class="new-count-badge" />
+                  </div>
                   <div class="item-tags" v-if="item.tags?.length || item.reviewStatus">
                     <Tag v-if="item.reviewStatus" :value="item.reviewStatus" :severity="getStatusSeverity(item.reviewStatus)" class="item-tag status-tag" />
                     <Tag 
@@ -445,6 +451,7 @@ import Tag from 'primevue/tag'
 import SplitButton from 'primevue/splitbutton'
 import Toast from 'primevue/toast'
 import Dropdown from 'primevue/dropdown'
+import Badge from 'primevue/badge'
 
 const toast = useToast()
 const confirm = useConfirm()
@@ -1187,6 +1194,12 @@ watch(filterTags, () => loadData(currentFolder.value?._id), { deep: true })
   width: 100%;
 }
 
+.item-title-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .item-title {
   margin: 0 0 1rem 0;
   font-size: 1.125rem;
@@ -1316,6 +1329,11 @@ watch(filterTags, () => loadData(currentFolder.value?._id), { deep: true })
 
 .details-main {
   margin-bottom: 0.75rem;
+}
+
+.new-count-badge {
+  background: #22c55e;
+  color: #fff;
 }
 
 .item-title {

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -82,6 +82,18 @@ export const getFolders = async (req, res) => {
       !f.allowedUsers?.length || f.allowedUsers.some(id => id.equals(req.user._id))
     )
   }
+  // Count new edited assets (reviewStatus pending) for each folder
+  const folderIds = result.map(f => f._id)
+  let countMap = {}
+  if (folderIds.length) {
+    const counts = await Asset.aggregate([
+      { $match: { folderId: { $in: folderIds }, type: 'edited', reviewStatus: 'pending' } },
+      { $group: { _id: '$folderId', count: { $sum: 1 } } }
+    ])
+    counts.forEach(c => {
+      countMap[c._id.toString()] = c.count
+    })
+  }
 
   if (req.query.progress === 'true') {
     const total = await ReviewStage.countDocuments()
@@ -90,14 +102,15 @@ export const getFolders = async (req, res) => {
       { $match: { folderId: { $in: ids }, completed: true } },
       { $group: { _id: '$folderId', done: { $sum: 1 } } }
     ])
-    const map = {}
+    const progressMap = {}
     records.forEach(r => {
-      map[r._id.toString()] = r.done
+      progressMap[r._id.toString()] = r.done
     })
     const data = result.map(f => ({
       ...f.toObject(),
-      progress: { done: map[f._id.toString()] || 0, total },
-      creatorName: f.createdBy?.name || f.createdBy?.username
+      progress: { done: progressMap[f._id.toString()] || 0, total },
+      creatorName: f.createdBy?.name || f.createdBy?.username,
+      newCount: countMap[f._id.toString()] || 0
     }))
     await setCache(cacheKey, data)
     return res.json(data)
@@ -105,7 +118,8 @@ export const getFolders = async (req, res) => {
 
   const data = result.map(f => ({
     ...f.toObject(),
-    creatorName: f.createdBy?.name || f.createdBy?.username
+    creatorName: f.createdBy?.name || f.createdBy?.username,
+    newCount: countMap[f._id.toString()] || 0
   }))
   await setCache(cacheKey, data)
   res.json(data)


### PR DESCRIPTION
## Summary
- count pending edited assets per folder in backend and return newCount
- expose newCount to client and show badge on folders

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js` *(fails: libcrypto.so.1.1 missing and GCS bucket not set)*

------
https://chatgpt.com/codex/tasks/task_e_6890415e40a883299c2cfd8d166794c2