### PR TITLE
feat: adopt winston for server logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ google.json
 google.json
 tmp/
 server/tmp/
+server/logs/

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm --prefix server start
+web: LOG_PATH=server/logs/app.log npm --prefix server start

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,8 @@
         "mongoose": "^8.3.1",
         "multer": "^1.4.5-lts.1",
         "archiver": "^5.3.2",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "winston": "^3.10.0"
       },
       "devDependencies": {
         "ioredis-mock": "^8.6.0",

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,8 @@
     "mongoose": "^8.3.1",
     "multer": "^1.4.5-lts.1",
     "archiver": "^5.3.2",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "winston": "^3.10.0"
   },
   "devDependencies": {
     "ioredis-mock": "^8.6.0",

--- a/server/src/config/db.js
+++ b/server/src/config/db.js
@@ -5,6 +5,7 @@ import mongoose from 'mongoose'
 import dotenv from 'dotenv'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import logger from './logger.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 dotenv.config({ path: path.resolve(__dirname, '../../.env') })
@@ -12,9 +13,9 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 const connectDB = async () => {
   try {
     await mongoose.connect(process.env.MONGODB_URI)
-    console.log('\u2705 MongoDB \u5df2\u9023\u7dda')
+    logger.info('\u2705 MongoDB \u5df2\u9023\u7dda')
   } catch (err) {
-    console.error('\u274C MongoDB \u9023\u7dda\u5931\u6557\uff1a', err.message)
+    logger.error('\u274C MongoDB \u9023\u7dda\u5931\u6557\uff1a', err.message)
     process.exit(1)
   }
 }

--- a/server/src/config/logger.js
+++ b/server/src/config/logger.js
@@ -1,0 +1,33 @@
+import { createLogger, format, transports } from 'winston';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const logDir = process.env.LOG_DIR || path.join(__dirname, '../../logs');
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir, { recursive: true });
+}
+
+const logPath = process.env.LOG_PATH || path.join(logDir, 'app.log');
+
+const logger = createLogger({
+  level: process.env.LOG_LEVEL || 'info',
+  format: format.combine(
+    format.timestamp(),
+    format.printf(({ timestamp, level, message }) => `${timestamp} [${level}] ${message}`)
+  ),
+  transports: [
+    new transports.File({ filename: logPath }),
+    new transports.Console({
+      format: format.combine(
+        format.colorize(),
+        format.simple()
+      )
+    })
+  ]
+});
+
+export default logger;

--- a/server/src/config/redis.js
+++ b/server/src/config/redis.js
@@ -8,6 +8,7 @@ import RedisMock from 'ioredis-mock'
 import dotenv    from 'dotenv'
 import path      from 'node:path'
 import { fileURLToPath } from 'node:url'
+import logger from './logger.js'
 
 /* ---------- .env ---------- */
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -40,10 +41,9 @@ const redis = new RedisClient(
   redisOptions
 )
 
-console.log('[Redis] 初始化來源 =',
-            REDIS_URL ? 'Heroku' : 'localhost:6379')
+logger.info(`[Redis] 初始化來源 = ${REDIS_URL ? 'Heroku' : 'localhost:6379'}`)
 
-redis.on('connect', () => console.log('🟢 Redis 已連線'))
-redis.on('error',   err => console.error('Redis 連線失敗：', err))
+redis.on('connect', () => logger.info('🟢 Redis 已連線'))
+redis.on('error',   err => logger.error('Redis 連線失敗：', err))
 
 export default redis

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -16,6 +16,7 @@ import { getDescendantFolderIds, getAncestorFolderIds, getRootFolder } from '../
 import { includeManagers } from '../utils/includeManagers.js'
 import { getCache, setCache, clearCacheByPrefix, delCache } from '../utils/cache.js'
 import { clearDashboardCache } from './dashboard.controller.js'
