### PR TITLE
移除共用樣式中深色主題註解

### DIFF
--- a/client/src/assets/shared-library-styles.css
+++ b/client/src/assets/shared-library-styles.css
@@ -181,7 +181,7 @@ body {
   font-weight: 700;
 }
 
-/* Text utilities with proper dark theme support */
+/* Text utilities */
 .text-primary {
   color: var(--text-primary) !important;
 }


### PR DESCRIPTION
## 摘要
- 移除 shared-library-styles.css 中提及深色主題的註解
- 確認檔案未包含任何深色主題媒體查詢或變數
- 驗證 :root 與 body 保持白色背景與深色文字

## 測試
- `npm test` *(失敗：找不到 jest)*
- `npm install --prefix server` *(失敗：403 Forbidden 取得 archiver 套件)*

------
https://chatgpt.com/codex/tasks/task_e_68a96eb1541c83299dbcb0f25b7aa26c