### PR TITLE
在 loadDaily 錯誤時加入提示與錯誤紀錄

### DIFF
--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -539,6 +539,7 @@ const loadDaily = async () => {
     dailyData.value = data
   } catch (err) {
     dailyData.value = []
+    console.error('取得每日資料失敗', err)
     toast.add({ severity: 'error', summary: '錯誤', detail: err.message || '取得每日資料失敗', life: 3000 })
   } finally {
     loading.value = false


### PR DESCRIPTION
## 摘要
- 在 `loadDaily` 失敗時使用 `console.error` 紀錄詳細錯誤
- 保留既有的 `toast.add` 提示讓使用者知道資料載入失敗

## 測試
- `npm test`（失敗：`jest: not found`）

------
https://chatgpt.com/codex/tasks/task_e_68c19528aa848329aba481ce1937fb30