### PR TITLE
feat(gcs): support default credentials

### DIFF
--- a/server/src/utils/gcs.js
+++ b/server/src/utils/gcs.js
@@ -7,10 +7,15 @@ import fs from 'node:fs'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
-const storage = new Storage({
-  projectId: process.env.GCS_PROJECT_ID,
-  keyFilename: process.env.GCS_KEY_FILE
-})
+const storageOptions = {
+  projectId: process.env.GCS_PROJECT_ID
+}
+
+if (process.env.GCS_KEY_FILE) {
+  storageOptions.keyFilename = process.env.GCS_KEY_FILE
+}
+
+const storage = new Storage(storageOptions)
 
 const bucket = storage.bucket(process.env.GCS_BUCKET)
 

--- a/server/tests/gcs.test.js
+++ b/server/tests/gcs.test.js
@@ -1,0 +1,56 @@
+import { PassThrough } from 'stream'
+import { jest, describe, test, expect } from '@jest/globals'
+
+describe('gcs utils', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  test('uses default credentials when GCS_KEY_FILE is not provided', async () => {
+    const originalEnv = process.env.NODE_ENV
+    const originalProject = process.env.GCS_PROJECT_ID
+    const originalBucket = process.env.GCS_BUCKET
+    const originalKeyFile = process.env.GCS_KEY_FILE
+
+    process.env.GCS_PROJECT_ID = 'proj'
+    process.env.GCS_BUCKET = 'bucket'
+    delete process.env.GCS_KEY_FILE
+    process.env.NODE_ENV = 'production'
+
+    const storageOptions = {}
+
+    jest.unstable_mockModule('@google-cloud/storage', () => {
+      return {
+        Storage: class {
+          constructor(options) {
+            Object.assign(storageOptions, options)
+          }
+          bucket() {
+            return {
+              file: () => ({
+                createWriteStream: () => new PassThrough(),
+                getSignedUrl: async () => ['https://signed.url']
+              })
+            }
+          }
+        }
+      }
+    })
+
+    const { uploadStream, getSignedUrl } = await import('../src/utils/gcs.js')
+
+    const buffer = Buffer.from('test')
+    const dest = 'path/file.txt'
+    await expect(uploadStream(buffer, dest, 'text/plain')).resolves.toBe(dest)
+
+    expect(storageOptions).toEqual({ projectId: 'proj' })
+
+    const url = await getSignedUrl(dest)
+    expect(url).toBe('https://signed.url')
+
+    process.env.NODE_ENV = originalEnv
+    process.env.GCS_PROJECT_ID = originalProject
+    process.env.GCS_BUCKET = originalBucket
+    process.env.GCS_KEY_FILE = originalKeyFile
+  })
+})


### PR DESCRIPTION
## Summary
- allow using default Google Cloud credentials when `GCS_KEY_FILE` is absent
- add unit test for uploading and signing without key file

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/gcs.test.js`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/role.test.js` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891b1c64a2c83299fce1f31ff7f9bd8