### PR TITLE
支援平台欄位重命名與即時編輯功能

### DIFF
--- a/client/src/services/platforms.js
+++ b/client/src/services/platforms.js
@@ -17,3 +17,6 @@ export const getPlatform = (clientId, id) =>
 
 export const transferPlatform = (id, clientId) =>
   api.put(`/platforms/${id}/transfer`, { clientId }).then(r => r.data)
+
+export const renamePlatformField = (clientId, platformId, data) =>
+  api.put(`/clients/${clientId}/platforms/${platformId}/rename-field`, data).then(r => r.data)


### PR DESCRIPTION
## 摘要
- 調整平台管理頁面欄位列為可編輯元件
- 新增 renamePlatformField API 封裝並於儲存時處理 slug 重命名
- 更新欄位排序與資料同步邏輯

## 測試
- `npm test` *(失敗：缺少 jest 套件)*
- `npm --prefix server test server/tests/platformFieldRename.test.js` *(失敗：缺少 jest 套件)*

------
https://chatgpt.com/codex/tasks/task_e_68c2956f01cc8329afefb5f5cbe827ab