### PR TITLE
refactor: centralize shared library styles

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -10,6 +10,7 @@ import ConfirmationService from 'primevue/confirmationservice'
 import Aura from '@primeuix/themes/aura' // Aura Light Blue 主題
 import 'primeicons/primeicons.css'
 import 'primeflex/primeflex.css'
+import './assets/shared-library-styles.css'
 
 // 移除 ElementPlus 的樣式和全域樣式
 // import './style.css'

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -391,7 +391,6 @@
 </template>
 
 <script setup>
-import '../assets/shared-library-styles.css';
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -442,7 +442,6 @@
 </template>
 
 <script setup>
-import '../assets/shared-library-styles.css';
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'


### PR DESCRIPTION
## Summary
- import shared library stylesheet globally in main.js
- remove redundant stylesheet imports from asset and product libraries

## Testing
- `npm test` *(fails: Unrecognized option "experimental-vm-modules")*
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_68949ab1aa048329b2006326219d2949