### PR TITLE
feat: restrict recent data to last 24 hours

### DIFF
--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -256,7 +256,8 @@ export const deleteAsset = async (req, res) => {
 /* ---------- 依 limit 取得最新素材 ---------- */
 export const getRecentAssets = async (req, res) => {
   const limit = Number(req.query.limit) || 5
-  const query = {}
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000)
+  const query = { createdAt: { $gte: since } }
   const assets = await Asset.find(query)
     .sort({ createdAt: -1 })
     .limit(limit)

--- a/server/src/controllers/dashboard.controller.js
+++ b/server/src/controllers/dashboard.controller.js
@@ -10,8 +10,10 @@ export const getSummary = async (req, res) => {
   const cached = await getCache(cacheKey)
   if (cached) return res.json(cached)
 
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000)
+
   /* -------- 最近素材 -------- */
-  const assetDocs = await Asset.find()
+  const assetDocs = await Asset.find({ createdAt: { $gte: since } })
     .sort({ createdAt: -1 })
     .limit(7)
     .populate('uploadedBy', 'username name')
@@ -48,7 +50,7 @@ export const getSummary = async (req, res) => {
     }))
 
   /* -------- 最近成品及進度 -------- */
-  const productDocs = await Asset.find({ type: 'edited' })
+  const productDocs = await Asset.find({ type: 'edited', createdAt: { $gte: since } })
     .sort({ createdAt: -1 })
     .populate('uploadedBy', 'username name')
     .lean()


### PR DESCRIPTION
## Summary
- filter recent assets query within 24 hours
- dashboard recent assets and products use the same 24-hour range

## Testing
- `npm test` *(fails: Unrecognized option "experimental-vm-modules")*

------
https://chatgpt.com/codex/tasks/task_e_6890473886b4832998330bed5b91caa8