### PR TITLE
修正欄位改名時同步更新色票

### DIFF
--- a/server/src/controllers/platform.controller.js
+++ b/server/src/controllers/platform.controller.js
@@ -148,6 +148,17 @@ export const renamePlatformField = async (req, res) => {
   }
 
   await platform.save()
+  if (oldSlug !== slug) {
+    await AdDaily.updateMany(
+      { platformId: req.params.id },
+      {
+        $rename: {
+          [`extraData.${oldSlug}`]: `extraData.${slug}`,
+          [`colors.${oldSlug}`]: `colors.${slug}`
+        }
+      }
+    )
+  }
   await clearCacheByPrefix('platforms:')
   await delCache(`platform:${req.params.id}`)
   res.json(platform)

--- a/server/tests/platformFieldRename.test.js
+++ b/server/tests/platformFieldRename.test.js
@@ -77,8 +77,8 @@ describe('rename platform field', () => {
       .get(`/api/clients/${clientId}/platforms/${platformId}/ad-daily?start=${date}&end=${date}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200)
-    expect(list.body[0].extraData).toEqual({ old: 5 })
-    expect(list.body[0].colors).toEqual({ old: '#fff' })
+    expect(list.body[0].extraData).toEqual({ new: 5 })
+    expect(list.body[0].colors).toEqual({ new: '#fff' })
 
     const platform = await request(app)
       .get(`/api/clients/${clientId}/platforms/${platformId}`)


### PR DESCRIPTION
## 摘要
- 改名平台欄位時同步更新 AdDaily 的 `extraData` 與 `colors`
- 調整欄位改名測試以驗證色票仍可讀取

## 測試
- `npm test` *(失敗: jest: not found)*
- `npm run lint` *(失敗: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c171df851083299f06e28b1ce1c405