### PR TITLE
新增平台與每日資料遷移腳本

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -17,6 +17,10 @@ npm start                 # 啟動伺服器
 若舊有廣告資料含有 "RM" 前綴的數字字串，可執行
 `npm run sanitize-ad-daily` 將其批次轉為數字。
 
+如需同步平台欄位 ID 與廣告資料，可執行
+`npm run migrate:platform-data`，執行後會於 `src/scripts`
+產生 `migrate-platform-report.json`，記錄無法匹配的欄位。
+
 預設登入資訊如下：
 
 | 帳號 | 密碼  | 角色 |

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "test": "jest --experimental-vm-modules",
     "seed": "node src/scripts/seedUsers.js",
     "sanitize-ad-daily": "node src/scripts/sanitizeAdDaily.js",
-    "migrate-extra-data": "node src/scripts/migrateExtraDataFieldId.js"
+    "migrate-extra-data": "node src/scripts/migrateExtraDataFieldId.js",
+    "migrate:platform-data": "node src/scripts/migratePlatformAndData.js"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.16.0",

--- a/server/src/scripts/migratePlatformAndData.js
+++ b/server/src/scripts/migratePlatformAndData.js
@@ -1,0 +1,92 @@
+import mongoose from 'mongoose'
+import dotenv from 'dotenv'
+import path from 'node:path'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import Platform from '../models/platform.model.js'
+import AdDaily from '../models/adDaily.model.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+
+const recordMismatch = (mismatches, platformId, key) => {
+  if (!mismatches[platformId]) mismatches[platformId] = new Set()
+  mismatches[platformId].add(key)
+}
+
+export const migratePlatform = async (p, mismatches) => {
+  let platformChanged = false
+  const aliasToId = {}
+  const idSet = new Set()
+  p.fields.forEach(f => {
+    if (!f.id) {
+      f.id = new mongoose.Types.ObjectId().toString()
+      platformChanged = true
+    }
+    idSet.add(f.id)
+    if (f.id) aliasToId[f.id] = f.id
+    if (f.slug) aliasToId[f.slug] = f.id
+    if (f.name) aliasToId[f.name] = f.id
+  })
+  if (platformChanged) {
+    await p.save()
+    console.log(`Platform ${p._id} 欄位 id 已補齊`)
+  }
+
+  const cursor = AdDaily.find({ platformId: p._id }).cursor()
+  for await (const doc of cursor) {
+    let changed = false
+    const extra = {}
+    for (const [k, v] of Object.entries(doc.extraData || {})) {
+      const id = idSet.has(k) ? k : aliasToId[k]
+      if (id) {
+        extra[id] = v
+        if (id !== k) changed = true
+      } else {
+        extra[k] = v
+        recordMismatch(mismatches, p._id.toString(), k)
+      }
+    }
+    const colors = {}
+    for (const [k, v] of Object.entries(doc.colors || {})) {
+      const id = idSet.has(k) ? k : aliasToId[k]
+      if (id) {
+        colors[id] = v
+        if (id !== k) changed = true
+      } else {
+        colors[k] = v
+        recordMismatch(mismatches, p._id.toString(), k)
+      }
+    }
+    if (changed) {
+      doc.extraData = extra
+      doc.colors = colors
+      await doc.save()
+      console.log(`AdDaily ${doc._id} 已同步鍵值`)
+    }
+  }
+}
+
+export const run = async () => {
+  const mismatches = {}
+  try {
+    await mongoose.connect(process.env.MONGODB_URI)
+    console.log('✅ MongoDB 已連線')
+    const platforms = await Platform.find()
+    for (const p of platforms) {
+      await migratePlatform(p, mismatches)
+    }
+    const report = Object.fromEntries(Object.entries(mismatches).map(([id, set]) => [id, [...set]]))
+    const reportPath = path.resolve(__dirname, 'migrate-platform-report.json')
+    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2))
+    console.log('🍺 轉換完成，異常報告已輸出：', reportPath)
+  } catch (err) {
+    console.error('❌ 轉換失敗：', err.message)
+  } finally {
+    await mongoose.disconnect()
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run()
+}


### PR DESCRIPTION
## Summary
- 新增 `migratePlatformAndData` 腳本，補齊平台欄位 ID 並同步廣告資料鍵值
- 加入 npm 指令 `migrate:platform-data`
- README 說明遷移腳本使用方式

## Testing
- `npm test` *(失敗：jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fc62b3cc83299aa6621f3f9f6801