### PR TITLE
refactor product batch download

### DIFF
--- a/server/src/controllers/product.controller.js
+++ b/server/src/controllers/product.controller.js
@@ -9,6 +9,41 @@ import bucket, { uploadFile as gcsUploadFile, getSignedUrl } from '../utils/gcs.
 import { getCache, setCache, delCache } from '../utils/cache.js';
 import logger from '../config/logger.js';
 
+export const archiveProducts = (products, tmpDir, cacheKey, zipPath) =>
+  new Promise((resolve, reject) => {
+    const output = createWriteStream(zipPath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+
+    output.on('close', () => resolve(zipPath));
+    archive.on('error', reject);
+
+    archive.pipe(output);
+
+    (async () => {
+      let processed = 0;
+      const total = products.length;
+
+      for (const product of products) {
+        const localPath = path.join(tmpDir, product.filename);
+        try {
+          await bucket.file(product.path).download({ destination: localPath });
+          archive.file(localPath, { name: product.title || product.filename });
+
+          processed++;
+          const percent = Math.round((processed / total) * 100);
+          await setCache(cacheKey, { percent, url: null, error: null }, 600);
+        } catch (err) {
+          logger.error(`Failed to download or archive ${product.path}:`, err);
+          const currentProgress = (await getCache(cacheKey)) || {};
+          const newError = (currentProgress.error || '') + `無法處理 ${product.title || product.filename}. `;
+          await setCache(cacheKey, { ...currentProgress, error: newError }, 600);
+        }
+      }
+
+      archive.finalize();
+    })().catch(reject);
+  });
+
 export const getProducts = async (req, res) => {
   if (!req.query.type) req.query.type = 'edited';
   await getAssets(req, res);
@@ -58,38 +93,7 @@ export const batchDownload = async (req, res) => {
       const zipName = `products-${Date.now()}.zip`;
       const zipPath = path.join(tmpDir, zipName);
 
-      await new Promise(async (resolve, reject) => {
-        const output = createWriteStream(zipPath);
-        const archive = archiver('zip', { zlib: { level: 9 } });
-
-        output.on('close', resolve);
-        archive.on('error', reject);
-        
-        archive.pipe(output);
-
-        let processed = 0;
-        const total = products.length;
-
-        for (const product of products) {
-          const localPath = path.join(tmpDir, product.filename);
-          try {
-            await bucket.file(product.path).download({ destination: localPath });
-            archive.file(localPath, { name: product.title || product.filename });
-            
-            processed++;
-            const percent = Math.round((processed / total) * 100);
-            await setCache(cacheKey, { percent, url: null, error: null }, 600);
-
-          } catch (err) {
-            logger.error(`Failed to download or archive ${product.path}:`, err);
-            const currentProgress = await getCache(cacheKey) || {};
-            const newError = (currentProgress.error || '') + `無法處理 ${product.title || product.filename}. `;
-            await setCache(cacheKey, { ...currentProgress, error: newError }, 600);
-          }
-        }
-
-        archive.finalize();
-      });
+      await archiveProducts(products, tmpDir, cacheKey, zipPath);
 
       const gcsPath = await gcsUploadFile(zipPath, zipName, 'application/zip');
       const url = await getSignedUrl(gcsPath, {

--- a/server/tests/archiveProducts.test.js
+++ b/server/tests/archiveProducts.test.js
@@ -1,0 +1,61 @@
+import { jest, describe, it, expect } from '@jest/globals';
+
+const setupMocks = async (downloadReject = false) => {
+  jest.resetModules();
+
+  const outputHandlers = {};
+  const createWriteStream = jest.fn(() => ({
+    on: (event, handler) => {
+      if (event === 'close') outputHandlers.close = handler;
+    }
+  }));
+
+  const archive = {
+    pipe: jest.fn(),
+    file: jest.fn(),
+    on: jest.fn((event, handler) => {
+      if (event === 'error') archive._error = handler;
+    }),
+    finalize: jest.fn(() => {
+      if (outputHandlers.close) outputHandlers.close();
+    })
+  };
+
+  const download = downloadReject
+    ? jest.fn().mockRejectedValue(new Error('download error'))
+    : jest.fn().mockResolvedValue();
+  const bucket = { file: jest.fn(() => ({ download })) };
+
+  const setCache = jest.fn().mockResolvedValue();
+  const getCache = jest.fn().mockResolvedValue({});
+  const logger = { error: jest.fn() };
+
+  jest.unstable_mockModule('archiver', () => ({ default: () => archive }));
+  jest.unstable_mockModule('node:fs', () => ({ createWriteStream }));
+  jest.unstable_mockModule('../src/utils/gcs.js', () => ({ default: bucket }));
+  jest.unstable_mockModule('../src/utils/cache.js', () => ({ setCache, getCache }));
+  jest.unstable_mockModule('../src/config/logger.js', () => ({ default: logger }));
+
+  const { archiveProducts } = await import('../src/controllers/product.controller.js');
+
+  return { archiveProducts, setCache, logger };
+};
+
+describe('archiveProducts', () => {
+  it('resolves and updates progress on success', async () => {
+    const { archiveProducts, setCache } = await setupMocks();
+    const products = [{ path: 'p', filename: 'f', title: 't' }];
+    const result = await archiveProducts(products, '/tmp', 'key', '/tmp/z.zip');
+    expect(result).toBe('/tmp/z.zip');
+    expect(setCache).toHaveBeenCalledWith('key', { percent: 100, url: null, error: null }, 600);
+  });
+
+  it('logs error and continues when download fails', async () => {
+    const { archiveProducts, setCache, logger } = await setupMocks(true);
+    const products = [{ path: 'p', filename: 'f', title: 't' }];
+    const result = await archiveProducts(products, '/tmp', 'key', '/tmp/z.zip');
+    expect(result).toBe('/tmp/z.zip');
+    expect(logger.error).toHaveBeenCalled();
+    expect(setCache).toHaveBeenCalledWith('key', { error: expect.stringContaining('無法處理') }, 600);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor product batch download by extracting archiveProducts helper
- add tests covering archiveProducts success and failure cases

## Testing
- `npm test` *(fails: jest: not found)*
- `npm --prefix server install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/archiver)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fe33a3448329abb58bd12b487467