### PR TITLE
feat: add recent-first folder sorting

### DIFF
--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -475,8 +475,9 @@ const products = ref([])
 const currentFolder = ref(null)
 const newFolderName = ref('')
 const filterTags = ref([])
-const sortOrder = ref('updatedAt_desc')
+const sortOrder = ref('recentFirst')
 const sortOptions = [
+  { label: '最近更新優先', value: 'recentFirst' },
   { label: '更新時間（新→舊）', value: 'updatedAt_desc' },
   { label: '更新時間（舊→新）', value: 'updatedAt_asc' },
   { label: '名稱（A→Z）', value: 'name_asc' },
@@ -600,7 +601,12 @@ async function loadData(folderId = null) {
   try {
     const [folderData, productData, currentFolderData] = await Promise.all([
       fetchFolders(folderId, filterTags.value, 'edited', false, false, sortOrder.value),
-      fetchProducts(folderId, filterTags.value, false, sortOrder.value),
+      fetchProducts(
+        folderId,
+        filterTags.value,
+        false,
+        sortOrder.value === 'recentFirst' ? 'updatedAt_desc' : sortOrder.value
+      ),
       folderId ? getFolder(folderId) : Promise.resolve(null)
     ])
     folders.value = folderData


### PR DESCRIPTION
## Summary
- support `recentFirst` sorting for folders to prioritize recently updated items
- add recent-first sort option in ProductLibrary and default to it

## Testing
- `node --experimental-vm-modules ./server/node_modules/jest/bin/jest.js` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890473cb9bc8329adf64981168586b0