### PR TITLE
完善資料遷移腳本並補充執行說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,16 @@ GCS_CORS_ORIGIN=http://localhost:5173
 參數取得下載專用的 URL。
 所有受保護的路由都會檢查使用者是否具有對應權限，
 缺乏權限時伺服器將回傳 `403` 並顯示 `權限不足`。
-3. 執行測試前請先在 `server` 目錄安裝相依套件：
+3. 升級或部署前請先執行資料遷移：
+   \`\`\`bash
+   node server/src/scripts/migrateExtraDataFieldId.js
+   \`\`\`
+   轉換將補齊各平台欄位 ID，並把 `AdDaily` 的 `extraData`、`colors` 鍵改為欄位 ID。
+4. 執行測試前請先在 `server` 目錄安裝相依套件：
    \`\`\`bash
    npm install
    \`\`\`
-4. 進行登入測試：
+5. 進行登入測試：
    \`\`\`bash
    npm test
    \`\`\`

--- a/server/src/scripts/migrateExtraDataFieldId.js
+++ b/server/src/scripts/migrateExtraDataFieldId.js
@@ -36,20 +36,31 @@ const run = async () => {
         let changed = false
         const extra = {}
         for (const [k, v] of Object.entries(doc.extraData || {})) {
-          const fid = nameToId[k] || slugToId[k] || k
-          extra[fid] = v
-          if (fid !== k) changed = true
+          const fid = nameToId[k] || slugToId[k]
+          if (fid) {
+            extra[fid] = v
+            if (fid !== k) changed = true
+          } else {
+            extra[k] = v
+            console.warn(`AdDaily ${doc._id} 欄位 ${k} 無對應 ID`)
+          }
         }
         const colors = {}
         for (const [k, v] of Object.entries(doc.colors || {})) {
-          const fid = nameToId[k] || slugToId[k] || k
-          colors[fid] = v
-          if (fid !== k) changed = true
+          const fid = nameToId[k] || slugToId[k]
+          if (fid) {
+            colors[fid] = v
+            if (fid !== k) changed = true
+          } else {
+            colors[k] = v
+            console.warn(`AdDaily ${doc._id} 色票 ${k} 無對應 ID`)
+          }
         }
         if (changed) {
           doc.extraData = extra
           doc.colors = colors
           await doc.save()
+          console.log(`AdDaily ${doc._id} 已更新欄位鍵`)
         }
       }
     }


### PR DESCRIPTION
## Summary
- 補強 `migrateExtraDataFieldId.js`，若欄位名稱或 slug 無對應 ID 會提示警告
- README 補充部署前需執行資料遷移腳本的步驟

## Testing
- `npm install --prefix server` (失敗：403 Forbidden)
- `npm test` (失敗：jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c2745c29e883298718aaaf67f77b42