### PR TITLE
feat: 顯示客戶與平台麵包屑

### DIFF
--- a/client/src/services/clients.js
+++ b/client/src/services/clients.js
@@ -3,6 +3,9 @@ import api from './api'
 export const fetchClients = () =>
   api.get('/clients').then(r => r.data)
 
+export const getClient = id =>
+  api.get(`/clients/${id}`).then(r => r.data)
+
 export const createClient = data =>
   api.post('/clients', data).then(r => r.data)
 


### PR DESCRIPTION
## Summary
- 新增 getClient API 以取得客戶名稱
- 監聽路由取得 clientId 與 platformId，並在麵包屑顯示客戶與平台名稱

## Testing
- `npm test` *(fail: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b28011ae6c832996f2ffed07269647