### PR TITLE
fix: set multipart headers for weekly note uploads

### DIFF
--- a/client/src/services/weeklyNotes.js
+++ b/client/src/services/weeklyNotes.js
@@ -25,7 +25,8 @@ export const createWeeklyNote = (clientId, platformId, data) => {
   return api
     .post(
       `/clients/${clientId}/platforms/${platformId}/weekly-notes`,
-      formData
+      formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } }
     )
     .then(r => r.data)
 }
@@ -47,7 +48,8 @@ export const updateWeeklyNote = (clientId, platformId, week, data) => {
   return api
     .put(
       `/clients/${clientId}/platforms/${platformId}/weekly-notes/${week}`,
-      formData
+      formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } }
     )
     .then(r => r.data)
 }


### PR DESCRIPTION
## Summary
- ensure weekly note uploads set `multipart/form-data` headers
- keep image uploads under the `images` field

## Testing
- `npm --prefix server test` *(fails: Unrecognized option "experimental-vm-modules")*

------
https://chatgpt.com/codex/tasks/task_e_6891b1bca7d8832988f4b96e16c6f167