### PR TITLE
refactor: add return to weekly note image url

### DIFF
--- a/client/src/services/weeklyNotes.js
+++ b/client/src/services/weeklyNotes.js
@@ -44,10 +44,11 @@ export const updateWeeklyNote = (clientId, platformId, week, data) => {
   ).then(r => r.data)
 }
 
-export const getWeeklyNoteImageUrl = (clientId, platformId, path) =>
-  api
+export const getWeeklyNoteImageUrl = (clientId, platformId, path) => {
+  return api
     .get(
       `/clients/${clientId}/platforms/${platformId}/weekly-notes/image-url`,
       { params: { path } }
     )
     .then(r => r.data.url)
+}


### PR DESCRIPTION
## Summary
- refactor weekly note image URL fetching helper to use block form with explicit return

## Testing
- `npm --prefix client run build` *(fails: process stuck at transforming stage)*
- `npm test` *(fails: Unrecognized option "experimental-vm-modules")*

------
https://chatgpt.com/codex/tasks/task_e_6891a4418144832992561f4940fdb6c8