### PR TITLE
修正 adData 無法在頁面更新的問題

### DIFF
--- a/client/src/views/AdData.e2e.test.js
+++ b/client/src/views/AdData.e2e.test.js
@@ -1,0 +1,58 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import AdData from './AdData.vue'
+
+vi.mock('@/services/adDaily', () => ({
+  fetchDaily: vi.fn(),
+  createDaily: vi.fn(),
+  bulkCreateDaily: vi.fn(),
+  updateDaily: vi.fn(),
+  deleteDaily: vi.fn(),
+}))
+
+vi.mock('@/services/weeklyNotes', () => ({
+  fetchWeeklyNote: vi.fn(),
+  fetchWeeklyNotes: vi.fn(),
+  createWeeklyNote: vi.fn(),
+  updateWeeklyNote: vi.fn(),
+  getWeeklyNoteImageUrl: vi.fn(),
+}))
+
+vi.mock('@/services/platforms', () => ({
+  getPlatform: vi.fn(),
+}))
+
+describe('AdData.vue e2e', () => {
+  it('模擬 API 回傳後頁面顯示 adData 內容', async () => {
+    const sample = [
+      { date: '2024-01-01', extraData: { clicks: 10 } },
+      { date: '2024-01-02', extraData: { clicks: 20 } },
+    ]
+
+    const { fetchDaily } = await import('@/services/adDaily')
+    const { getPlatform } = await import('@/services/platforms')
+    const { fetchWeeklyNotes } = await import('@/services/weeklyNotes')
+
+    fetchDaily.mockResolvedValue({ records: sample })
+    getPlatform.mockResolvedValue({ fields: [] })
+    fetchWeeklyNotes.mockResolvedValue([])
+
+    const wrapper = mount(AdData, {
+      global: {
+        stubs: {
+          DataTable: {
+            props: ['value'],
+            template: '<div><div v-for="item in value" class="row">{{ item.date }} {{ item.extraData.clicks }}</div></div>',
+          },
+        },
+      },
+    })
+
+    await flushPromises()
+
+    const rows = wrapper.findAll('.row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text()).toContain('2024-01-01')
+    expect(rows[0].text()).toContain('10')
+  })
+})

--- a/client/src/views/AdData.test.js
+++ b/client/src/views/AdData.test.js
@@ -23,6 +23,32 @@ vi.mock('@/services/platforms', () => ({
 }))
 
 describe('AdData.vue', () => {
+  it('載入後更新 adData', async () => {
+    const sample = [
+      { date: '2024-01-01', extraData: { clicks: 10 } },
+      { date: '2024-01-02', extraData: { clicks: 20 } }
+    ]
+
+    const { fetchDaily } = await import('@/services/adDaily')
+    const { getPlatform } = await import('@/services/platforms')
+    const { fetchWeeklyNotes } = await import('@/services/weeklyNotes')
+
+    fetchDaily.mockResolvedValue({ records: sample })
+    getPlatform.mockResolvedValue({ fields: [] })
+    fetchWeeklyNotes.mockResolvedValue([])
+
+    const wrapper = shallowMount(AdData, {
+      global: {
+        stubs: {
+          DataTable: { template: '<div />' }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.vm.adData).toEqual(sample)
+  })
   it('渲染每日資料', async () => {
     const sample = [
       { date: '2024-01-01', extraData: { clicks: 10 } },


### PR DESCRIPTION
## Summary
- 在 `AdData.vue` 中定義 `adData` 預設值並於載入後賦值，模板改用該屬性綁定
- 新增單元測試驗證 `adData` 會更新
- 新增端到端測試模擬 API 回傳後頁面顯示 `adData`

## Testing
- `npm test` *(失敗：jest: not found)*
- `npm --prefix client test` *(失敗：vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ec412b3483299852eb85dea78900