### PR TITLE
fix: 驗證產品 ID

### DIFF
--- a/server/src/controllers/product.controller.js
+++ b/server/src/controllers/product.controller.js
@@ -8,6 +8,7 @@ import archiver from 'archiver';
 import bucket, { uploadFile as gcsUploadFile, getSignedUrl } from '../utils/gcs.js';
 import { getCache, setCache, delCache } from '../utils/cache.js';
 import logger from '../config/logger.js';
+import mongoose from 'mongoose';
 
 export const getProducts = async (req, res) => {
   if (!req.query.type) req.query.type = 'edited';
@@ -15,12 +16,18 @@ export const getProducts = async (req, res) => {
 };
 
 export const getProduct = async (req, res) => {
+  if (!mongoose.isValidObjectId(req.params.id)) {
+    return res.status(400).json({ message: t('PARAMS_ERROR') });
+  }
   const product = await Asset.findOne({ _id: req.params.id, type: 'edited' });
   if (!product) return res.status(404).json({ message: t('ASSET_NOT_FOUND') });
   res.json(product);
 };
 
 export const getProductSignedUrl = async (req, res) => {
+  if (!mongoose.isValidObjectId(req.params.id)) {
+    return res.status(400).json({ message: t('PARAMS_ERROR') });
+  }
   const product = await Asset.findOne({ _id: req.params.id, type: 'edited' });
   if (!product) return res.status(404).json({ message: t('ASSET_NOT_FOUND') });
 

--- a/server/tests/productUrl.test.js
+++ b/server/tests/productUrl.test.js
@@ -75,4 +75,20 @@ describe('Product signed url', () => {
       .set('Authorization', `Bearer ${token}`)
       .expect(404)
   })
+
+  it('should return 400 when invalid id', async () => {
+    await request(app)
+      .get('/api/products/invalid-id/url')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(400)
+  })
+})
+
+describe('Get product', () => {
+  it('should return 400 when invalid id', async () => {
+    await request(app)
+      .get('/api/products/invalid-id')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(400)
+  })
 })


### PR DESCRIPTION
## Summary
- 檢查 `getProduct` 與 `getProductSignedUrl` 的 `id` 參數
- 當 `id` 無效時回傳 400 錯誤
- 增加單元測試驗證錯誤 ID

## Testing
- `npm test` *(失敗：jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fe35efd48329922e19197e777e0d