### PR TITLE
fix: use native File objects for weekly notes

### DIFF
--- a/client/src/services/weeklyNotes.js
+++ b/client/src/services/weeklyNotes.js
@@ -18,18 +18,23 @@ export const createWeeklyNote = (clientId, platformId, data) => {
   const formData = new FormData()
   formData.append('week', data.week)
   formData.append('text', data.text || '')
-  ;(data.images || []).forEach(f => formData.append('images', f))
-  return api.post(
-    `/clients/${clientId}/platforms/${platformId}/weekly-notes`,
-    formData,
-    { headers: { 'Content-Type': 'multipart/form-data' } }
-  ).then(r => r.data)
+  ;(data.images || []).forEach(f =>
+    formData.append('images', f instanceof File ? f : f.file)
+  )
+  return api
+    .post(
+      `/clients/${clientId}/platforms/${platformId}/weekly-notes`,
+      formData
+    )
+    .then(r => r.data)
 }
 
 export const updateWeeklyNote = (clientId, platformId, week, data) => {
   const formData = new FormData()
   formData.append('text', data.text || '')
-  ;(data.images || []).forEach(f => formData.append('images', f))
+  ;(data.images || []).forEach(f =>
+    formData.append('images', f instanceof File ? f : f.file)
+  )
   if (Array.isArray(data.keepImages)) {
     if (data.keepImages.length) {
       data.keepImages.forEach(i => formData.append('keepImages', i))
@@ -37,11 +42,12 @@ export const updateWeeklyNote = (clientId, platformId, week, data) => {
       formData.append('keepImages', '')
     }
   }
-  return api.put(
-    `/clients/${clientId}/platforms/${platformId}/weekly-notes/${week}`,
-    formData,
-    { headers: { 'Content-Type': 'multipart/form-data' } }
-  ).then(r => r.data)
+  return api
+    .put(
+      `/clients/${clientId}/platforms/${platformId}/weekly-notes/${week}`,
+      formData
+    )
+    .then(r => r.data)
 }
 
 export const getWeeklyNoteImageUrl = (clientId, platformId, path) => {


### PR DESCRIPTION
## Summary
- ensure weekly note uploads use File instances
- allow axios to set multipart headers automatically

## Testing
- `npm run build --prefix client`
- `npm test` *(fails: Unrecognized option "experimental-vm-modules")*

------
https://chatgpt.com/codex/tasks/task_e_6891aa82c2e0832990f3d8ce1e29449f