### PR TITLE
fix: add BOM to daily CSV export

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -671,7 +671,7 @@ const exportDaily = () => {
     })
     return row
   })
-  const csv = Papa.unparse(rows)
+  const csv = '\uFEFF' + Papa.unparse(rows)
   saveAs(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), 'daily.csv')
 }
 


### PR DESCRIPTION
## Summary
- ensure exported daily CSV starts with UTF-8 BOM so Excel displays Chinese correctly

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a49a78d883298d75eb7b1b52f80f