### PR TITLE
新增平台欄位 slug 與 formula 遷移腳本

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,8 @@
     "seed": "node src/scripts/seedUsers.js",
     "sanitize-ad-daily": "node src/scripts/sanitizeAdDaily.js",
     "migrate-extra-data": "node src/scripts/migrateExtraDataFieldId.js",
-    "migrate:platform-data": "node src/scripts/migratePlatformAndData.js"
+    "migrate:platform-data": "node src/scripts/migratePlatformAndData.js",
+    "migrate:platform-slug-formula": "node src/scripts/migratePlatformFieldsSlugFormula.js"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.16.0",

--- a/server/src/scripts/migratePlatformFieldsSlugFormula.js
+++ b/server/src/scripts/migratePlatformFieldsSlugFormula.js
@@ -1,0 +1,62 @@
+import dotenv from 'dotenv'
+import mongoose from 'mongoose'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Platform from '../models/platform.model.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+
+const slugPattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+const slugify = (s, exist = new Set()) => {
+  let base = s?.toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+  if (!base || !slugPattern.test(base) || exist.has(base)) {
+    let i = 1
+    while (exist.has(`f_${i}`)) i++
+    base = `f_${i}`
+  }
+  exist.add(base)
+  return base
+}
+
+export const migratePlatform = async (platform) => {
+  let changed = false
+  const slugs = new Set()
+  for (const f of platform.fields) {
+    if (f.slug) slugs.add(f.slug)
+  }
+  for (const f of platform.fields) {
+    if (!f.slug) {
+      f.slug = slugify(f.name, slugs)
+      changed = true
+    }
+    if (f.formula == null) {
+      f.formula = ''
+      changed = true
+    }
+  }
+  if (changed) {
+    await platform.save()
+    console.log(`平台 ${platform.name || platform._id} 已更新欄位 slug/formula`)
+  }
+}
+
+export const run = async () => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI)
+    console.log('✅ MongoDB 已連線')
+    const platforms = await Platform.find()
+    for (const p of platforms) {
+      await migratePlatform(p)
+    }
+    console.log('🍺 遷移完成')
+  } catch (err) {
+    console.error('❌ 遷移失敗：', err.message)
+  } finally {
+    await mongoose.disconnect()
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run()
+}

--- a/server/tests/migratePlatformFieldsSlugFormula.test.js
+++ b/server/tests/migratePlatformFieldsSlugFormula.test.js
@@ -1,0 +1,46 @@
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import Client from '../src/models/client.model.js'
+import Platform from '../src/models/platform.model.js'
+import { migratePlatform } from '../src/scripts/migratePlatformFieldsSlugFormula.js'
+
+describe('migratePlatformFieldsSlugFormula', () => {
+  let mongo
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    await mongoose.connect(mongo.getUri())
+  })
+
+  afterAll(async () => {
+    await mongoose.disconnect()
+    await mongo.stop()
+  })
+
+  it('補齊 slug 與 formula 並確保 slug 唯一', async () => {
+    const client = await Client.create({ name: 'C1' })
+    const platform = await Platform.create({
+      clientId: client._id,
+      name: 'Meta',
+      fields: [
+        { id: 'f1', name: 'Field One' },
+        { id: 'f2', name: 'Field One', slug: '' },
+        { id: 'f3', name: 'Field Two', slug: 'field_two' }
+      ]
+    })
+
+    await migratePlatform(platform)
+
+    const p = await Platform.findById(platform._id)
+    const slugs = p.fields.map(f => f.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+    const field1 = p.fields.find(f => f.id === 'f1')
+    const field2 = p.fields.find(f => f.id === 'f2')
+    const field3 = p.fields.find(f => f.id === 'f3')
+    expect(field1.slug).toBe('field_one')
+    expect(field2.slug).toBe('f_1')
+    expect(field3.slug).toBe('field_two')
+    p.fields.forEach(f => {
+      expect(f.formula).toBe('')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 新增 migratePlatformFieldsSlugFormula.js 腳本，補齊平台欄位 slug 與 formula
- 導入執行腳本的 npm 指令
- 撰寫對應 Jest 測試，確保 slug 唯一且 formula 補值

## Testing
- `npm test` *(失敗：sh: 1: jest: not found)*
- `npm install --prefix server` *(失敗：403 Forbidden - GET https://registry.npmjs.org/archiver)*

------
https://chatgpt.com/codex/tasks/task_e_68c4078773308329b26f789611530f57