### PR TITLE
fix: 將通知面板改為固定定位避免被遮蓋

### DIFF
--- a/client/src/layouts/DashboardLayout.vue
+++ b/client/src/layouts/DashboardLayout.vue
@@ -341,7 +341,7 @@ onUnmounted(() => {
 }
 
 .notification-panel {
-  position: absolute;
+  position: fixed;
   top: 3.5rem;
   right: 0;
   width: 300px;
@@ -351,7 +351,7 @@ onUnmounted(() => {
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 0.5rem;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-  z-index: 1000;
+  z-index: 9999;
 }
 
 .notification-list {


### PR DESCRIPTION
## Summary
- 調整 DashboardLayout 通知面板為固定定位並提高 z-index，避免被其他內容遮蔽

## Testing
- `npm test` *(失敗：缺少 libcrypto.so.1.1 以及 GCS bucket 設定)*

------
https://chatgpt.com/codex/tasks/task_e_68904c7b2dbc8329bc8a2418d496a84f