### PR TITLE
fix: disable automatic dark mode detection

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -23,7 +23,10 @@ app.use(createPinia())
 app.use(router)
 app.use(PrimeVue, {
   theme: {
-    preset: Aura
+    preset: Aura,
+    options: {
+      darkModeSelector: 'none'
+    }
   },
   ripple: true
 })


### PR DESCRIPTION
## Summary
- prevent PrimeVue from auto-switching to dark mode by specifying `options.darkModeSelector` as none

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa9bb2f6448329902e338c9910dece