### PR TITLE
feat: 平台欄位加入 slug 並以 slug 計算公式

### DIFF
--- a/client/src/utils/adData.js
+++ b/client/src/utils/adData.js
@@ -49,8 +49,8 @@ export const normalizeRows = (arr, customFields) => arr
       if (c.type === 'formula') return
       if (r[c.name] !== undefined) {
         const val = r[c.name]
-        if (c.type === 'number') extra[c.name] = Number(val) || 0
-        else extra[c.name] = val
+        if (c.type === 'number') extra[c.slug] = Number(val) || 0
+        else extra[c.slug] = val
       }
     })
     const ignore = new Set([
@@ -78,7 +78,7 @@ export const buildExportRows = (dailyData, customFields, dateFmt) =>
       點擊: r.clicks
     }
     customFields.forEach(c => {
-      const val = r.extraData?.[c.name]
+      const val = r.extraData?.[c.slug]
       obj[c.name] = c.type === 'date'
         ? (val ? dateFmt({ date: val }) : '')
         : (val ?? '')

--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -57,8 +57,8 @@ export const createAdDaily = async (req, res) => {
     const vars = { ...payload, ...payload.extraData }
     for (const f of formulas) {
       const val = evalFormula(f.formula, vars)
-      payload.extraData[f.name] = val
-      vars[f.name] = val
+      payload.extraData[f.slug] = val
+      vars[f.slug] = val
     }
   }
   const rec = await AdDaily.findOneAndUpdate(
@@ -168,8 +168,8 @@ export const bulkCreateAdDaily = async (req, res) => {
       const vars = { ...r, ...r.extraData }
       for (const f of formulas) {
         const val = evalFormula(f.formula, vars)
-        r.extraData[f.name] = val
-        vars[f.name] = val
+        r.extraData[f.slug] = val
+        vars[f.slug] = val
       }
     }
   }
@@ -252,8 +252,8 @@ export const importAdDaily = async (req, res) => {
       const vars = { ...r, ...r.extraData }
       for (const f of formulas) {
         const val = evalFormula(f.formula, vars)
-        r.extraData[f.name] = val
-        vars[f.name] = val
+        r.extraData[f.slug] = val
+        vars[f.slug] = val
       }
     }
   }
@@ -288,8 +288,8 @@ export const updateAdDaily = async (req, res) => {
     const vars = { ...payload, ...payload.extraData }
     for (const f of formulas) {
       const val = evalFormula(f.formula, vars)
-      payload.extraData[f.name] = val
-      vars[f.name] = val
+      payload.extraData[f.slug] = val
+      vars[f.slug] = val
     }
   }
 

--- a/server/src/controllers/platform.controller.js
+++ b/server/src/controllers/platform.controller.js
@@ -5,10 +5,17 @@ import WeeklyNote from '../models/weeklyNote.model.js'
 import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
 
 const formulaPattern = /^[0-9+\-*/().\s_a-zA-Z]+$/
+const slugPattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/
 
 const validateFields = fields => {
   if (!Array.isArray(fields)) return []
-  const fieldNames = new Set(fields.map(f => f.name))
+  const slugs = new Set()
+  for (const f of fields) {
+    if (!f.slug || !slugPattern.test(f.slug) || slugs.has(f.slug)) {
+      throw new Error('INVALID_FORMULA')
+    }
+    slugs.add(f.slug)
+  }
   for (const f of fields) {
     if (f.formula) {
       if (!formulaPattern.test(f.formula)) {
@@ -16,7 +23,7 @@ const validateFields = fields => {
       }
       const vars = f.formula.match(/[a-zA-Z_][a-zA-Z0-9_]*/g) || []
       for (const v of vars) {
-        if (!fieldNames.has(v)) {
+        if (!slugs.has(v)) {
           throw new Error('INVALID_FORMULA')
         }
       }

--- a/server/src/models/platform.model.js
+++ b/server/src/models/platform.model.js
@@ -12,6 +12,7 @@ const platformSchema = new mongoose.Schema(
         new mongoose.Schema(
           {
             name: { type: String, required: true },
+            slug: { type: String, required: true },
             type: { type: String, default: 'text' },
             order: { type: Number, default: 0 },
             formula: { type: String, default: '' }

--- a/server/tests/adDataUtils.test.js
+++ b/server/tests/adDataUtils.test.js
@@ -3,10 +3,10 @@ import dayjs from 'dayjs'
 
 describe('adData helpers', () => {
   const fields = [
-    { name: 'foo', type: 'number' },
-    { name: 'bar', type: 'text' },
-    { name: 'baz', type: 'date' },
-    { name: 'calc', type: 'formula', formula: 'foo * 2' }
+    { name: 'foo', slug: 'foo', type: 'number' },
+    { name: 'bar', slug: 'bar', type: 'text' },
+    { name: 'baz', slug: 'baz', type: 'date' },
+    { name: 'calc', slug: 'calc', type: 'formula', formula: 'foo * 2' }
   ]
 
   test('excel spec and template order', () => {
@@ -27,7 +27,7 @@ describe('adData helpers', () => {
     const rows = normalizeRows([
       { date:'2025-06-02', foo:'A', bar:'B', baz:'2025-06-01', calc:5, spent:100 }
     ], fields)
-    expect(Object.keys(rows[0].extraData)).toEqual(fields.filter(f => f.type !== 'formula').map(f => f.name))
+    expect(Object.keys(rows[0].extraData)).toEqual(fields.filter(f => f.type !== 'formula').map(f => f.slug))
   })
 
   test('export rows follow field order', () => {

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -69,9 +69,9 @@ describe('Client and AdDaily', () => {
       .send({
         name: 'Calc',
         fields: [
-          { name: 'a', type: 'number' },
-          { name: 'b', type: 'number' },
-          { name: 'c', type: 'formula', formula: 'a + b' }
+          { name: 'a', slug: 'a', type: 'number' },
+          { name: 'b', slug: 'b', type: 'number' },
+          { name: 'c', slug: 'c', type: 'formula', formula: 'a + b' }
         ]
       })
       .expect(201)

--- a/server/tests/platform.test.js
+++ b/server/tests/platform.test.js
@@ -20,12 +20,12 @@ let token
 let clientId
 let platformId
 const defaultFields = [
-  { name: 'date',        type: 'text' },
-  { name: 'spent',       type: 'number' },
-  { name: 'enquiries',   type: 'number' },
-  { name: 'reach',       type: 'number' },
-  { name: 'impressions', type: 'number' },
-  { name: 'clicks',      type: 'number' }
+  { name: 'date', slug: 'date', type: 'text' },
+  { name: 'spent', slug: 'spent', type: 'number' },
+  { name: 'enquiries', slug: 'enquiries', type: 'number' },
+  { name: 'reach', slug: 'reach', type: 'number' },
+  { name: 'impressions', slug: 'impressions', type: 'number' },
+  { name: 'clicks', slug: 'clicks', type: 'number' }
 ]
 
 beforeAll(async () => {
@@ -67,12 +67,12 @@ describe('Platform API', () => {
       .send({
         name: 'Meta',
         platformType: 'Meta',
-        fields: [{ name: 'note', type: 'text' }],
+        fields: [{ name: 'note', slug: 'note', type: 'text' }],
         mode: 'custom'
       })
       .expect(201)
     platformId = resC.body._id
-    expect(resC.body.fields).toEqual([{ name: 'note', type: 'text' }])
+    expect(resC.body.fields).toEqual([{ name: 'note', slug: 'note', type: 'text' }])
 
     const resG = await request(app)
       .get(`/api/clients/${clientId}/platforms`)
@@ -86,14 +86,14 @@ describe('Platform API', () => {
       .send({
         name: 'Meta2',
         fields: [
-          { name: 'x', type: 'number' },
-          { name: 'y', type: 'text' }
+          { name: 'x', slug: 'x', type: 'number' },
+          { name: 'y', slug: 'y', type: 'text' }
         ]
       })
       .expect(200)
     expect(resU.body.fields).toEqual([
-      { name: 'x', type: 'number' },
-      { name: 'y', type: 'text' }
+      { name: 'x', slug: 'x', type: 'number' },
+      { name: 'y', slug: 'y', type: 'text' }
     ])
 
     await request(app)
@@ -138,7 +138,7 @@ describe('Platform API', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({
         name: 'BadFormula',
-        fields: [{ name: 'f1', type: 'formula', formula: 'process.exit()' }]
+        fields: [{ name: 'f1', slug: 'f1', type: 'formula', formula: 'process.exit()' }]
       })
       .expect(400)
     expect(res.body.message).toBe(t('INVALID_FORMULA'))
@@ -151,8 +151,8 @@ describe('Platform API', () => {
       .send({
         name: 'BadRef',
         fields: [
-          { name: 'a', type: 'number' },
-          { name: 'b', type: 'formula', formula: 'a + c' }
+          { name: 'a', slug: 'a', type: 'number' },
+          { name: 'b', slug: 'b', type: 'formula', formula: 'a + c' }
         ]
       })
       .expect(400)


### PR DESCRIPTION
## Summary
- 後端平台模型新增 slug 欄位並以 slug 驗證公式
- 廣告日誌與前端改用 slug 存取與計算欄位，支援 slug 介面
- Excel 匯入匯出、測試檔更新對應 slug

## Testing
- `npm --prefix server test` *(失敗：jest: not found)*
- `npm --prefix server install` *(失敗：403 Forbidden)*
- `npm run lint` *(失敗：Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c144184e248329a985ba2a04ffc367