### PR TITLE
feat: support keeping weekly note images

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -747,7 +747,7 @@ const openNote = async row => {
     const promises = note.images.map(async p => {
       try {
         const url = await getWeeklyNoteImageUrl(clientId, platformId, p)
-        return { name: p, url }
+        return { name: p, url, path: p }
       } catch {
         return null
       }
@@ -760,11 +760,13 @@ const openNote = async row => {
 
 const saveNote = async () => {
   const { week, text, images } = noteForm.value
+  const keepImages = images.filter(i => i.path).map(i => i.path)
+  const newImages = images.filter(i => !i.path).map(f => f.raw)
   let note
   try {
-    note = await updateWeeklyNote(clientId, platformId, week, { text, images: images.map(f => f.raw) })
+    note = await updateWeeklyNote(clientId, platformId, week, { text, images: newImages, keepImages })
   } catch {
-    note = await createWeeklyNote(clientId, platformId, { week, text, images: images.map(f => f.raw) })
+    note = await createWeeklyNote(clientId, platformId, { week, text, images: newImages })
   }
   weeklyNotes.value[week] = note
   toast.add({ severity: 'success', summary: '成功', detail: '已儲存備註', life: 3000 })


### PR DESCRIPTION
## Summary
- preserve image path when opening weekly note
- send keepImages so existing note images survive updates

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/platform.test.js 2>&1 | tail -n 40`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/asset.test.js 2>&1 | tail -n 40`


------
https://chatgpt.com/codex/tasks/task_e_689194f637648329983ae3f97b40624b