### PR TITLE
fix: enable breadcrumb navigation in asset library

### DIFF
--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -483,7 +483,10 @@ const selectAll = computed({
   set: val => { selectedItems.value = val ? combinedItems.value.map(i => i.id) : [] }
 })
 
-const breadcrumbHome = ref({ icon: 'pi pi-home', to: '/assets' })
+const breadcrumbHome = ref({
+  icon: 'pi pi-home',
+  command: () => router.push({ name: 'Assets' })
+})
 const breadcrumbItems = ref([])
 
 const formatDate = d => d ? new Date(d).toLocaleDateString('zh-TW', { 
@@ -545,7 +548,7 @@ function buildBreadcrumb(folder) {
   while (current) {
     items.unshift({
       label: current.name,
-      to: `/assets/${current._id}`
+      command: () => router.push({ name: 'Assets', params: { folderId: current._id } })
     })
     current = current.parent
   }


### PR DESCRIPTION
## Summary
- enable breadcrumb home to navigate with router command
- build breadcrumb items using router push with params

## Testing
- `npm --prefix client test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2db61ce648329967478c1e5f98399