### PR TITLE
新增 AdDaily 資料鍵轉換腳本與測試

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ GCS_CORS_ORIGIN=http://localhost:5173
 3. 升級或部署前請先執行資料遷移：
    \`\`\`bash
    node server/src/scripts/migrateExtraDataFieldId.js
+   node server/src/scripts/migrateAdDailyExtraData.js
    \`\`\`
-   轉換將補齊各平台欄位 ID，並把 `AdDaily` 的 `extraData`、`colors` 鍵改為欄位 ID。
+   這會補齊各平台欄位 ID，並將 `AdDaily` 的 `extraData`、`colors` 鍵統一為欄位 ID。
 4. 執行測試前請先在 `server` 目錄安裝相依套件：
    \`\`\`bash
    npm install

--- a/server/src/scripts/migrateAdDailyExtraData.js
+++ b/server/src/scripts/migrateAdDailyExtraData.js
@@ -1,0 +1,71 @@
+import dotenv from 'dotenv'
+import mongoose from 'mongoose'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Platform from '../models/platform.model.js'
+import AdDaily from '../models/adDaily.model.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+
+export const migratePlatform = async p => {
+  const aliasToId = {}
+  const idSet = new Set()
+  p.fields.forEach(f => {
+    idSet.add(f.id)
+    if (f.id) aliasToId[f.id] = f.id
+    if (f.slug) aliasToId[f.slug] = f.id
+    if (f.name) aliasToId[f.name] = f.id
+  })
+
+  const cursor = AdDaily.find({ platformId: p._id }).cursor()
+  for await (const doc of cursor) {
+    let changed = false
+    const extra = {}
+    for (const [k, v] of Object.entries(doc.extraData || {})) {
+      const id = idSet.has(k) ? k : aliasToId[k]
+      if (id) {
+        extra[id] = v
+        if (id !== k) changed = true
+      } else {
+        extra[k] = v
+      }
+    }
+    const colors = {}
+    for (const [k, v] of Object.entries(doc.colors || {})) {
+      const id = idSet.has(k) ? k : aliasToId[k]
+      if (id) {
+        colors[id] = v
+        if (id !== k) changed = true
+      } else {
+        colors[k] = v
+      }
+    }
+    if (changed) {
+      doc.extraData = extra
+      doc.colors = colors
+      await doc.save()
+      console.log(`AdDaily ${doc._id} 已更新欄位鍵`)
+    }
+  }
+}
+
+export const run = async () => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI)
+    console.log('✅ MongoDB 已連線')
+    const platforms = await Platform.find()
+    for (const p of platforms) {
+      await migratePlatform(p)
+    }
+    console.log('🍺 轉換完成')
+  } catch (err) {
+    console.error('❌ 轉換失敗：', err.message)
+  } finally {
+    await mongoose.disconnect()
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run()
+}

--- a/server/tests/migrateAdDailyExtraData.test.js
+++ b/server/tests/migrateAdDailyExtraData.test.js
@@ -1,0 +1,86 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import authRoutes from '../src/routes/auth.routes.js'
+import clientRoutes from '../src/routes/client.routes.js'
+import platformRoutes from '../src/routes/platform.routes.js'
+import adDailyRoutes from '../src/routes/adDaily.routes.js'
+import User from '../src/models/user.model.js'
+import Role from '../src/models/role.model.js'
+import AdDaily from '../src/models/adDaily.model.js'
+import Platform from '../src/models/platform.model.js'
+import { migratePlatform } from '../src/scripts/migrateAdDailyExtraData.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+describe('migrateAdDailyExtraData', () => {
+  let mongo
+  let app
+  let token
+  let clientId
+  let platformId
+  const date = new Date('2024-01-02').toISOString()
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    await mongoose.connect(mongo.getUri())
+
+    app = express()
+    app.use(express.json())
+    app.use('/api/auth', authRoutes)
+    app.use('/api/clients', clientRoutes)
+    app.use('/api/clients/:clientId/platforms', platformRoutes)
+    app.use('/api/clients/:clientId/platforms/:platformId/ad-daily', adDailyRoutes)
+
+    const role = await Role.create({ name: 'manager' })
+    await User.create({ username: 'admin', password: 'pwd', email: 'a@b.c', roleId: role._id })
+    const res = await request(app).post('/api/auth/login').send({ username: 'admin', password: 'pwd' })
+    token = res.body.token
+  })
+
+  afterAll(async () => {
+    await mongoose.disconnect()
+    await mongo.stop()
+  })
+
+  it('舊欄位名稱或 slug 可轉為欄位 id 並可由 API 讀取', async () => {
+    const clientRes = await request(app)
+      .post('/api/clients')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'C1' })
+      .expect(201)
+    clientId = clientRes.body._id
+
+    const platformRes = await request(app)
+      .post(`/api/clients/${clientId}/platforms`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Meta', fields: [{ id: 'f1', name: 'Name1', slug: 'slug1', type: 'number' }] })
+      .expect(201)
+    platformId = platformRes.body._id
+
+    await AdDaily.create({
+      clientId,
+      platformId,
+      date,
+      extraData: { slug1: 10 },
+      colors: { Name1: '#123456' }
+    })
+
+    const platformDoc = await Platform.findById(platformId)
+    await migratePlatform(platformDoc)
+
+    const doc = await AdDaily.findOne({ platformId })
+    expect(doc.extraData).toEqual({ f1: 10 })
+    expect(doc.colors).toEqual({ f1: '#123456' })
+
+    const listRes = await request(app)
+      .get(`/api/clients/${clientId}/platforms/${platformId}/ad-daily?start=${date}&end=${date}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(listRes.body[0].extraData).toEqual({ f1: 10 })
+    expect(listRes.body[0].colors).toEqual({ f1: '#123456' })
+  })
+})


### PR DESCRIPTION
## 摘要
- 新增 `migrateAdDailyExtraData.js` 腳本，自動將 `AdDaily` 中使用欄位名稱或 slug 的鍵轉為欄位 id
- README 增列腳本執行方式，確保升級或部署時可完成資料鍵轉換
- 補上對應的 Jest 測試，驗證舊鍵轉換後仍能透過 API 正常讀取

## 測試
- `npm test` *(失敗：sh: 1: jest: not found)*
- `npm install` *(失敗：403 Forbidden - GET https://registry.npmjs.org/archiver)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d8f5b3048329a1781c805e9b0e70