### PR TITLE
feat: 廣告欄位改用識別碼並新增遷移腳本

### DIFF
--- a/client/src/utils/adData.js
+++ b/client/src/utils/adData.js
@@ -49,8 +49,8 @@ export const normalizeRows = (arr, customFields) => arr
       if (c.type === 'formula') return
       if (r[c.name] !== undefined) {
         const val = r[c.name]
-        if (c.type === 'number') extra[c.slug] = Number(val) || 0
-        else extra[c.slug] = val
+        if (c.type === 'number') extra[c.id] = Number(val) || 0
+        else extra[c.id] = val
       }
     })
     const ignore = new Set([
@@ -78,7 +78,7 @@ export const buildExportRows = (dailyData, customFields, dateFmt) =>
       點擊: r.clicks
     }
     customFields.forEach(c => {
-      const val = r.extraData?.[c.slug]
+      const val = r.extraData?.[c.id]
       obj[c.name] = c.type === 'date'
         ? (val ? dateFmt({ date: val }) : '')
         : (val ?? '')

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
     "start": "node src/server.js",
     "test": "jest --experimental-vm-modules",
     "seed": "node src/scripts/seedUsers.js",
-    "sanitize-ad-daily": "node src/scripts/sanitizeAdDaily.js"
+    "sanitize-ad-daily": "node src/scripts/sanitizeAdDaily.js",
+    "migrate-extra-data": "node src/scripts/migrateExtraDataFieldId.js"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.16.0",

--- a/server/src/models/platform.model.js
+++ b/server/src/models/platform.model.js
@@ -11,6 +11,11 @@ const platformSchema = new mongoose.Schema(
       type: [
         new mongoose.Schema(
           {
+            id: {
+              type: String,
+              required: true,
+              default: () => new mongoose.Types.ObjectId().toString()
+            },
             name: { type: String, required: true },
             slug: { type: String, required: true },
             type: { type: String, default: 'text' },

--- a/server/src/scripts/migrateExtraDataFieldId.js
+++ b/server/src/scripts/migrateExtraDataFieldId.js
@@ -1,0 +1,64 @@
+import dotenv from 'dotenv'
+import mongoose from 'mongoose'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Platform from '../models/platform.model.js'
+import AdDaily from '../models/adDaily.model.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+
+const run = async () => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI)
+    console.log('✅ MongoDB 已連線')
+
+    const platforms = await Platform.find()
+    for (const p of platforms) {
+      const nameToId = {}
+      const slugToId = {}
+      let platformUpdated = false
+      p.fields.forEach(f => {
+        if (!f.id) {
+          f.id = new mongoose.Types.ObjectId().toString()
+          platformUpdated = true
+        }
+        nameToId[f.name] = f.id
+        slugToId[f.slug] = f.id
+      })
+      if (platformUpdated) {
+        await p.save()
+        console.log(`平台 ${p.name} 已補齊欄位 id`)
+      }
+
+      const cursor = AdDaily.find({ platformId: p._id }).cursor()
+      for await (const doc of cursor) {
+        let changed = false
+        const extra = {}
+        for (const [k, v] of Object.entries(doc.extraData || {})) {
+          const fid = nameToId[k] || slugToId[k] || k
+          extra[fid] = v
+          if (fid !== k) changed = true
+        }
+        const colors = {}
+        for (const [k, v] of Object.entries(doc.colors || {})) {
+          const fid = nameToId[k] || slugToId[k] || k
+          colors[fid] = v
+          if (fid !== k) changed = true
+        }
+        if (changed) {
+          doc.extraData = extra
+          doc.colors = colors
+          await doc.save()
+        }
+      }
+    }
+    console.log('🍺 轉換完成')
+  } catch (err) {
+    console.error('❌ 轉換失敗：', err.message)
+  } finally {
+    await mongoose.disconnect()
+  }
+}
+
+run()

--- a/server/tests/adDataUtils.test.js
+++ b/server/tests/adDataUtils.test.js
@@ -3,10 +3,10 @@ import dayjs from 'dayjs'
 
 describe('adData helpers', () => {
   const fields = [
-    { name: 'foo', slug: 'foo', type: 'number' },
-    { name: 'bar', slug: 'bar', type: 'text' },
-    { name: 'baz', slug: 'baz', type: 'date' },
-    { name: 'calc', slug: 'calc', type: 'formula', formula: 'foo * 2' }
+    { id: 'foo', name: 'foo', slug: 'foo', type: 'number' },
+    { id: 'bar', name: 'bar', slug: 'bar', type: 'text' },
+    { id: 'baz', name: 'baz', slug: 'baz', type: 'date' },
+    { id: 'calc', name: 'calc', slug: 'calc', type: 'formula', formula: 'foo * 2' }
   ]
 
   test('excel spec and template order', () => {
@@ -27,7 +27,7 @@ describe('adData helpers', () => {
     const rows = normalizeRows([
       { date:'2025-06-02', foo:'A', bar:'B', baz:'2025-06-01', calc:5, spent:100 }
     ], fields)
-    expect(Object.keys(rows[0].extraData)).toEqual(fields.filter(f => f.type !== 'formula').map(f => f.slug))
+    expect(Object.keys(rows[0].extraData)).toEqual(fields.filter(f => f.type !== 'formula').map(f => f.id))
   })
 
   test('export rows follow field order', () => {

--- a/server/tests/clientAdDaily.test.js
+++ b/server/tests/clientAdDaily.test.js
@@ -19,6 +19,9 @@ let token
 let clientId
 let platformId
 let formulaPlatformId
+let fieldAId
+let fieldBId
+let fieldCId
 
 beforeAll(async () => {
   mongo = await MongoMemoryServer.create()
@@ -76,6 +79,7 @@ describe('Client and AdDaily', () => {
       })
       .expect(201)
     formulaPlatformId = res.body._id
+    ;[fieldAId, fieldBId, fieldCId] = res.body.fields.map(f => f.id)
   })
 
   it('weekly aggregate', async () => {
@@ -197,21 +201,21 @@ describe('Client and AdDaily', () => {
     const res = await request(app)
       .post(`/api/clients/${clientId}/platforms/${formulaPlatformId}/ad-daily`)
       .set('Authorization', `Bearer ${token}`)
-      .send({ date, extraData: { a: 2, b: 3 } })
+      .send({ date, extraData: { [fieldAId]: 2, [fieldBId]: 3 } })
       .expect(201)
-    expect(res.body.extraData).toEqual({ a: 2, b: 3, c: 5 })
+    expect(res.body.extraData).toEqual({ [fieldAId]: 2, [fieldBId]: 3, [fieldCId]: 5 })
 
     const rows = [
-      { date: new Date('2024-07-02').toISOString(), extraData: { a: 1, b: 2 } },
-      { date: new Date('2024-07-03').toISOString(), extraData: { a: 3, b: 4 } }
+      { date: new Date('2024-07-02').toISOString(), extraData: { [fieldAId]: 1, [fieldBId]: 2 } },
+      { date: new Date('2024-07-03').toISOString(), extraData: { [fieldAId]: 3, [fieldBId]: 4 } }
     ]
     const bulk = await request(app)
       .post(`/api/clients/${clientId}/platforms/${formulaPlatformId}/ad-daily/bulk`)
       .set('Authorization', `Bearer ${token}`)
       .send(rows)
       .expect(201)
-    expect(bulk.body[0].extraData.c).toBe(3)
-    expect(bulk.body[1].extraData.c).toBe(7)
+    expect(bulk.body[0].extraData[fieldCId]).toBe(3)
+    expect(bulk.body[1].extraData[fieldCId]).toBe(7)
   })
 
   it('sort adDaily by spent desc', async () => {

--- a/server/tests/platform.test.js
+++ b/server/tests/platform.test.js
@@ -72,7 +72,8 @@ describe('Platform API', () => {
       })
       .expect(201)
     platformId = resC.body._id
-    expect(resC.body.fields).toEqual([{ name: 'note', slug: 'note', type: 'text' }])
+    expect(resC.body.fields[0]).toMatchObject({ name: 'note', slug: 'note', type: 'text' })
+    expect(resC.body.fields[0].id).toBeDefined()
 
     const resG = await request(app)
       .get(`/api/clients/${clientId}/platforms`)
@@ -91,10 +92,9 @@ describe('Platform API', () => {
         ]
       })
       .expect(200)
-    expect(resU.body.fields).toEqual([
-      { name: 'x', slug: 'x', type: 'number' },
-      { name: 'y', slug: 'y', type: 'text' }
-    ])
+    expect(resU.body.fields.length).toBe(2)
+    expect(resU.body.fields[0]).toMatchObject({ name: 'x', slug: 'x', type: 'number' })
+    expect(resU.body.fields[1]).toMatchObject({ name: 'y', slug: 'y', type: 'text' })
 
     await request(app)
       .delete(`/api/clients/${clientId}/platforms/${platformId}`)
@@ -114,7 +114,11 @@ describe('Platform API', () => {
       })
       .expect(201)
     expect(res.body.mode).toBe('default')
-    expect(res.body.fields).toEqual(defaultFields)
+    expect(res.body.fields.length).toBe(defaultFields.length)
+    res.body.fields.forEach((f, idx) => {
+      expect(f).toMatchObject(defaultFields[idx])
+      expect(f.id).toBeDefined()
+    })
   })
 
   it('duplicate platform name returns 409', async () => {
@@ -158,7 +162,7 @@ describe('Platform API', () => {
       .expect(400)
     expect(resBad.body.message).toBe(t('INVALID_FORMULA'))
 
-    const resGood = await request(app)
+  const resGood = await request(app)
       .post(`/api/clients/${clientId}/platforms`)
       .set('Authorization', `Bearer ${token}`)
       .send({
@@ -169,10 +173,9 @@ describe('Platform API', () => {
         ]
       })
       .expect(201)
-    expect(resGood.body.fields).toEqual([
-      { name: 'a', type: 'number' },
-      { name: 'b', type: 'formula', formula: 'a + 1' }
-    ])
+    expect(resGood.body.fields.length).toBe(2)
+    expect(resGood.body.fields[0]).toMatchObject({ name: 'a', type: 'number' })
+    expect(resGood.body.fields[1]).toMatchObject({ name: 'b', type: 'formula', formula: 'a + 1' })
   })
 
   it('transfer platform to another client', async () => {


### PR DESCRIPTION
## Summary
- 平台欄位加入 id 並於伺服器端自動補齊
- 廣告每日資料改以 fieldId 儲存，前端對應顯示名稱
- 新增資料遷移腳本轉換既有欄位鍵值

## Testing
- `npm test` *(failed: jest: not found)*
- `npm run lint` *(failed: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68c1473d6fd483298fdbfba4f8ffb2ac