### PR TITLE
隱藏素材與成品庫上傳元件的內建按鈕

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -752,12 +752,8 @@ watch(filterTags, () => loadData(currentFolder.value?._id), { deep: true })
 </script>
 
 <style scoped>
-.hidden-file-upload {
-  opacity: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
-  left: -9999px;
+:deep(.hidden-file-upload) {
+  display: none;
 }
 
 .library-container {

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -876,12 +876,8 @@ watch(sortOrder, () => loadData(currentFolder.value?._id))
 </script>
 
 <style scoped>
-.hidden-file-upload {
-  opacity: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
-  left: -9999px;
+:deep(.hidden-file-upload) {
+  display: none;
 }
 
 .library-container {


### PR DESCRIPTION
## Summary
- 以 `:deep(.hidden-file-upload)` 隱藏 AssetLibrary 與 ProductLibrary 中的 FileUpload 內建選擇按鈕

## Testing
- `npm test`（缺少 jest 無法執行）
- `npm --prefix server install`（403 Forbidden 無法安裝依賴）

------
https://chatgpt.com/codex/tasks/task_e_68ac0bfb75088329a3753aabf12d671a