### PR TITLE
fix: preserve file extension for asset and product downloads

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -471,6 +471,14 @@ const formatDate = d => d ? new Date(d).toLocaleDateString('zh-TW', {
 const isImage = item => item && item.name && /\.(png|jpe?g|gif|webp|svg)$/i.test(item.name)
 const isVideo = item => item && item.name && /\.(mp4|webm|ogg|avi|mov)$/i.test(item.name)
 
+const getDownloadName = (item) => {
+  const title = item?.title || ''
+  if (title && /\.[^\\/]+$/.test(title)) {
+    return title
+  }
+  return item?.filename || title
+}
+
 const getItemIcon = (item) => {
   if (item.type === 'folder') return 'pi pi-folder'
   if (isImage(item)) return 'pi pi-image'
@@ -588,7 +596,7 @@ async function downloadSingleItem(item) {
     if (isVideo(item)) {
       const link = document.createElement('a');
       link.href = url;
-      link.setAttribute('download', item.name);
+      link.setAttribute('download', getDownloadName(item));
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -284,7 +284,16 @@ export const getAssetSignedUrl = async (req, res) => {
 
   const options = {}
   if (req.query.download === '1') {
-    const name = encodeURIComponent(asset.title || asset.filename)
+    let filename = asset.title || asset.filename
+    if (!path.extname(asset.title || '')) {
+      const ext = path.extname(asset.filename || '')
+      if (asset.title && ext) {
+        filename = asset.title + ext
+      } else {
+        filename = asset.filename || asset.title
+      }
+    }
+    const name = encodeURIComponent(filename)
     options.responseDisposition = `attachment; filename="${name}"`
   }
 

--- a/server/src/controllers/product.controller.js
+++ b/server/src/controllers/product.controller.js
@@ -70,7 +70,16 @@ export const getProductSignedUrl = async (req, res) => {
 
   const options = {};
   if (req.query.download === '1') {
-    const name = encodeURIComponent(product.title || product.filename);
+    let filename = product.title || product.filename;
+    if (!path.extname(product.title || '')) {
+      const ext = path.extname(product.filename || '');
+      if (product.title && ext) {
+        filename = product.title + ext;
+      } else {
+        filename = product.filename || product.title;
+      }
+    }
+    const name = encodeURIComponent(filename);
     options.responseDisposition = `attachment; filename="${name}"`;
   }
 


### PR DESCRIPTION
## Summary
- ensure asset signed URL uses filename with extension when title lacks one
- ensure product signed URL uses filename with extension when title lacks one
- adjust AssetLibrary download helper to fall back to filename when title has no extension

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac062a724c83299f1ef3643c1b9b7a