### PR TITLE
fix: handle 404 for unknown API routes

### DIFF
--- a/server/src/server.js
+++ b/server/src/server.js
@@ -129,7 +129,10 @@ app.use('/api/dashboard', dashboardRoutes)
 /* ────────────────────────── 5. 前端靜態檔案 ───────────────────────── */
 const clientDist = path.resolve(__dirname, '../../client/dist')
 app.use(express.static(clientDist))
-app.get('*', (_, res) => res.sendFile(path.join(clientDist, 'index.html')))
+// 只回傳前端入口給非 /api 路徑，避免覆蓋 API 404
+app.get(/^\/(?!api).*/, (_, res) =>
+  res.sendFile(path.join(clientDist, 'index.html'))
+)
 
 /* ────────────────────────── 6. 404 & 全域錯誤 ───────────────────────── */
 app.use(notFound)

--- a/server/tests/apiNotFound.test.js
+++ b/server/tests/apiNotFound.test.js
@@ -1,0 +1,15 @@
+import request from 'supertest'
+import express from 'express'
+import { notFound, errorHandler } from '../src/utils/handleError.js'
+// 建立模擬的伺服器，只加入前端 fallback 與錯誤處理
+const app = express()
+// 模擬 server.js 的非 /api fallback
+app.get(/^\/(?!api).*/, (_, res) => res.send('index'))
+app.use(notFound)
+app.use(errorHandler)
+
+describe('GET /api/non-existent', () => {
+  it('should return 404 for unknown API routes', async () => {
+    await request(app).get('/api/non-existent').expect(404)
+  })
+})


### PR DESCRIPTION
## Summary
- avoid serving SPA for missing API endpoints by excluding `/api` paths from fallback
- add test ensuring unknown API routes return 404

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cffdf8808329a8dc64bcd41ce802