### PR TITLE
移除素材與成品庫空資料夾中的上傳按鈕

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -154,15 +154,9 @@
           <h3 class="empty-title">此資料夾為空</h3>
           <p class="empty-description">開始上傳素材或建立新資料夾來組織您的內容</p>
           <div class="empty-actions">
-            <Button 
-              icon="pi pi-upload" 
-              label="上傳素材" 
-              class="action-btn primary"
-              @click="triggerUpload"
-            />
-            <Button 
-              icon="pi pi-plus" 
-              label="建立資料夾" 
+            <Button
+              icon="pi pi-plus"
+              label="建立資料夾"
               class="action-btn secondary"
               @click="focusFolderInput"
             />

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -162,15 +162,9 @@
           <h3 class="empty-title">此資料夾為空</h3>
           <p class="empty-description">開始上傳成品或建立新資料夾來組織您的內容</p>
           <div class="empty-actions">
-            <Button 
-              icon="pi pi-upload" 
-              label="上傳成品" 
-              class="action-btn primary"
-              @click="triggerUpload"
-            />
-            <Button 
-              icon="pi pi-plus" 
-              label="建立資料夾" 
+            <Button
+              icon="pi pi-plus"
+              label="建立資料夾"
               class="action-btn secondary"
               @click="focusFolderInput"
             />


### PR DESCRIPTION
## 摘要
- 移除素材庫空資料夾視圖中的上傳按鈕，僅保留建立資料夾功能
- 移除成品庫空資料夾視圖中的上傳按鈕，保留建立資料夾選項

## 測試
- `npm test` *(失敗：缺少 jest 模組)*
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac08b3082c832996c8b9911779941f