### PR TITLE
修正欄位 ID 遷移誤判

### DIFF
--- a/server/src/scripts/migrateExtraDataFieldId.js
+++ b/server/src/scripts/migrateExtraDataFieldId.js
@@ -21,12 +21,14 @@ export const migratePlatform = async (p, mismatches = []) => {
   const nameToId = {}
   const slugToId = {}
   const aliasToId = {}
+  const idSet = new Set()
   let platformUpdated = false
   p.fields.forEach(f => {
     if (!f.id) {
       f.id = new mongoose.Types.ObjectId().toString()
       platformUpdated = true
     }
+    idSet.add(f.id)
     nameToId[f.name] = f.id
     slugToId[f.slug] = f.id
   })
@@ -50,7 +52,8 @@ export const migratePlatform = async (p, mismatches = []) => {
     let changed = false
     const extra = {}
     for (const [k, v] of Object.entries(doc.extraData || {})) {
-      const fid = nameToId[k] || slugToId[k] || aliasToId[k]
+      let fid = nameToId[k] || slugToId[k] || aliasToId[k]
+      if (!fid && idSet.has(k)) fid = k
       if (fid) {
         extra[fid] = v
         successCount += 1
@@ -64,7 +67,8 @@ export const migratePlatform = async (p, mismatches = []) => {
     }
     const colors = {}
     for (const [k, v] of Object.entries(doc.colors || {})) {
-      const fid = nameToId[k] || slugToId[k] || aliasToId[k]
+      let fid = nameToId[k] || slugToId[k] || aliasToId[k]
+      if (!fid && idSet.has(k)) fid = k
       if (fid) {
         colors[fid] = v
         successCount += 1

--- a/server/tests/migrateExtraDataFieldId.test.js
+++ b/server/tests/migrateExtraDataFieldId.test.js
@@ -42,4 +42,30 @@ describe('migrateExtraDataFieldId 舊名稱映射', () => {
     expect(doc.extraData).toEqual({ f1: 5 })
     expect(doc.colors).toEqual({ f1: '#fff' })
   })
+
+  it('欄位 id 已存在時應保持不變', async () => {
+    oldFieldMappings.Meta = {}
+    const client = await Client.create({ name: 'C2' })
+    const platform = await Platform.create({
+      clientId: client._id,
+      name: 'Meta',
+      fields: [{ id: 'f1', name: 'New', slug: 'new', type: 'number' }]
+    })
+    await AdDaily.create({
+      clientId: client._id,
+      platformId: platform._id,
+      date: new Date(),
+      extraData: { f1: 5 },
+      colors: { f1: '#fff' }
+    })
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    await migratePlatform(platform)
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    const doc = await AdDaily.findOne({ platformId: platform._id })
+    expect(doc.extraData).toEqual({ f1: 5 })
+    expect(doc.colors).toEqual({ f1: '#fff' })
+  })
 })


### PR DESCRIPTION
## Summary
- 於欄位遷移腳本新增 `idSet`，處理已使用欄位 ID 的資料
- 補充測試覆蓋原始即為欄位 ID 的情境

## Testing
- `npm test` *(失敗：jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c28f3e39e48329b2f3fc671f15fb50