### PR TITLE
feat: configure CORS allow list via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ JWT_EXPIRES_IN=7d
 # 伺服器監聽埠
 PORT=3000
 
+# CORS 允許網域 (逗號分隔)
+CORS_ALLOW_LIST=https://www.golden-goose-media.com,https://golden-goose-media.com,http://localhost:5173,http://localhost:3000
+
 # 檔案上傳暫存資料夾（預設 /tmp/uploads，會自動建立）
 UPLOAD_DIR=uploads
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
    npm install
    \`\`\`
 伺服器啟動前，請在根目錄複製 `.env.example` 為 `.env`，並依需求調整 MongoDB、JWT、GCS 等設定。
+若要允許額外的前端網域，請設定 `CORS_ALLOW_LIST`（以逗號分隔）。
  `.env` 中需填入以下 GCS 相關欄位：
 
 \`\`\`bash
@@ -144,7 +145,7 @@ server/  # 後端 API
 以下為將專案部署至 **Heroku** 的基本流程：
 
 1. **設定環境變數**：在 Heroku 後台依序新增
-   `MONGODB_URI`、`JWT_SECRET`、`JWT_EXPIRES_IN` 及 `UPLOAD_DIR` 等欄位，
+   `MONGODB_URI`、`JWT_SECRET`、`JWT_EXPIRES_IN`、`CORS_ALLOW_LIST` 及 `UPLOAD_DIR` 等欄位，
    值可參考 `server/.env.example`。
 2. **部署程式碼**：登入後建立應用程式並執行
    \`\`\`bash

--- a/server/README.md
+++ b/server/README.md
@@ -9,6 +9,7 @@ npm start                 # 啟動伺服器
 \`\`\`
 
 伺服器啟動前請在根目錄複製 `.env.example` 為 `.env`，並填入 MongoDB、JWT 及 GCS 設定。
+如需允許新的前端網域，請在 `.env` 中設定 `CORS_ALLOW_LIST`（逗號分隔）。
 
 `.env` 中的 `UPLOAD_DIR` 可指定暫存上傳檔案的資料夾，預設值為 `/tmp/uploads`。
 

--- a/server/src/config/cors.js
+++ b/server/src/config/cors.js
@@ -1,0 +1,29 @@
+const defaultAllowList = [
+  'https://www.golden-goose-media.com',
+  'https://golden-goose-media.com',
+  'http://localhost:5173',
+  'http://localhost:3000'
+]
+
+export function getAllowList(env = process.env.CORS_ALLOW_LIST) {
+  if (!env) return defaultAllowList
+  return env.split(',').map(s => s.trim()).filter(Boolean)
+}
+
+export function createCorsOptions(env) {
+  const allowList = getAllowList(env)
+  return {
+    origin: (origin, cb) => {
+      if (!origin) return cb(null, true)
+      if (allowList.includes(origin)) return cb(null, true)
+      console.warn('[CORS] Blocked Origin =', origin)
+      return cb(new Error('Not allowed by CORS'))
+    },
+    credentials: true,
+    allowedHeaders:
+      'Content-Type,Authorization,Accept,Origin,X-Requested-With',
+    methods: 'GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS'
+  }
+}
+
+export { defaultAllowList }

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -14,6 +14,7 @@ import dotenv             from 'dotenv'
 import path               from 'node:path'
 import fs                 from 'node:fs'
 import { fileURLToPath }  from 'node:url'
+import { createCorsOptions } from './config/cors.js'
 
 import mongoose                    from 'mongoose'
 import connectDB                   from './config/db.js'
@@ -50,29 +51,7 @@ const app = express()
 app.enable('trust proxy')                  // Heroku 需開啟，否則 secure cookie 不生效
 
 /* ────────────────────────── 2. CORS (放最前) ───────────────────────── */
-const allowList = [
-  'https://www.golden-goose-media.com',
-  'https://golden-goose-media.com',
-  'http://localhost:5173',
-  'http://localhost:3000'
-]
-
-const corsOptions = {
-  /**
-   * 動態驗證 Origin：
-   * 無 Origin（Postman / SSR）直接放行；前端請求需在 allowList
-   */
-  origin: (origin, cb) => {
-    if (!origin) return cb(null, true)
-    if (allowList.includes(origin)) return cb(null, true)
-    console.warn('[CORS] Blocked Origin =', origin)
-    return cb(new Error('Not allowed by CORS'))
-  },
-  credentials: true,
-  allowedHeaders:
-    'Content-Type,Authorization,Accept,Origin,X-Requested-With',
-  methods: 'GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS'
-}
+const corsOptions = createCorsOptions()
 
 app.use(cors(corsOptions))
 app.options('*', cors(corsOptions))        // 處理所有預檢

--- a/server/tests/cors.test.js
+++ b/server/tests/cors.test.js
@@ -1,0 +1,48 @@
+import request from 'supertest'
+import express from 'express'
+import cors from 'cors'
+import { createCorsOptions, defaultAllowList } from '../src/config/cors.js'
+
+describe('CORS allow list', () => {
+  const createApp = () => {
+    const app = express()
+    const options = createCorsOptions()
+    app.use(cors(options))
+    app.get('/api/health', (req, res) => res.json({ status: 'ok' }))
+    return app
+  }
+
+  afterEach(() => {
+    delete process.env.CORS_ALLOW_LIST
+  })
+
+  it('allows origin from CORS_ALLOW_LIST', async () => {
+    process.env.CORS_ALLOW_LIST = 'http://foo.com,http://bar.com'
+    const app = createApp()
+    const res = await request(app)
+      .get('/api/health')
+      .set('Origin', 'http://foo.com')
+      .expect(200)
+    expect(res.headers['access-control-allow-origin']).toBe('http://foo.com')
+  })
+
+  it('blocks origin not in CORS_ALLOW_LIST', async () => {
+    process.env.CORS_ALLOW_LIST = 'http://foo.com'
+    const app = createApp()
+    const res = await request(app)
+      .get('/api/health')
+      .set('Origin', 'http://bar.com')
+    expect(res.status).toBe(500)
+    expect(res.text).toMatch(/Not allowed by CORS/)
+  })
+
+  it('uses default list when CORS_ALLOW_LIST is not set', async () => {
+    const app = createApp()
+    const origin = defaultAllowList[0]
+    const res = await request(app)
+      .get('/api/health')
+      .set('Origin', origin)
+      .expect(200)
+    expect(res.headers['access-control-allow-origin']).toBe(origin)
+  })
+})


### PR DESCRIPTION
## Summary
- read CORS allow list from `CORS_ALLOW_LIST` env var with defaults
- document how to configure allowed origins in env files and deployment guides
- test CORS behavior for allowed and blocked origins

## Testing
- `npm install` *(failed: 403 Forbidden - GET https://registry.npmjs.org/archiver)*
- `npm test` *(failed: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cffb85188329b98a7c0346a2dfc6