### PR TITLE
feat: enable breadcrumb navigation for assets and products

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -513,7 +513,10 @@ function buildBreadcrumb(folder) {
   const items = []
   let current = folder
   while (current) {
-    items.unshift({ label: current.name, to: { name: 'Assets', params: { folderId: current._id } } })
+    items.unshift({
+      label: current.name,
+      to: `/assets/${current._id}`
+    })
     current = current.parent
   }
   breadcrumbItems.value = items

--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -626,7 +626,10 @@ function buildBreadcrumb(folder) {
   const items = []
   let current = folder
   while (current) {
-    items.unshift({ label: current.name, to: { name: 'Products', params: { folderId: current._id } } })
+    items.unshift({
+      label: current.name,
+      to: `/products/${current._id}`
+    })
     current = current.parent
   }
   breadcrumbItems.value = items


### PR DESCRIPTION
## Summary
- enable navigation in AssetLibrary breadcrumb by using `to: /assets/:id`
- enable navigation in ProductLibrary breadcrumb by using `to: /products/:id`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2800fdd7c83299d48f016ecca4ec9