### PR TITLE
feat: add validation middleware and tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-validator": "^7.0.1",
     "ioredis": "^5.3.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.3.1",

--- a/server/src/middleware/validate.js
+++ b/server/src/middleware/validate.js
@@ -1,0 +1,9 @@
+import { validationResult } from 'express-validator'
+
+export const validate = (req, res, next) => {
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ message: errors.array()[0].msg })
+  }
+  next()
+}

--- a/server/src/routes/auth.routes.js
+++ b/server/src/routes/auth.routes.js
@@ -1,10 +1,27 @@
 import { Router } from 'express'
+import { body } from 'express-validator'
 import { login, register } from '../controllers/auth.controller.js'
 import asyncHandler from '../utils/asyncHandler.js'
+import { validate } from '../middleware/validate.js'
+
 const router = Router()
 
-router.post('/login', asyncHandler(login))
+router.post(
+  '/login',
+  body('username').notEmpty().withMessage('Username is required'),
+  body('password').notEmpty().withMessage('Password is required'),
+  validate,
+  asyncHandler(login)
+)
 // \u82e5\u4e0d\u958b\u653e\u8a3b\u518a\u53ef\u79fb\u9664\u6b64\u884c
-router.post('/register', asyncHandler(register))
+router.post(
+  '/register',
+  body('username').notEmpty().withMessage('Username is required'),
+  body('password').isLength({ min: 6 }).withMessage('Password must be at least 6 characters'),
+  body('email').isEmail().withMessage('Email is invalid'),
+  body('role').notEmpty().withMessage('Role is required'),
+  validate,
+  asyncHandler(register)
+)
 
 export default router

--- a/server/src/routes/user.routes.js
+++ b/server/src/routes/user.routes.js
@@ -1,4 +1,5 @@
 import { Router } from 'express'
+import { body } from 'express-validator'
 import { protect } from '../middleware/auth.js'
 import { requirePerm } from '../middleware/permission.js'
 import { PERMISSIONS } from '../config/permissions.js'
@@ -11,6 +12,7 @@ import {
   updateProfile
 } from '../controllers/user.controller.js'
 import asyncHandler from '../utils/asyncHandler.js'
+import { validate } from '../middleware/validate.js'
 
 const router = Router()
 
@@ -21,11 +23,25 @@ router.put('/profile', asyncHandler(updateProfile))
 router
   .route('/')
   .get(requirePerm(PERMISSIONS.USER_MANAGE), asyncHandler(getAllUsers))               // GET  /api/user
-  .post(requirePerm(PERMISSIONS.USER_MANAGE), asyncHandler(createUser))               // POST /api/user
+  .post(
+    requirePerm(PERMISSIONS.USER_MANAGE),
+    body('username').notEmpty().withMessage('Username is required'),
+    body('name').notEmpty().withMessage('Name is required'),
+    body('email').isEmail().withMessage('Email is invalid'),
+    body('role').notEmpty().withMessage('Role is required'),
+    body('password').isLength({ min: 6 }).withMessage('Password must be at least 6 characters'),
+    validate,
+    asyncHandler(createUser)
+  )               // POST /api/user
 
 router
   .route('/:id')
-  .put(requirePerm(PERMISSIONS.USER_MANAGE), asyncHandler(updateUser))                // PUT    /api/user/:id
+  .put(
+    requirePerm(PERMISSIONS.USER_MANAGE),
+    body('email').optional().isEmail().withMessage('Email is invalid'),
+    validate,
+    asyncHandler(updateUser)
+  )                // PUT    /api/user/:id
   .delete(requirePerm(PERMISSIONS.USER_MANAGE), asyncHandler(deleteUser))             // DELETE /api/user/:id
 
 export default router

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -45,4 +45,24 @@ describe('POST /api/auth/login', () => {
     expect(res.body).toHaveProperty('user.role')
     expect(res.body.user).toHaveProperty('permissions')
   })
+
+  it('should return 400 if username is missing', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ password: 'mypwd' })
+      .expect(400)
+
+    expect(res.body.message).toBe('Username is required')
+  })
+})
+
+describe('POST /api/auth/register', () => {
+  it('should return 400 if email is invalid', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ username: 'new', password: 'mypwd', email: 'notemail', role: 'manager' })
+      .expect(400)
+
+    expect(res.body.message).toBe('Email is invalid')
+  })
 })

--- a/server/tests/user.test.js
+++ b/server/tests/user.test.js
@@ -61,3 +61,30 @@ describe('create user then login', () => {
     expect(res.body).toHaveProperty('token')
   })
 })
+
+describe('validation', () => {
+  it('should return 400 when creating user without username', async () => {
+    const res = await request(app)
+      .post('/api/user')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'U2', email: 'u2@example.com', role: 'employee', password: 'pwd' })
+      .expect(400)
+
+    expect(res.body.message).toBe('Username is required')
+  })
+
+  it('should return 400 when updating user with invalid email', async () => {
+    const created = await request(app)
+      .post('/api/user')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ username: 'u3', name: 'U3', email: 'u3@example.com', role: 'employee', password: 'pwd' })
+
+    const res = await request(app)
+      .put(`/api/user/${created.body._id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ email: 'notanemail' })
+      .expect(400)
+
+    expect(res.body.message).toBe('Email is invalid')
+  })
+})


### PR DESCRIPTION
## Summary
- add express-validator dependency and shared validate middleware
- enforce field validation on auth and user routes
- add unit tests for validation failures

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cffcb530832989e3003ff8096736