### PR TITLE
feat: add product signed url endpoint

### DIFF
--- a/server/src/controllers/product.controller.js
+++ b/server/src/controllers/product.controller.js
@@ -19,6 +19,20 @@ export const getProduct = async (req, res) => {
   res.json(product);
 };
 
+export const getProductSignedUrl = async (req, res) => {
+  const product = await Asset.findOne({ _id: req.params.id, type: 'edited' });
+  if (!product) return res.status(404).json({ message: t('ASSET_NOT_FOUND') });
+
+  const options = {};
+  if (req.query.download === '1') {
+    const name = encodeURIComponent(product.title || product.filename);
+    options.responseDisposition = `attachment; filename="${name}"`;
+  }
+
+  const url = await getSignedUrl(product.path, options);
+  res.json({ url });
+};
+
 export const batchDownload = async (req, res) => {
   const { ids } = req.body;
   if (!Array.isArray(ids) || !ids.length) {

--- a/server/src/routes/product.routes.js
+++ b/server/src/routes/product.routes.js
@@ -2,7 +2,7 @@ import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
 import { requirePerm } from '../middleware/permission.js'
 import { PERMISSIONS } from '../config/permissions.js'
-import { getProducts, getProduct, batchDownload, getBatchDownloadProgress } from '../controllers/product.controller.js'
+import { getProducts, getProduct, batchDownload, getBatchDownloadProgress, getProductSignedUrl } from '../controllers/product.controller.js'
 
 const router = Router()
 
@@ -10,5 +10,6 @@ router.post('/batch-download', protect, batchDownload)
 router.get('/batch-download/:id', protect, getBatchDownloadProgress)
 router.get('/', protect, requirePerm(PERMISSIONS.ASSET_READ), getProducts)
 router.get('/:id', protect, requirePerm(PERMISSIONS.ASSET_READ), getProduct)
+router.get('/:id/url', protect, requirePerm(PERMISSIONS.ASSET_READ), getProductSignedUrl)
 
 export default router

--- a/server/tests/productUrl.test.js
+++ b/server/tests/productUrl.test.js
@@ -1,0 +1,78 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import productRoutes from '../src/routes/product.routes.js'
+import authRoutes from '../src/routes/auth.routes.js'
+import Asset from '../src/models/asset.model.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+let tokenNoPerm
+let productId
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/products', productRoutes)
+
+  const managerRole = await Role.create({ name: 'manager', permissions: ['asset:read'] })
+  const empRole = await Role.create({ name: 'emp', permissions: [] })
+
+  await User.create({ username: 'admin', password: 'pwd', email: 'a@test', roleId: managerRole._id })
+  await User.create({ username: 'emp', password: 'pwd', email: 'e@test', roleId: empRole._id })
+
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'admin', password: 'pwd' })
+  token = res.body.token
+
+  const res2 = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'emp', password: 'pwd' })
+  tokenNoPerm = res2.body.token
+
+  const product = await Asset.create({ filename: 'p.mp4', path: '/tmp/p.mp4', type: 'edited' })
+  productId = product._id
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+describe('Product signed url', () => {
+  it('should return signed url', async () => {
+    const res = await request(app)
+      .get(`/api/products/${productId}/url`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(res.body.url).toMatch(/^https?:\/\/.*p\.mp4/)
+  })
+
+  it('should return 403 when no permission', async () => {
+    await request(app)
+      .get(`/api/products/${productId}/url`)
+      .set('Authorization', `Bearer ${tokenNoPerm}`)
+      .expect(403)
+  })
+
+  it('should return 404 when product not found', async () => {
+    const id = new mongoose.Types.ObjectId()
+    await request(app)
+      .get(`/api/products/${id}/url`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404)
+  })
+})


### PR DESCRIPTION
## Summary
- expose API to get signed URL for edited product assets
- route wiring for product signed URL
- add unit tests for product signed URL scenarios

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a978538f048329bbf0ef654bfb03c5