### PR TITLE
新增平台舊欄位映射及單元測試

### DIFF
--- a/server/src/scripts/migrateExtraDataFieldId.js
+++ b/server/src/scripts/migrateExtraDataFieldId.js
@@ -6,10 +6,88 @@ import { fileURLToPath } from 'node:url'
 import Platform from '../models/platform.model.js'
 import AdDaily from '../models/adDaily.model.js'
 
+// 舊名稱或舊 slug 對應現有欄位 slug 的表
+export const oldFieldMappings = {
+  // 範例：Meta 平台的舊欄位 old 對應到現有欄位 new
+  Meta: {
+    old: 'new'
+  }
+}
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
-const run = async () => {
+export const migratePlatform = async (p, mismatches = []) => {
+  const nameToId = {}
+  const slugToId = {}
+  const aliasToId = {}
+  let platformUpdated = false
+  p.fields.forEach(f => {
+    if (!f.id) {
+      f.id = new mongoose.Types.ObjectId().toString()
+      platformUpdated = true
+    }
+    nameToId[f.name] = f.id
+    slugToId[f.slug] = f.id
+  })
+
+  const mapping = oldFieldMappings[p.name] || {}
+  for (const [oldKey, target] of Object.entries(mapping)) {
+    aliasToId[oldKey] = nameToId[target] || slugToId[target]
+  }
+
+  if (platformUpdated) {
+    await p.save()
+    console.log(`平台 ${p.name} 已補齊欄位 id`)
+  }
+
+  let adDailyCount = 0
+  let successCount = 0
+  let failCount = 0
+  const cursor = AdDaily.find({ platformId: p._id }).cursor()
+  for await (const doc of cursor) {
+    adDailyCount += 1
+    let changed = false
+    const extra = {}
+    for (const [k, v] of Object.entries(doc.extraData || {})) {
+      const fid = nameToId[k] || slugToId[k] || aliasToId[k]
+      if (fid) {
+        extra[fid] = v
+        successCount += 1
+        if (fid !== k) changed = true
+      } else {
+        extra[k] = v
+        failCount += 1
+        mismatches.push({ platform: p.name, docId: doc._id.toString(), field: k, type: 'extraData' })
+        console.warn(`AdDaily ${doc._id} 欄位 ${k} 無對應 ID`)
+      }
+    }
+    const colors = {}
+    for (const [k, v] of Object.entries(doc.colors || {})) {
+      const fid = nameToId[k] || slugToId[k] || aliasToId[k]
+      if (fid) {
+        colors[fid] = v
+        successCount += 1
+        if (fid !== k) changed = true
+      } else {
+        colors[k] = v
+        failCount += 1
+        mismatches.push({ platform: p.name, docId: doc._id.toString(), field: k, type: 'color' })
+        console.warn(`AdDaily ${doc._id} 色票 ${k} 無對應 ID`)
+      }
+    }
+    if (changed) {
+      doc.extraData = extra
+      doc.colors = colors
+      await doc.save()
+      console.log(`AdDaily ${doc._id} 已更新欄位鍵`)
+    }
+  }
+  console.log(`平台 ${p.name} 共處理 ${adDailyCount} 筆 AdDaily，成功 ${successCount} 欄位，失敗 ${failCount} 欄位`)
+  return mismatches
+}
+
+export const run = async () => {
   try {
     await mongoose.connect(process.env.MONGODB_URI)
     console.log('✅ MongoDB 已連線')
@@ -17,65 +95,7 @@ const run = async () => {
     const platforms = await Platform.find()
     const mismatches = []
     for (const p of platforms) {
-      const nameToId = {}
-      const slugToId = {}
-      let platformUpdated = false
-      p.fields.forEach(f => {
-        if (!f.id) {
-          f.id = new mongoose.Types.ObjectId().toString()
-          platformUpdated = true
-        }
-        nameToId[f.name] = f.id
-        slugToId[f.slug] = f.id
-      })
-      if (platformUpdated) {
-        await p.save()
-        console.log(`平台 ${p.name} 已補齊欄位 id`)
-      }
-
-      let adDailyCount = 0
-      let successCount = 0
-      let failCount = 0
-      const cursor = AdDaily.find({ platformId: p._id }).cursor()
-      for await (const doc of cursor) {
-        adDailyCount += 1
-        let changed = false
-        const extra = {}
-        for (const [k, v] of Object.entries(doc.extraData || {})) {
-          const fid = nameToId[k] || slugToId[k]
-          if (fid) {
-            extra[fid] = v
-            successCount += 1
-            if (fid !== k) changed = true
-          } else {
-            extra[k] = v
-            failCount += 1
-            mismatches.push({ platform: p.name, docId: doc._id.toString(), field: k, type: 'extraData' })
-            console.warn(`AdDaily ${doc._id} 欄位 ${k} 無對應 ID`)
-          }
-        }
-        const colors = {}
-        for (const [k, v] of Object.entries(doc.colors || {})) {
-          const fid = nameToId[k] || slugToId[k]
-          if (fid) {
-            colors[fid] = v
-            successCount += 1
-            if (fid !== k) changed = true
-          } else {
-            colors[k] = v
-            failCount += 1
-            mismatches.push({ platform: p.name, docId: doc._id.toString(), field: k, type: 'color' })
-            console.warn(`AdDaily ${doc._id} 色票 ${k} 無對應 ID`)
-          }
-        }
-        if (changed) {
-          doc.extraData = extra
-          doc.colors = colors
-          await doc.save()
-          console.log(`AdDaily ${doc._id} 已更新欄位鍵`)
-        }
-      }
-      console.log(`平台 ${p.name} 共處理 ${adDailyCount} 筆 AdDaily，成功 ${successCount} 欄位，失敗 ${failCount} 欄位`)
+      await migratePlatform(p, mismatches)
     }
     if (mismatches.length) {
       const outPath = path.resolve(__dirname, 'migrateExtraDataFieldId-unmatched.json')
@@ -90,4 +110,6 @@ const run = async () => {
   }
 }
 
-run()
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run()
+}

--- a/server/tests/migrateExtraDataFieldId.test.js
+++ b/server/tests/migrateExtraDataFieldId.test.js
@@ -1,0 +1,45 @@
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import Platform from '../src/models/platform.model.js'
+import AdDaily from '../src/models/adDaily.model.js'
+import Client from '../src/models/client.model.js'
+import { migratePlatform, oldFieldMappings } from '../src/scripts/migrateExtraDataFieldId.js'
+
+describe('migrateExtraDataFieldId 舊名稱映射', () => {
+  let mongo
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    await mongoose.connect(mongo.getUri())
+  })
+
+  afterAll(async () => {
+    await mongoose.disconnect()
+    await mongo.stop()
+  })
+
+  it('舊欄位名稱可轉換為對應的欄位 id', async () => {
+    oldFieldMappings.Meta = { old: 'new' }
+    const client = await Client.create({ name: 'C1' })
+    const platform = await Platform.create({
+      clientId: client._id,
+      name: 'Meta',
+      fields: [{ id: 'f1', name: 'New', slug: 'new', type: 'number' }]
+    })
+    await AdDaily.create({
+      clientId: client._id,
+      platformId: platform._id,
+      date: new Date(),
+      extraData: { old: 5 },
+      colors: { old: '#fff' }
+    })
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    await migratePlatform(platform)
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    const doc = await AdDaily.findOne({ platformId: platform._id })
+    expect(doc.extraData).toEqual({ f1: 5 })
+    expect(doc.colors).toEqual({ f1: '#fff' })
+  })
+})


### PR DESCRIPTION
## Summary
- 在 `migrateExtraDataFieldId` 加入舊名稱/slug 對應表並納入遷移比對
- 增加 `migratePlatform` 函式以便測試與重複使用
- 撰寫 `migrateExtraDataFieldId` 單元測試驗證舊名稱轉換

## Testing
- `npm install --prefix server` *(失敗: 403 Forbidden - archiver)*
- `npm test` *(失敗: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2835797088329bff2c4b58232dd3a