### PR TITLE
feat: 新增平台欄位改名 API

### DIFF
--- a/server/src/routes/platform.routes.js
+++ b/server/src/routes/platform.routes.js
@@ -5,7 +5,8 @@ import {
   getPlatforms,
   getPlatform,
   updatePlatform,
-  deletePlatform
+  deletePlatform,
+  renamePlatformField
 } from '../controllers/platform.controller.js'
 
 import asyncHandler from '../utils/asyncHandler.js'
@@ -22,5 +23,7 @@ router.route('/:id')
   .get(asyncHandler(getPlatform))
   .put(asyncHandler(updatePlatform))
   .delete(asyncHandler(deletePlatform))
+
+router.put('/:id/rename-field', asyncHandler(renamePlatformField))
 
 export default router

--- a/server/tests/platformFieldRename.test.js
+++ b/server/tests/platformFieldRename.test.js
@@ -1,0 +1,88 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import authRoutes from '../src/routes/auth.routes.js'
+import clientRoutes from '../src/routes/client.routes.js'
+import platformRoutes from '../src/routes/platform.routes.js'
+import adDailyRoutes from '../src/routes/adDaily.routes.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+let clientId
+let platformId
+const date = new Date('2024-01-01').toISOString()
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/clients', clientRoutes)
+  app.use('/api/clients/:clientId/platforms', platformRoutes)
+  app.use('/api/clients/:clientId/platforms/:platformId/ad-daily', adDailyRoutes)
+
+  const role = await Role.create({ name: 'manager' })
+  await User.create({ username: 'admin', password: 'pwd', email: 'test@test', roleId: role._id })
+  const res = await request(app).post('/api/auth/login').send({ username: 'admin', password: 'pwd' })
+  token = res.body.token
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+describe('rename platform field', () => {
+  it('rename field and update adDaily extraData', async () => {
+    const clientRes = await request(app)
+      .post('/api/clients')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'ClientA' })
+      .expect(201)
+    clientId = clientRes.body._id
+
+    const platformRes = await request(app)
+      .post(`/api/clients/${clientId}/platforms`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Meta',
+        fields: [{ id: 'old', name: 'Old', slug: 'old', type: 'number' }]
+      })
+      .expect(201)
+    platformId = platformRes.body._id
+
+    await request(app)
+      .post(`/api/clients/${clientId}/platforms/${platformId}/ad-daily`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ date, extraData: { old: 5 } })
+      .expect(201)
+
+    await request(app)
+      .put(`/api/clients/${clientId}/platforms/${platformId}/rename-field`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ id: 'old', name: 'New', slug: 'new' })
+      .expect(200)
+
+    const list = await request(app)
+      .get(`/api/clients/${clientId}/platforms/${platformId}/ad-daily?start=${date}&end=${date}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(list.body[0].extraData).toEqual({ new: 5 })
+
+    const platform = await request(app)
+      .get(`/api/clients/${clientId}/platforms/${platformId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(platform.body.fields[0]).toMatchObject({ id: 'new', name: 'New', slug: 'new' })
+  })
+})


### PR DESCRIPTION
## Summary
- 新增 renamePlatformField 介面，支援欄位名稱與 slug 改名並同步 AdDaily
- 路由加入 /rename-field 端點
- 測試：驗證欄位改名後仍可取得舊資料

## Testing
- `npm test` *(失敗: jest: not found)*
- `npm run lint` *(失敗: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68c15119e18083299c3d95d71830f958