### PR TITLE
feat: enable mobile file uploads

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -293,14 +293,16 @@
     </div>
 
     <!-- Hidden File Upload -->
-    <FileUpload 
+    <FileUpload
       ref="fileUploadRef"
-      mode="basic" 
-      :auto="true" 
-      :customUpload="true" 
-      @uploader="uploadRequest" 
+      mode="basic"
+      :auto="true"
+      :customUpload="true"
+      @uploader="uploadRequest"
       :multiple="true"
-      style="display: none;"
+      accept="image/*"
+      capture="environment"
+      class="hidden-file-upload"
     />
 
     <!-- Dialogs -->
@@ -739,6 +741,11 @@ onMounted(() => {
   loadData(route.params.folderId || null)
   fetchTags().then(tags => allTags.value = tags.map(t => t.name))
   fetchUsers().then(u => users.value = u)
+  const input = fileUploadRef.value?.$el.querySelector('input[type="file"]')
+  if (input) {
+    input.setAttribute('accept', 'image/*')
+    input.setAttribute('capture', 'environment')
+  }
 })
 
 watch(() => route.params.folderId, (newId) => loadData(newId || null))
@@ -746,6 +753,14 @@ watch(filterTags, () => loadData(currentFolder.value?._id), { deep: true })
 </script>
 
 <style scoped>
+.hidden-file-upload {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+  left: -9999px;
+}
+
 .library-container {
   padding: 0;
   max-width: none;

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -331,14 +331,16 @@
     </div>
 
     <!-- Hidden File Upload -->
-    <FileUpload 
+    <FileUpload
       ref="fileUploadRef"
-      mode="basic" 
-      :auto="true" 
-      :customUpload="true" 
-      @uploader="uploadRequest" 
+      mode="basic"
+      :auto="true"
+      :customUpload="true"
+      @uploader="uploadRequest"
       :multiple="true"
-      style="display: none;"
+      accept="image/*"
+      capture="environment"
+      class="hidden-file-upload"
     />
 
     <!-- Dialogs -->
@@ -870,6 +872,11 @@ onMounted(() => {
   loadData(route.params.folderId || null)
   fetchTags().then(tags => allTags.value = tags.map(t => t.name))
   fetchUsers().then(u => users.value = u)
+  const input = fileUploadRef.value?.$el.querySelector('input[type="file"]')
+  if (input) {
+    input.setAttribute('accept', 'image/*')
+    input.setAttribute('capture', 'environment')
+  }
 })
 
 watch(() => route.params.folderId, (newId) => loadData(newId || null))
@@ -878,6 +885,14 @@ watch(sortOrder, () => loadData(currentFolder.value?._id))
 </script>
 
 <style scoped>
+.hidden-file-upload {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+  left: -9999px;
+}
+
 .library-container {
   padding: 0;
   max-width: none;


### PR DESCRIPTION
## Summary
- allow mobile file uploads in asset and product libraries
- add hidden uploader class and camera capture attributes

## Testing
- `node --experimental-vm-modules server/node_modules/jest/bin/jest.js 2>&1 | tail -n 20` *(fails: A bucket name is needed to use Cloud Storage)*

------
https://chatgpt.com/codex/tasks/task_e_6891c1f8fc008329adb5e69ec27b9d31