### PR TITLE
chore: allow any file type in product library uploads

### DIFF
--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -338,7 +338,6 @@
       :customUpload="true"
       @uploader="uploadRequest"
       :multiple="true"
-      accept="image/*"
       capture="environment"
       class="hidden-file-upload"
     />
@@ -874,7 +873,6 @@ onMounted(() => {
   fetchUsers().then(u => users.value = u)
   const input = fileUploadRef.value?.$el.querySelector('input[type="file"]')
   if (input) {
-    input.setAttribute('accept', 'image/*')
     input.setAttribute('capture', 'environment')
   }
 })


### PR DESCRIPTION
## Summary
- allow any file type in product library uploads

## Testing
- `npm test` *(fails: Unrecognized option "experimental-vm-modules")*


------
https://chatgpt.com/codex/tasks/task_e_68949aa27c8c8329ae72428602a07072