### PR TITLE
修正 loadDaily 日期參數名稱與後端一致

### DIFF
--- a/client/src/views/AdData.test.js
+++ b/client/src/views/AdData.test.js
@@ -90,4 +90,34 @@ describe('AdData.vue', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0].text()).toBe('5')
   })
+
+  it('傳入日期範圍時使用正確參數呼叫 fetchDaily', async () => {
+    const { fetchDaily } = await import('@/services/adDaily')
+    const { getPlatform } = await import('@/services/platforms')
+    const { fetchWeeklyNotes } = await import('@/services/weeklyNotes')
+
+    fetchDaily.mockResolvedValue({ records: [] })
+    getPlatform.mockResolvedValue({ fields: [] })
+    fetchWeeklyNotes.mockResolvedValue([])
+
+    const wrapper = shallowMount(AdData, {
+      global: {
+        stubs: {
+          DataTable: { template: '<div />' }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    fetchDaily.mockClear()
+
+    wrapper.vm.startDate = '2024-01-01'
+    wrapper.vm.endDate = '2024-01-31'
+    await flushPromises()
+
+    expect(fetchDaily).toHaveBeenCalledTimes(1)
+    const params = fetchDaily.mock.calls[0][2]
+    expect(params).toEqual({ start: '2024-01-01', end: '2024-01-31' })
+  })
 })

--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -650,8 +650,8 @@ const loadPlatform = async () => {
 const loadDaily = async () => {
   loading.value = true
   const params = {}
-  if (startDate.value) params.startDate = dayjs(startDate.value).format('YYYY-MM-DD')
-  if (endDate.value) params.endDate = dayjs(endDate.value).format('YYYY-MM-DD')
+  if (startDate.value) params.start = dayjs(startDate.value).format('YYYY-MM-DD')
+  if (endDate.value) params.end = dayjs(endDate.value).format('YYYY-MM-DD')
   if (sortField.value) {
     params.sort = sortField.value
     params.order = sortOrder.value === 1 ? 'asc' : 'desc'


### PR DESCRIPTION
## Summary
- 與後端同步日期參數名稱改為 start/end
- 新增測試驗證 fetchDaily 接收正確日期參數

## Testing
- `npm --prefix client test` *(失敗：vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c299da105483298744d7d357307768