### PR TITLE
處理多陣列每日資料並新增測試

### DIFF
--- a/client/src/views/AdData.test.js
+++ b/client/src/views/AdData.test.js
@@ -82,6 +82,44 @@ describe('AdData.vue', () => {
     expect(rows[0].text()).toContain('10')
   })
 
+  it('物件多陣列欄位轉換並渲染', async () => {
+    const sample = {
+      date: ['2024-01-01', '2024-01-02'],
+      clicks: [5, 10]
+    }
+
+    const { fetchDaily } = await import('@/services/adDaily')
+    const { getPlatform } = await import('@/services/platforms')
+    const { fetchWeeklyNotes } = await import('@/services/weeklyNotes')
+
+    fetchDaily.mockResolvedValue(sample)
+    getPlatform.mockResolvedValue({ fields: [] })
+    fetchWeeklyNotes.mockResolvedValue([])
+
+    const wrapper = shallowMount(AdData, {
+      global: {
+        stubs: {
+          DataTable: {
+            props: ['value'],
+            template: '<div><div v-for="item in value" class="row">{{ item.date }} {{ item.clicks }}</div></div>'
+          }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.vm.adData).toEqual([
+      { date: '2024-01-01', clicks: 5 },
+      { date: '2024-01-02', clicks: 10 }
+    ])
+
+    const rows = wrapper.findAll('.row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text()).toContain('2024-01-01')
+    expect(rows[0].text()).toContain('5')
+  })
+
   it('自動推斷舊欄位別名後顯示資料', async () => {
     const sample = [
       { date: '2024-01-01', extraData: { 點擊: 5 } }

--- a/client/src/views/AdData.vue
+++ b/client/src/views/AdData.vue
@@ -669,8 +669,17 @@ const loadDaily = async () => {
     else if (Array.isArray(list?.data)) data = list.data
     else if (Array.isArray(list?.records)) data = list.records
     else if (list && typeof list === 'object') {
-      const firstArray = Object.values(list).find(Array.isArray)
-      data = firstArray || []
+      const keys = Object.keys(list).filter(k => Array.isArray(list[k]))
+      if (keys.length) {
+        const maxLen = Math.max(...keys.map(k => list[k].length))
+        data = Array.from({ length: maxLen }, (_, i) => {
+          const row = {}
+          keys.forEach(k => {
+            row[k] = list[k][i]
+          })
+          return row
+        })
+      }
     }
     adData.value = data
   } catch (err) {


### PR DESCRIPTION
## 摘要
- 支援 `loadDaily` 將物件型多陣列資料轉為列陣列
- 新增測試案例驗證轉換與渲染

## 測試
- `npm test`（失敗：`vitest` 未安裝，嘗試 `npm install` 時無法存取 npm registry）

------
https://chatgpt.com/codex/tasks/task_e_68c2fd13de0883298ca3795de3ac17ae