### PR TITLE
調整 ProductLibrary 卡片文字置中

### DIFF
--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -1225,6 +1225,7 @@ watch(sortOrder, () => loadData(currentFolder.value?._id))
 .item-title-wrapper {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
 }
 
@@ -1240,6 +1241,7 @@ watch(sortOrder, () => loadData(currentFolder.value?._id))
 .item-meta {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 0.25rem;
   margin-bottom: 1rem;
   font-size: 0.875rem;


### PR DESCRIPTION
## 摘要
- 讓成品庫卡片標題容器水平置中
- 讓成品庫卡片資訊欄位垂直置中

## 測試
- `npm --prefix client run build`
- `npm test`（失敗：Unrecognized option "experimental-vm-modules"）

------
https://chatgpt.com/codex/tasks/task_e_6890552a91648329a5ce002bc25892ab