### PR TITLE
feat: include asset path in notifications

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -31,7 +31,11 @@ const routes = [
     children: [
       { path: 'dashboard', name: 'Dashboard', component: Dashboard, meta: { menu: 'dashboard' } },
       { path: 'account', name: 'Account', component: Account, meta: { menu: 'account' } },
+      { path: 'assets/asset/:assetId', name: 'AssetDetailRoot', component: AssetLibrary, meta: { menu: 'assets' } },
+      { path: 'assets/:folderId/asset/:assetId', name: 'AssetDetail', component: AssetLibrary, meta: { menu: 'assets' } },
       { path: 'assets/:folderId?', name: 'Assets', component: AssetLibrary, meta: { menu: 'assets' } },
+      { path: 'products/asset/:assetId', name: 'ProductAssetDetailRoot', component: ProductLibrary, meta: { menu: 'products' } },
+      { path: 'products/:folderId/asset/:assetId', name: 'ProductAssetDetail', component: ProductLibrary, meta: { menu: 'products' } },
       { path: 'products/:folderId?', name: 'Products', component: ProductLibrary, meta: { menu: 'products' } },
 
       { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { menu: 'employees' } },

--- a/client/src/stores/notifications.js
+++ b/client/src/stores/notifications.js
@@ -8,18 +8,23 @@ export const useNotificationStore = defineStore('notifications', {
   getters: {
     unreadCount: state => state.list.filter(n => !n.read).length,
     productUnreadCount: state =>
-      state.list.filter(n => !n.read && n.link === '/products').length
+      state.list.filter(n => !n.read && n.link.startsWith('/products')).length
   },
   actions: {
     async fetch() {
       const data = await fetchNotifications()
-      this.list = data.map(item => ({
-        id: item._id,
-        title: item.fileName,
-        type: item.fileType,
-        link: item.fileType === 'edited' ? '/products' : '/assets',
-        read: false
-      }))
+      this.list = data.map(item => {
+        const base = item.fileType === 'edited' ? '/products' : '/assets'
+        const folderPath = item.folderId ? `${base}/${item.folderId}` : base
+        const detailPath = item._id ? `${folderPath}/asset/${item._id}` : folderPath
+        return {
+          id: item._id,
+          title: item.fileName,
+          type: item.fileType,
+          link: detailPath,
+          read: false
+        }
+      })
     },
     markAsRead(id) {
       const target = this.list.find(n => n.id === id)


### PR DESCRIPTION
## Summary
- 根據通知使用 folderId 與 assetId 組合成對應連結
- 新增包含 assetId 的路由以支援直接開啟檔案資訊

## Testing
- `npm test` *(失敗：Unrecognized option "experimental-vm-modules")*


------
https://chatgpt.com/codex/tasks/task_e_68904b2241c08329a37f2a89f3f3f21d