### PR TITLE
以指示點取代成品庫資料夾新項徽章

### DIFF
--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -214,7 +214,10 @@
                 <div class="item-info">
                   <div class="item-title-wrapper">
                     <h4 class="item-title">{{ item.name }}</h4>
-                    <Badge v-if="item.type === 'folder' && item.newCount" :value="item.newCount" class="new-count-badge" />
+                    <Badge
+                      v-if="item.type === 'folder' && item.newCount > 0"
+                      class="update-dot"
+                    />
                   </div>
                   <div class="item-meta">
                     <span class="meta-date">建於: {{ formatDate(item.createdAt) }}</span>
@@ -272,7 +275,10 @@
                 <div class="details-main">
                   <div class="item-title-wrapper">
                     <h4 class="item-title">{{ item.name }}</h4>
-                    <Badge v-if="item.type === 'folder' && item.newCount" :value="item.newCount" class="new-count-badge" />
+                    <Badge
+                      v-if="item.type === 'folder' && item.newCount > 0"
+                      class="update-dot"
+                    />
                   </div>
                   <div class="item-tags" v-if="item.tags?.length || item.reviewStatus">
                     <Tag v-if="item.reviewStatus" :value="item.reviewStatus" :severity="getStatusSeverity(item.reviewStatus)" class="item-tag status-tag" />
@@ -1355,7 +1361,17 @@ watch(sortOrder, () => loadData(currentFolder.value?._id))
 
 .new-count-badge {
   background: #22c55e;
-  color: #fff;
+}
+
+.update-dot {
+  background: #22c55e;
+  width: 8px;
+  height: 8px;
+  min-width: 8px;
+  min-height: 8px;
+  border-radius: 50%;
+  padding: 0;
+  display: inline-flex;
 }
 
 .item-title {


### PR DESCRIPTION
## Summary
- 改以無數字的指示點顯示資料夾內的新項目
- 新增 `.update-dot` 樣式並移除 `.new-count-badge` 的文字色設定

## Testing
- `npm test` *(失敗：Unrecognized option "experimental-vm-modules")*

------
https://chatgpt.com/codex/tasks/task_e_689051422578832996fdd97eafb36219