### PR TITLE
feat: validate formula field references

### DIFF
--- a/server/src/controllers/platform.controller.js
+++ b/server/src/controllers/platform.controller.js
@@ -8,9 +8,18 @@ const formulaPattern = /^[0-9+\-*/().\s_a-zA-Z]+$/
 
 const validateFields = fields => {
   if (!Array.isArray(fields)) return []
+  const fieldNames = new Set(fields.map(f => f.name))
   for (const f of fields) {
-    if (f.formula && !formulaPattern.test(f.formula)) {
-      throw new Error('INVALID_FORMULA')
+    if (f.formula) {
+      if (!formulaPattern.test(f.formula)) {
+        throw new Error('INVALID_FORMULA')
+      }
+      const vars = f.formula.match(/[a-zA-Z_][a-zA-Z0-9_]*/g) || []
+      for (const v of vars) {
+        if (!fieldNames.has(v)) {
+          throw new Error('INVALID_FORMULA')
+        }
+      }
     }
   }
   return fields

--- a/server/tests/platform.test.js
+++ b/server/tests/platform.test.js
@@ -144,6 +144,37 @@ describe('Platform API', () => {
     expect(res.body.message).toBe(t('INVALID_FORMULA'))
   })
 
+  it('validates field references in formula', async () => {
+    const resBad = await request(app)
+      .post(`/api/clients/${clientId}/platforms`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'BadRef',
+        fields: [
+          { name: 'a', type: 'number' },
+          { name: 'b', type: 'formula', formula: 'a + c' }
+        ]
+      })
+      .expect(400)
+    expect(resBad.body.message).toBe(t('INVALID_FORMULA'))
+
+    const resGood = await request(app)
+      .post(`/api/clients/${clientId}/platforms`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'GoodRef',
+        fields: [
+          { name: 'a', type: 'number' },
+          { name: 'b', type: 'formula', formula: 'a + 1' }
+        ]
+      })
+      .expect(201)
+    expect(resGood.body.fields).toEqual([
+      { name: 'a', type: 'number' },
+      { name: 'b', type: 'formula', formula: 'a + 1' }
+    ])
+  })
+
   it('transfer platform to another client', async () => {
     const resNewClient = await request(app)
       .post('/api/clients')


### PR DESCRIPTION
## Summary
- validate that formula variables exist in platform fields
- add tests for formula field references

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4b3178f48329a6cedacd67d41e8f