### PR TITLE
fix: show all edited products in dashboard

### DIFF
--- a/server/src/controllers/dashboard.controller.js
+++ b/server/src/controllers/dashboard.controller.js
@@ -49,8 +49,8 @@ export const getSummary = async (req, res) => {
       updatedBy: r.updatedBy?.name || r.updatedBy?.username
     }))
 
-  /* -------- 最近成品及進度 -------- */
-  const productDocs = await Asset.find({ type: 'edited', createdAt: { $gte: since } })
+  /* -------- 成品及進度 -------- */
+  const productDocs = await Asset.find({ type: 'edited' })
     .sort({ createdAt: -1 })
     .populate('uploadedBy', 'username name')
     .lean()


### PR DESCRIPTION
## Summary
- remove createdAt filter from dashboard product query to list all edited assets

## Testing
- `node --experimental-vm-modules server/node_modules/jest/bin/jest.js server/tests/dashboardSummaryProgress.test.js server/tests/dashboard.test.js` *(fails: libcrypto.so.1.1 missing; GCS bucket not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6890513ffa608329a25f7ef346b0884f