### PR TITLE
feat: add sorting options for folders and products

### DIFF
--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -16,12 +16,13 @@ export const fetchAssets = (folderId, type, tags = [], deep = false) => {
   )
 }
 
-export const fetchProducts = (folderId, tags = [], deep = false, withProgress = false) => {
+export const fetchProducts = (folderId, tags = [], deep = false, withProgress = false, sort) => {
   const params = {}
   if (folderId) params.folderId = folderId
   if (tags.length) params.tags = tags
   if (deep) params.deep = 'true'
   if (withProgress) params.progress = 'true'
+  if (sort) params.sort = sort
 
   return api.get('/products', { params }).then(res =>
     res.data.map(a => ({

--- a/client/src/services/folders.js
+++ b/client/src/services/folders.js
@@ -5,7 +5,8 @@ export const fetchFolders = (
   tags = [],
   type,
   deep = false,
-  withProgress = false
+  withProgress = false,
+  sort
 ) => {
   const params = {}
   if (parentId) params.parentId = parentId
@@ -13,6 +14,7 @@ export const fetchFolders = (
   if (type) params.type = type
   if (deep) params.deep = 'true'
   if (withProgress) params.progress = 'true'
+  if (sort) params.sort = sort
   return api.get('/folders', { params }).then((res) => res.data)
 
 }

--- a/client/src/services/products.js
+++ b/client/src/services/products.js
@@ -15,8 +15,8 @@ import {
   getBatchDownloadProgress as getAssetBatchDownloadProgress
 } from './assets'
 
-export const fetchProducts = (folderId, tags = [], deep = false) =>
-  fetchProductsRaw(folderId, tags, deep, true)
+export const fetchProducts = (folderId, tags = [], deep = false, sort) =>
+  fetchProductsRaw(folderId, tags, deep, true, sort)
 
 export const uploadProduct = (file, folderId, progressCb) =>
   uploadAssetAuto(file, folderId, { type: 'edited' }, progressCb)

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -56,17 +56,25 @@
           </div>
         </div>
         <div class="toolbar-right">
-          <MultiSelect 
-            v-model="filterTags" 
-            :options="allTags" 
-            placeholder="篩選標籤" 
+          <MultiSelect
+            v-model="filterTags"
+            :options="allTags"
+            placeholder="篩選標籤"
             class="tag-filter"
             :maxSelectedLabels="2"
           />
+          <Dropdown
+            v-model="sortOrder"
+            :options="sortOptions"
+            optionLabel="label"
+            optionValue="value"
+            class="sort-select"
+            @change="loadData(currentFolder?._id)"
+          />
           <div class="view-controls">
-            <Button 
-              icon="pi pi-th-large" 
-              @click="viewMode = 'grid'" 
+            <Button
+              icon="pi pi-th-large"
+              @click="viewMode = 'grid'"
               :class="{'active': viewMode === 'grid'}"
               class="view-btn"
               v-tooltip.bottom="'網格檢視'"
@@ -460,6 +468,13 @@ const products = ref([])
 const currentFolder = ref(null)
 const newFolderName = ref('')
 const filterTags = ref([])
+const sortOrder = ref('updatedAt_desc')
+const sortOptions = [
+  { label: '更新時間（新→舊）', value: 'updatedAt_desc' },
+  { label: '更新時間（舊→新）', value: 'updatedAt_asc' },
+  { label: '名稱（A→Z）', value: 'name_asc' },
+  { label: '名稱（Z→A）', value: 'name_desc' }
+]
 const allTags = ref([])
 const users = ref([])
 const viewMode = ref('grid')
@@ -577,8 +592,8 @@ async function loadData(folderId = null) {
   loading.value = true
   try {
     const [folderData, productData, currentFolderData] = await Promise.all([
-      fetchFolders(folderId, filterTags.value, 'edited'),
-      fetchProducts(folderId, filterTags.value),
+      fetchFolders(folderId, filterTags.value, 'edited', false, false, sortOrder.value),
+      fetchProducts(folderId, filterTags.value, false, sortOrder.value),
       folderId ? getFolder(folderId) : Promise.resolve(null)
     ])
     folders.value = folderData
@@ -840,6 +855,7 @@ onMounted(() => {
 
 watch(() => route.params.folderId, (newId) => loadData(newId || null))
 watch(filterTags, () => loadData(currentFolder.value?._id), { deep: true })
+watch(sortOrder, () => loadData(currentFolder.value?._id))
 </script>
 
 <style scoped>

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -117,7 +117,13 @@ export const getAssets = async (req, res) => {
     query.tags = { $all: tags }
   }
 
+  const sortParam = req.query.sort || 'updatedAt_desc'
+  const [sortField, sortOrder] = sortParam.split('_')
+  const fieldMap = { name: 'title' }
+  const sort = { [fieldMap[sortField] || sortField]: sortOrder === 'asc' ? 1 : -1 }
+
   const assets = await Asset.find(query)
+    .sort(sort)
     .populate('uploadedBy', 'username name')
 
   const filtered = assets.filter(a =>

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -75,7 +75,13 @@ export const getFolders = async (req, res) => {
       : req.query.tags.split(',')
     query.tags = { $all: tags }
   }
-  const folders = await Folder.find(query).populate('createdBy', 'username name')
+  const sortParam = req.query.sort || 'updatedAt_desc'
+  const [sortField, sortOrder] = sortParam.split('_')
+  const sort = { [sortField]: sortOrder === 'asc' ? 1 : -1 }
+
+  const folders = await Folder.find(query)
+    .sort(sort)
+    .populate('createdBy', 'username name')
   let result = folders
   if (req.user.roleId?.name !== 'manager') {
     result = folders.filter(f =>

--- a/server/tests/asset.test.js
+++ b/server/tests/asset.test.js
@@ -141,6 +141,36 @@ describe('Batch update viewers', () => {
   })
 })
 
+describe('Asset sorting', () => {
+  let a1, a2
+
+  beforeAll(async () => {
+    a1 = await Asset.create({ filename: 'a.mp4', path: '/tmp/a', type: 'edited', title: 'Alpha', tags: ['sorttest'] })
+    await Asset.findByIdAndUpdate(a1._id, { updatedAt: new Date(Date.now() - 1000) })
+    a2 = await Asset.create({ filename: 'b.mp4', path: '/tmp/b', type: 'edited', title: 'Beta', tags: ['sorttest'] })
+  })
+
+  it('default sort by updatedAt desc', async () => {
+    const res = await request(app)
+      .get('/api/assets')
+      .query({ tags: 'sorttest', type: 'edited' })
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(res.body[0]._id).toBe(a2._id.toString())
+    expect(res.body[1]._id).toBe(a1._id.toString())
+  })
+
+  it('sort by name asc', async () => {
+    const res = await request(app)
+      .get('/api/assets')
+      .query({ tags: 'sorttest', type: 'edited', sort: 'name_asc' })
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(res.body[0]._id).toBe(a1._id.toString())
+    expect(res.body[1]._id).toBe(a2._id.toString())
+  })
+})
+
 describe('Asset signed url', () => {
   it('should return signed url', async () => {
     const res = await request(app)

--- a/server/tests/folder.test.js
+++ b/server/tests/folder.test.js
@@ -176,16 +176,48 @@ describe('Batch update folder viewers', () => {
 })
 
 
-describe('Folder review', () => {
-  it('update reviewStatus', async () => {
-    const res = await request(app)
-      .put(`/api/folders/${folderId}/review`)
-      .set('Authorization', `Bearer ${token}`)
-      .send({ reviewStatus: 'approved' })
-      .expect(200)
-    expect(res.body.reviewStatus).toBe('approved')
+  describe('Folder review', () => {
+    it('update reviewStatus', async () => {
+      const res = await request(app)
+        .put(`/api/folders/${folderId}/review`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ reviewStatus: 'approved' })
+        .expect(200)
+      expect(res.body.reviewStatus).toBe('approved')
+    })
+  })
 
-describe('Delete folder', () => {
+  describe('Folder sorting', () => {
+    let f1, f2
+
+    beforeAll(async () => {
+      f1 = await Folder.create({ name: 'A-folder', tags: ['sorttest'] })
+      await Folder.findByIdAndUpdate(f1._id, { updatedAt: new Date(Date.now() - 1000) })
+      f2 = await Folder.create({ name: 'B-folder', tags: ['sorttest'] })
+    })
+
+    it('default sort by updatedAt desc', async () => {
+      const res = await request(app)
+        .get('/api/folders')
+        .query({ tags: 'sorttest' })
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200)
+      expect(res.body[0]._id).toBe(f2._id.toString())
+      expect(res.body[1]._id).toBe(f1._id.toString())
+    })
+
+    it('sort by name asc', async () => {
+      const res = await request(app)
+        .get('/api/folders')
+        .query({ tags: 'sorttest', sort: 'name_asc' })
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200)
+      expect(res.body[0]._id).toBe(f1._id.toString())
+      expect(res.body[1]._id).toBe(f2._id.toString())
+    })
+  })
+
+  describe('Delete folder', () => {
   it('should remove subfolders and assets', async () => {
     const child = await Folder.create({ name: 'c1', parentId: folderId })
     const grand = await Folder.create({ name: 'c2', parentId: child._id })


### PR DESCRIPTION
## Summary
- support sort query for folders and products
- allow frontend to choose sort order and reload library
- cover folder/product sorting with tests

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx jest` *(fails: Missing libcrypto.so.1.1 and GCS bucket)*

------
https://chatgpt.com/codex/tasks/task_e_6890416041488329898378904f48d7da