### PR TITLE
fix: enable breadcrumb navigation in product library

### DIFF
--- a/client/src/views/ProductLibrary.vue
+++ b/client/src/views/ProductLibrary.vue
@@ -546,7 +546,10 @@ const selectAll = computed({
   set: val => { selectedItems.value = val ? combinedItems.value.map(i => i.id) : [] }
 })
 
-const breadcrumbHome = ref({ icon: 'pi pi-home', to: '/products' })
+const breadcrumbHome = ref({
+  icon: 'pi pi-home',
+  command: () => router.push({ name: 'Products' })
+})
 const breadcrumbItems = ref([])
 
 const formatDate = d => d ? new Date(d).toLocaleDateString('zh-TW', { 
@@ -658,7 +661,7 @@ function buildBreadcrumb(folder) {
   while (current) {
     items.unshift({
       label: current.name,
-      to: `/products/${current._id}`
+      command: () => router.push({ name: 'Products', params: { folderId: current._id } })
     })
     current = current.parent
   }


### PR DESCRIPTION
## Summary
- refactor breadcrumb home to use router navigation command
- use router commands for breadcrumb items instead of URL strings

## Testing
- `npm --prefix client test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2db83cb1c8329a07abf7deccf42a5