### PR TITLE
refactor weekly note fetch services

### DIFF
--- a/client/src/services/weeklyNotes.js
+++ b/client/src/services/weeklyNotes.js
@@ -1,10 +1,18 @@
 import api from './api'
 
-export const fetchWeeklyNote = (clientId, platformId, week) =>
-  api.get(`/clients/${clientId}/platforms/${platformId}/weekly-notes/${week}`).then(r => r.data)
+export const fetchWeeklyNote = (clientId, platformId, week) => {
+  return api
+    .get(
+      `/clients/${clientId}/platforms/${platformId}/weekly-notes/${week}`
+    )
+    .then(r => r.data)
+}
 
-export const fetchWeeklyNotes = (clientId, platformId) =>
-  api.get(`/clients/${clientId}/platforms/${platformId}/weekly-notes`).then(r => r.data)
+export const fetchWeeklyNotes = (clientId, platformId) => {
+  return api
+    .get(`/clients/${clientId}/platforms/${platformId}/weekly-notes`)
+    .then(r => r.data)
+}
 
 export const createWeeklyNote = (clientId, platformId, data) => {
   const formData = new FormData()


### PR DESCRIPTION
## Summary
- add explicit return blocks for weekly note service functions

## Testing
- `npm --prefix client run build`
- `npm test` *(fails: Unrecognized option "experimental-vm-modules")*

------
https://chatgpt.com/codex/tasks/task_e_68919ed8d2a4832993e7e5071f2dfa7e