### PR TITLE
修正每日記錄載入錯誤處理與 loading 重置

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -522,14 +522,27 @@ const loadPlatform = async () => {
 }
 
 const loadDaily = async () => {
+  loading.value = true
   const params = {}
   if (sortField.value) {
     params.sort = sortField.value
     params.order = sortOrder.value === 1 ? 'asc' : 'desc'
   }
-  const list = await fetchDaily(clientId, platformId, params)
-
-  dailyData.value = list
+  try {
+    const list = await fetchDaily(clientId, platformId, params)
+    let data = []
+    if (Array.isArray(list)) {
+      data = list
+    } else if (Array.isArray(list?.data)) {
+      data = list.data
+    }
+    dailyData.value = data
+  } catch (err) {
+    dailyData.value = []
+    toast.add({ severity: 'error', summary: '錯誤', detail: err.message || '取得每日資料失敗', life: 3000 })
+  } finally {
+    loading.value = false
+  }
 }
 
 const loadWeeklyNotes = async () => {


### PR DESCRIPTION
## Summary
- 新增每日記錄載入的錯誤處理並於成功時解析資料
- 請求結束後重置 `loading` 以恢復畫面

## Testing
- `npm test` (失敗：jest: not found)
- `npm --prefix server install` (失敗：403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c187cb56b88329833401e40b193462