### PR TITLE
feat: filter new asset counts by recent updates

### DIFF
--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -102,8 +102,9 @@ export const getFolders = async (req, res) => {
   const folderIds = result.map(f => f._id)
   let countMap = {}
   if (folderIds.length) {
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000)
     const counts = await Asset.aggregate([
-      { $match: { folderId: { $in: folderIds }, type: 'edited', reviewStatus: 'pending' } },
+      { $match: { folderId: { $in: folderIds }, type: 'edited', reviewStatus: 'pending', updatedAt: { $gte: cutoff } } },
       { $group: { _id: '$folderId', count: { $sum: 1 } } }
     ])
     counts.forEach(c => {


### PR DESCRIPTION
## Summary
- only count pending edited assets updated within the last 24 hours

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/platform.test.js` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68905534abd48329badfd87fe8f78c7a