### PR TITLE
feat: allow all file types in asset upload

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -300,7 +300,6 @@
       :customUpload="true"
       @uploader="uploadRequest"
       :multiple="true"
-      accept="image/*"
       capture="environment"
       class="hidden-file-upload"
     />
@@ -743,7 +742,6 @@ onMounted(() => {
   fetchUsers().then(u => users.value = u)
   const input = fileUploadRef.value?.$el.querySelector('input[type="file"]')
   if (input) {
-    input.setAttribute('accept', 'image/*')
     input.setAttribute('capture', 'environment')
   }
 })


### PR DESCRIPTION
## Summary
- remove `accept` restriction from asset library FileUpload and onMounted hook
- verify backend upload middleware only limits file size

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/platform.test.js` *(fails: libcrypto.so.1.1 missing)*
- `apt-get update` *(403 Forbidden while attempting to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68949a9caec08329a7d6ed2b5800f7f2