### PR TITLE
新增舊欄位 ID 對應功能

### DIFF
--- a/server/tests/migrateExtraDataFieldId.test.js
+++ b/server/tests/migrateExtraDataFieldId.test.js
@@ -43,6 +43,32 @@ describe('migrateExtraDataFieldId 舊名稱映射', () => {
     expect(doc.colors).toEqual({ f1: '#fff' })
   })
 
+  it('舊欄位 id 可轉換為對應的欄位 id', async () => {
+    oldFieldMappings.Meta = { oldf1: 'new' }
+    const client = await Client.create({ name: 'C1-2' })
+    const platform = await Platform.create({
+      clientId: client._id,
+      name: 'Meta',
+      fields: [{ id: 'f1', name: 'New', slug: 'new', type: 'number' }]
+    })
+    await AdDaily.create({
+      clientId: client._id,
+      platformId: platform._id,
+      date: new Date(),
+      extraData: { oldf1: 5 },
+      colors: { oldf1: '#000' }
+    })
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    await migratePlatform(platform)
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    const doc = await AdDaily.findOne({ platformId: platform._id })
+    expect(doc.extraData).toEqual({ f1: 5 })
+    expect(doc.colors).toEqual({ f1: '#000' })
+  })
+
   it('欄位 id 已存在時應保持不變', async () => {
     oldFieldMappings.Meta = {}
     const client = await Client.create({ name: 'C2' })


### PR DESCRIPTION
## Summary
- 擴充舊欄位對應表，支援以欄位名稱、slug 或舊 ID 指向新的欄位識別
- `migratePlatform` 建立名稱、slug、ID 的別名映射，轉換舊欄位 ID 為新欄位 ID
- 新增測試驗證舊欄位 ID 能正確轉換

## Testing
- `npm --prefix server install` *(failed: 403 Forbidden)*
- `npm test` *(failed: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c290e07edc8329bf5c94b79aa3cf69