### PR TITLE
擴充平台設定路由與麵包屑顯示

### DIFF
--- a/client/src/layouts/DashboardLayout.vue
+++ b/client/src/layouts/DashboardLayout.vue
@@ -163,6 +163,11 @@ const getBreadcrumb = () => {
       .filter(Boolean)
       .join(' / ')
   }
+  if (route.name === 'AdPlatforms') {
+    return [clientName.value, '平台設定']
+      .filter(Boolean)
+      .join(' / ')
+  }
   const path = route.path.substring(1)
   const segments = path.split('/')
   const menuKey = route.meta.menu || segments[0]
@@ -207,20 +212,24 @@ onUnmounted(() => {
 })
 
 const fetchNames = async () => {
-  if (route.name !== 'AdData') {
+  if (route.name !== 'AdData' && route.name !== 'AdPlatforms') {
     clientName.value = ''
     platformName.value = ''
     return
   }
+
   const { clientId, platformId } = route.params
   try {
     if (clientId) {
       const client = await getClient(clientId)
       clientName.value = client?.name
     }
-    if (clientId && platformId) {
+
+    if (route.name === 'AdData' && clientId && platformId) {
       const platform = await getPlatform(clientId, platformId)
       platformName.value = platform?.name
+    } else {
+      platformName.value = ''
     }
   } catch {
     clientName.value = ''

--- a/client/src/menuNames.js
+++ b/client/src/menuNames.js
@@ -8,5 +8,6 @@ export const MENU_NAMES = {
   tags: '标签管理',
   'review-stages': '审查关卡',
   'ad-data': '广告数据',
+  'ad-platforms': '平台設定',
   account: '帐号资讯'
 }

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -43,7 +43,7 @@ const routes = [
       { path: 'tags', name: 'TagManager', component: TagManager, meta: { menu: 'tags' } },
       { path: 'review-settings', name: 'ReviewSettings', component: ReviewSettings, meta: { menu: 'review-stages' } },
       { path: 'ad-clients', name: 'AdClients', component: AdClients, meta: { menu: 'ad-data' } },
-      { path: 'clients/:clientId/platforms', name: 'AdPlatforms', component: AdPlatforms },
+      { path: 'clients/:clientId/platforms', name: 'AdPlatforms', component: AdPlatforms, meta: { menu: 'ad-data' } },
       { path: 'clients/:clientId/platforms/:platformId/data', name: 'AdData', component: AdData }
     ]
   },


### PR DESCRIPTION
## 摘要
- AdPlatforms 路由新增 `menu: ad-data` meta
- DashboardLayout 新增平台設定麵包屑與名稱載入邏輯
- 補上 `ad-platforms` 菜單對應文字

## 測試
- `cd client && npm test`（缺少 test 腳本）
- `cd server && npm test`（缺少 jest，`npm install` 無法存取套件）

------
https://chatgpt.com/codex/tasks/task_e_68b2d69a9f2483299a25a74119312acc