### PR TITLE
修正每日資料載入並補齊測試

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.9.0",
@@ -28,6 +29,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@vue/test-utils": "^2.4.4",
+    "vitest": "^1.6.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/client/src/views/AdData.test.js
+++ b/client/src/views/AdData.test.js
@@ -1,0 +1,58 @@
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import AdData from './AdData.vue'
+
+vi.mock('@/services/adDaily', () => ({
+  fetchDaily: vi.fn(),
+  createDaily: vi.fn(),
+  bulkCreateDaily: vi.fn(),
+  updateDaily: vi.fn(),
+  deleteDaily: vi.fn()
+}))
+
+vi.mock('@/services/weeklyNotes', () => ({
+  fetchWeeklyNote: vi.fn(),
+  fetchWeeklyNotes: vi.fn(),
+  createWeeklyNote: vi.fn(),
+  updateWeeklyNote: vi.fn(),
+  getWeeklyNoteImageUrl: vi.fn()
+}))
+
+vi.mock('@/services/platforms', () => ({
+  getPlatform: vi.fn()
+}))
+
+describe('AdData.vue', () => {
+  it('渲染每日資料', async () => {
+    const sample = [
+      { date: '2024-01-01', extraData: { clicks: 10 } },
+      { date: '2024-01-02', extraData: { clicks: 20 } }
+    ]
+
+    const { fetchDaily } = await import('@/services/adDaily')
+    const { getPlatform } = await import('@/services/platforms')
+    const { fetchWeeklyNotes } = await import('@/services/weeklyNotes')
+
+    fetchDaily.mockResolvedValue({ records: sample })
+    getPlatform.mockResolvedValue({ fields: [] })
+    fetchWeeklyNotes.mockResolvedValue([])
+
+    const wrapper = shallowMount(AdData, {
+      global: {
+        stubs: {
+          DataTable: {
+            props: ['value'],
+            template: '<div><div v-for="item in value" class="row">{{ item.date }} {{ item.extraData.clicks }}</div></div>'
+          }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    const rows = wrapper.findAll('.row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text()).toContain('2024-01-01')
+    expect(rows[0].text()).toContain('10')
+  })
+})

--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -524,6 +524,8 @@ const loadPlatform = async () => {
 const loadDaily = async () => {
   loading.value = true
   const params = {}
+  if (startDate.value) params.startDate = startDate.value
+  if (endDate.value) params.endDate = endDate.value
   if (sortField.value) {
     params.sort = sortField.value
     params.order = sortOrder.value === 1 ? 'asc' : 'desc'
@@ -535,6 +537,11 @@ const loadDaily = async () => {
       data = list
     } else if (Array.isArray(list?.data)) {
       data = list.data
+    } else if (Array.isArray(list?.records)) {
+      data = list.records
+    } else if (list && typeof list === 'object') {
+      const firstArray = Object.values(list).find(Array.isArray)
+      data = firstArray || []
     }
     dailyData.value = data
   } catch (err) {
@@ -559,6 +566,8 @@ watch([sortField, sortOrder], () => {
   loadDaily()
 
 })
+
+watch([startDate, endDate], loadDaily)
 
 /**** --------------------------------------------------- 折線圖繪製 --------------------------------------------------- ****/
 const drawChart = () => {

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -17,5 +17,8 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src')   // ★ 加這行
     }
+  },
+  test: {
+    environment: 'jsdom'
   }
 })


### PR DESCRIPTION
## 摘要
- 載入每日資料時加入日期範圍與多種回傳格式解析
- 監聽日期變更自動重新載入資料
- 新增每日資料渲染測試並配置前端測試環境

## 測試
- `npm test`（失敗：vitest: not found）
- `npm test`（root，失敗：jest: not found）

------
https://chatgpt.com/codex/tasks/task_e_68c1baaf6f948329b419be2c83474a82