### PR TITLE
feat: log uploaded files in weekly note controller

### DIFF
--- a/server/src/controllers/weeklyNote.controller.js
+++ b/server/src/controllers/weeklyNote.controller.js
@@ -29,12 +29,14 @@ const parseKeepImages = value => {
 }
 
 export const createWeeklyNote = async (req, res) => {
+  console.log('uploaded files:', req.files)
+  const images = await uploadImages(req.files)
   const note = await WeeklyNote.create({
     clientId: req.params.clientId,
     platformId: req.params.platformId,
     week: req.body.week,
     text: req.body.text || '',
-    images: await uploadImages(req.files)
+    images
   })
   await clearCacheByPrefix('weeklyNotes:')
   res.status(201).json(note)
@@ -63,6 +65,7 @@ export const updateWeeklyNote = async (req, res) => {
   let newImages = []
   if (keep !== undefined) newImages = keep
   if (req.files?.length) {
+    console.log('uploaded files:', req.files)
     const uploaded = await uploadImages(req.files)
     newImages = [...newImages, ...uploaded]
   }


### PR DESCRIPTION
## Summary
- log uploaded files before image uploads in weekly note API

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js` *(fails: A bucket name is needed to use Cloud Storage)*
- `npm --prefix server run start` *(fails: A bucket name is needed to use Cloud Storage)*

------
https://chatgpt.com/codex/tasks/task_e_6891ad45602c8329ae1557059259a617