### PR TITLE
feat: add single product retrieval

### DIFF
--- a/server/src/controllers/product.controller.js
+++ b/server/src/controllers/product.controller.js
@@ -13,6 +13,12 @@ export const getProducts = async (req, res) => {
   await getAssets(req, res);
 };
 
+export const getProduct = async (req, res) => {
+  const product = await Asset.findOne({ _id: req.params.id, type: 'edited' });
+  if (!product) return res.status(404).json({ message: t('ASSET_NOT_FOUND') });
+  res.json(product);
+};
+
 export const batchDownload = async (req, res) => {
   const { ids } = req.body;
   if (!Array.isArray(ids) || !ids.length) {

--- a/server/src/routes/product.routes.js
+++ b/server/src/routes/product.routes.js
@@ -2,12 +2,13 @@ import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
 import { requirePerm } from '../middleware/permission.js'
 import { PERMISSIONS } from '../config/permissions.js'
-import { getProducts, batchDownload, getBatchDownloadProgress } from '../controllers/product.controller.js'
+import { getProducts, getProduct, batchDownload, getBatchDownloadProgress } from '../controllers/product.controller.js'
 
 const router = Router()
 
 router.post('/batch-download', protect, batchDownload)
 router.get('/batch-download/:id', protect, getBatchDownloadProgress)
 router.get('/', protect, requirePerm(PERMISSIONS.ASSET_READ), getProducts)
+router.get('/:id', protect, requirePerm(PERMISSIONS.ASSET_READ), getProduct)
 
 export default router


### PR DESCRIPTION
## Summary
- 新增依 ID 取得成品的 `getProduct`
- 路由新增 `/:id` 以支援單筆成品查詢

## Testing
- `npm test` *(失敗：找不到 jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a9755b1af48329895b83147976bc7d