### PR TITLE
feat: add department API and client integration

### DIFF
--- a/client/src/services/departments.js
+++ b/client/src/services/departments.js
@@ -1,0 +1,7 @@
+import api from './api'
+
+export const fetchDepartments = () =>
+  api.get('/departments').then(r => r.data)
+
+export const fetchSubDepartments = department =>
+  api.get('/departments/sub-departments', { params: { department } }).then(r => r.data)

--- a/client/src/views/EmployeeManager.vue
+++ b/client/src/views/EmployeeManager.vue
@@ -62,6 +62,7 @@ import { useToast } from 'primevue/usetoast'
 import { useConfirm } from 'primevue/useconfirm'
 import { fetchUsers, createUser, updateUser, deleteUser } from '../services/user'
 import { fetchRoles } from '../services/roles'
+import { fetchDepartments, fetchSubDepartments } from '../services/departments'
 import { useAuthStore } from '../stores/auth'
 
 // PrimeVue Components
@@ -86,6 +87,8 @@ if (!authStore.hasPermission('user:manage')) {
 const loading = ref(true)
 const users = ref([])
 const roleOptions = ref([])
+const departments = ref([])
+const subDepartments = ref([])
 const dialog = ref(false)
 const editing = ref(false)
 const form = ref({})
@@ -112,6 +115,17 @@ const loadRoles = async () => {
     roleOptions.value = roles.map(r => ({ label: r.name, value: r.name }))
   } catch (error) {
     toast.add({ severity: 'error', summary: 'Error', detail: 'Failed to load roles', life: 3000 })
+  }
+}
+
+const loadDepartments = async () => {
+  try {
+    departments.value = await fetchDepartments()
+    if (departments.value.length) {
+      subDepartments.value = await fetchSubDepartments(departments.value[0])
+    }
+  } catch (error) {
+    toast.add({ severity: 'error', summary: 'Error', detail: 'Failed to load departments', life: 3000 })
   }
 }
 
@@ -169,5 +183,6 @@ const confirmDeleteUser = (user) => {
 onMounted(() => {
   loadUsers()
   loadRoles()
+  loadDepartments()
 })
 </script>

--- a/server/src/controllers/department.controller.js
+++ b/server/src/controllers/department.controller.js
@@ -1,0 +1,18 @@
+import Department from '../models/department.model.js'
+
+export const getDepartments = async (_req, res) => {
+  const departments = await Department.find().select('name -_id')
+  res.json(departments.map(d => d.name))
+}
+
+export const getSubDepartments = async (req, res) => {
+  const { department } = req.query
+  if (!department) {
+    return res.status(400).json({ message: 'Department query required' })
+  }
+  const dept = await Department.findOne({ name: department })
+  if (!dept) {
+    return res.status(404).json({ message: 'Department not found' })
+  }
+  res.json(dept.subDepartments || [])
+}

--- a/server/src/models/department.model.js
+++ b/server/src/models/department.model.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose'
+
+const departmentSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, unique: true },
+    subDepartments: [{ type: String }]
+  },
+  { timestamps: true }
+)
+
+export default mongoose.model('Department', departmentSchema)

--- a/server/src/routes/department.routes.js
+++ b/server/src/routes/department.routes.js
@@ -1,0 +1,16 @@
+import { Router } from 'express'
+import { protect } from '../middleware/auth.js'
+import { requirePerm } from '../middleware/permission.js'
+import { PERMISSIONS } from '../config/permissions.js'
+import { getDepartments, getSubDepartments } from '../controllers/department.controller.js'
+import asyncHandler from '../utils/asyncHandler.js'
+
+const router = Router()
+
+router.use(protect)
+router.use(requirePerm(PERMISSIONS.USER_MANAGE))
+
+router.get('/', asyncHandler(getDepartments))
+router.get('/sub-departments', asyncHandler(getSubDepartments))
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -86,6 +86,7 @@ import platformTransferRoutes from './routes/platformTransfer.routes.js'
 import adDailyRoutes      from './routes/adDaily.routes.js'
 import weeklyNoteRoutes   from './routes/weeklyNote.routes.js'
 import dashboardRoutes    from './routes/dashboard.routes.js'
+import departmentRoutes   from './routes/department.routes.js'
 
 app.use('/api/auth',     authRoutes)
 app.use('/api/user',     userRoutes)
@@ -94,6 +95,7 @@ app.use('/api/products', productRoutes)
 app.use('/api/folders',  folderRoutes)
 app.use('/api/roles',    roleRoutes)
 app.use('/api/tags',     tagRoutes)
+app.use('/api/departments', departmentRoutes)
 app.use('/api/clients',  clientRoutes)
 app.use('/api/clients/:clientId/platforms', platformRoutes)
 app.use('/api/platforms', platformTransferRoutes)


### PR DESCRIPTION
## Summary
- add Department model, controller and routes with auth and permission checks
- expose Department APIs in server and hook up to frontend service
- load department data in EmployeeManager view

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1f44777c8329a1c46dd4eaec03bf