### PR TITLE
Add color-scheme meta tag and default body colors

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light" />
     <title>Golden Goose Media</title>
   </head>
-  <body>
+  <body style="background-color: #ffffff; color: #000000;">
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- ensure light color scheme metadata
- default body background and text colors

## Testing
- `npm --prefix server install` (fails: 403 Forbidden)
- `npm test` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68a96ead80248329b514439f75b13b6d