### PR TITLE
改善 valByField 對資料結構變動的容錯能力

### DIFF
--- a/client/src/views/AdData.test.js
+++ b/client/src/views/AdData.test.js
@@ -91,6 +91,39 @@ describe('AdData.vue', () => {
     expect(rows[0].text()).toBe('5')
   })
 
+  it('後端回傳根層欄位時 valByField 可顯示資料', async () => {
+    const sample = [
+      { date: '2024-01-01', clicks: 15 }
+    ]
+
+    const { fetchDaily } = await import('@/services/adDaily')
+    const { getPlatform } = await import('@/services/platforms')
+    const { fetchWeeklyNotes } = await import('@/services/weeklyNotes')
+
+    fetchDaily.mockResolvedValue({ records: sample })
+    getPlatform.mockResolvedValue({ fields: [
+      { id: 'clicks', name: '點擊' }
+    ] })
+    fetchWeeklyNotes.mockResolvedValue([])
+
+    const wrapper = shallowMount(AdData, {
+      global: {
+        stubs: {
+          DataTable: {
+            props: ['value'],
+            template: `<div><div v-for="row in value" class="row">{{$parent.valByField(row, $parent.customColumns[0])}}</div></div>`
+          }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    const rows = wrapper.findAll('.row')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].text()).toBe('15')
+  })
+
   it('傳入日期範圍時使用正確參數呼叫 fetchDaily', async () => {
     const { fetchDaily } = await import('@/services/adDaily')
     const { getPlatform } = await import('@/services/platforms')


### PR DESCRIPTION
## Summary
- 增強 valByField 支援根層欄位並處理 extraData 前綴
- 調整排序與數值欄位偵測以相容根層資料
- 新增測試覆蓋後端回傳根層欄位情境

## Testing
- `npm --prefix client test` *(失敗：vitest: not found)*
- `npm --prefix client ci` *(失敗：403 Forbidden - GET https://registry.npmjs.org/@vue%2ftest-utils)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a643ac448329a001a9e681c8bf98