+import logger from '../config/logger.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -428,7 +429,7 @@ export const batchDownload = async (req, res) => {
             await setCache(cacheKey, { percent, url: null, error: null }, 600);
 
           } catch (err) {
-            console.error(`Failed to download or archive ${asset.path}:`, err);
+            logger.error(`Failed to download or archive ${asset.path}:`, err);
             const currentProgress = await getCache(cacheKey) || {};
             const newError = (currentProgress.error || '') + `無法處理 ${asset.title || asset.filename}. `;
             await setCache(cacheKey, { ...currentProgress, error: newError }, 600);
@@ -447,11 +448,11 @@ export const batchDownload = async (req, res) => {
       await setCache(cacheKey, { ...finalProgress, percent: 100, url }, 600)
 
     } catch (e) {
-      console.error('zip error', e)
+      logger.error('zip error', e)
       await setCache(cacheKey, { percent: 100, url: null, error: e.message }, 600)
     } finally {
       if (tmpDir) {
-        await fs.rm(tmpDir, { recursive: true, force: true }).catch(err => console.error(`Failed to remove temp dir ${tmpDir}:`, err))
+        await fs.rm(tmpDir, { recursive: true, force: true }).catch(err => logger.error(`Failed to remove temp dir ${tmpDir}:`, err))
       }
     }
   })()

--- a/server/src/controllers/folder.controller.js
+++ b/server/src/controllers/folder.controller.js
@@ -11,6 +11,7 @@ import bucket, { uploadFile as gcsUploadFile, getSignedUrl } from '../utils/gcs.
 import fs from 'node:fs/promises'
 import archiver from 'archiver'
 import { createWriteStream } from 'node:fs'
+import logger from '../config/logger.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -347,7 +348,7 @@ export const downloadFolder = async (req, res) => {
             await setCache(cacheKey, { percent, url: null, error: null }, 600)
 
           } catch (err) {
-            console.error(`Failed to download or archive ${asset.path}:`, err)
+            logger.error(`Failed to download or archive ${asset.path}:`, err)
             const currentProgress = await getCache(cacheKey) || {}
             const newError = (currentProgress.error || '') + `無法處理 ${asset.title || asset.filename}. `
             await setCache(cacheKey, { ...currentProgress, error: newError }, 600)
@@ -366,11 +367,11 @@ export const downloadFolder = async (req, res) => {
       await setCache(cacheKey, { ...finalProgress, percent: 100, url }, 600)
 
     } catch (e) {
-      console.error('zip error', e)
+      logger.error('zip error', e)
       await setCache(cacheKey, { percent: 100, url: null, error: e.message }, 600)
     } finally {
       if (tmpDir) {
-        await fs.rm(tmpDir, { recursive: true, force: true }).catch(err => console.error(`Failed to remove temp dir ${tmpDir}:`, err))
+        await fs.rm(tmpDir, { recursive: true, force: true }).catch(err => logger.error(`Failed to remove temp dir ${tmpDir}:`, err))
       }
     }
   })()

--- a/server/src/controllers/weeklyNote.controller.js
+++ b/server/src/controllers/weeklyNote.controller.js
@@ -5,6 +5,7 @@ import { uploadFile, getSignedUrl } from '../utils/gcs.js'
 import { decodeFilename } from '../utils/decodeFilename.js'
 import fs from 'node:fs/promises'
 import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
+import logger from '../config/logger.js'
 
 const uploadImages = async files => {
   if (!files?.length) return []
@@ -46,7 +47,7 @@ const appendSignedUrls = async note => {
 }
 
 export const createWeeklyNote = async (req, res) => {
-  console.log('uploaded files:', req.files)
+  logger.debug('uploaded files:', req.files)
   const images = await uploadImages(req.files)
   const note = await WeeklyNote.create({
     clientId: req.params.clientId,
@@ -83,7 +84,7 @@ export const updateWeeklyNote = async (req, res) => {
   let newImages = []
   if (keep !== undefined) newImages = keep
   if (req.files?.length) {
-    console.log('uploaded files:', req.files)
+    logger.debug('uploaded files:', req.files)
     const uploaded = await uploadImages(req.files)
     newImages = [...newImages, ...uploaded]
   }


### PR DESCRIPTION
## Summary
- use winston with file and console transports
- replace console statements in configs and controllers
- configure Procfile for log path and ignore server logs

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cffb4bb0832984980c03552417c1