### PR TITLE
Add signed URLs to weekly notes

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -785,19 +785,6 @@ const saveNote = async () => {
   } catch {
     note = await createWeeklyNote(clientId, platformId, { week, text, images: newImages })
   }
-  if (note?.images?.length) {
-    const imgList = await Promise.all(
-      note.images.map(async p => {
-        try {
-          const url = await getWeeklyNoteImageUrl(clientId, platformId, p)
-          return { path: p, url }
-        } catch {
-          return { path: p, url: '' }
-        }
-      })
-    )
-    note.images = imgList
-  }
   weeklyNotes.value[week] = note
   toast.add({ severity: 'success', summary: '成功', detail: '已儲存備註', life: 3000 })
   noteDialog.value = false


### PR DESCRIPTION
## Summary
- include signed URLs for images when creating or updating weekly notes
- simplify saveNote logic to consume returned image URLs directly

## Testing
- `npm test` *(fails: Unrecognized option "experimental-vm-modules")*

------
https://chatgpt.com/codex/tasks/task_e_6891b1cc277c83298a723e654c731a8b