### PR TITLE
feat: 新增使用者客戶權限設定

### DIFF
--- a/client/src/views/EmployeeManager.vue
+++ b/client/src/views/EmployeeManager.vue
@@ -45,6 +45,10 @@
       <Dropdown id="role" v-model="form.role" :options="roleOptions" optionLabel="label" optionValue="value" placeholder="選擇角色" />
     </div>
     <div class="field">
+      <label for="allowedClients">可訪問客戶</label>
+      <MultiSelect id="allowedClients" v-model="form.allowedClients" :options="clients" optionLabel="name" optionValue="_id" placeholder="選擇客戶" display="chip" filter />
+    </div>
+    <div class="field">
       <label for="password">密碼</label>
       <Password id="password" v-model="form.password" :placeholder="editing ? '留空则不变' : ''" :feedback="false" toggleMask />
     </div>
@@ -63,6 +67,7 @@ import { useConfirm } from 'primevue/useconfirm'
 import { fetchUsers, createUser, updateUser, deleteUser } from '../services/user'
 import { fetchRoles } from '../services/roles'
 import { fetchDepartments, fetchSubDepartments } from '../services/departments'
+import { fetchClients } from '../services/clients'
 import { useAuthStore } from '../stores/auth'
 
 // PrimeVue Components
@@ -74,6 +79,7 @@ import Dialog from 'primevue/dialog'
 import InputText from 'primevue/inputtext'
 import Dropdown from 'primevue/dropdown'
 import Password from 'primevue/password'
+import MultiSelect from 'primevue/multiselect'
 
 const toast = useToast()
 const confirm = useConfirm()
@@ -89,6 +95,7 @@ const users = ref([])
 const roleOptions = ref([])
 const departments = ref([])
 const subDepartments = ref([])
+const clients = ref([])
 const dialog = ref(false)
 const editing = ref(false)
 const form = ref({})
@@ -129,15 +136,23 @@ const loadDepartments = async () => {
   }
 }
 
+const loadClients = async () => {
+  try {
+    clients.value = await fetchClients()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: 'Error', detail: 'Failed to load clients', life: 3000 })
+  }
+}
+
 const openCreate = () => {
   editing.value = false
-  form.value = { username: '', name: '', email: '', role: 'employee', password: '' }
+  form.value = { username: '', name: '', email: '', role: 'employee', password: '', allowedClients: [] }
   dialog.value = true
 }
 
 const openEdit = (user) => {
   editing.value = true
-  form.value = { ...user, password: '' }
+  form.value = { ...user, password: '', allowedClients: user.allowedClients || [] }
   dialog.value = true
 }
 
@@ -184,5 +199,6 @@ onMounted(() => {
   loadUsers()
   loadRoles()
   loadDepartments()
+  loadClients()
 })
 </script>

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -20,7 +20,8 @@ export const login = async (req, res) => {
       username: user.username,
       role: user.roleId?.name,
       menus: user.roleId?.menus || [],
-      permissions: user.roleId?.permissions || []
+      permissions: user.roleId?.permissions || [],
+      allowedClients: user.allowedClients || []
     }
   })
 }

--- a/server/src/models/user.model.js
+++ b/server/src/models/user.model.js
@@ -13,7 +13,9 @@ const userSchema = new mongoose.Schema(
     password: { type: String, required: true, select: false },
     email: { type: String, required: true, unique: true },
     // 角色參照 Role 集合
-    roleId: { type: mongoose.Schema.Types.ObjectId, ref: 'Role' }
+    roleId: { type: mongoose.Schema.Types.ObjectId, ref: 'Role' },
+    // 可訪問客戶列表
+    allowedClients: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Client', default: [] }]
   },
   { timestamps: true }
 )

--- a/server/src/models/userClientPermission.model.js
+++ b/server/src/models/userClientPermission.model.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose'
+
+const userClientPermissionSchema = new mongoose.Schema(
+  {
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true }
+  },
+  { timestamps: true }
+)
+
+userClientPermissionSchema.index({ userId: 1, clientId: 1 }, { unique: true })
+
+export default mongoose.model('UserClientPermission', userClientPermissionSchema)

--- a/server/src/routes/user.routes.js
+++ b/server/src/routes/user.routes.js
@@ -30,6 +30,8 @@ router
     body('email').isEmail().withMessage('Email is invalid'),
     body('role').notEmpty().withMessage('Role is required'),
     body('password').isLength({ min: 6 }).withMessage('Password must be at least 6 characters'),
+    body('allowedClients').optional().isArray(),
+    body('allowedClients.*').optional().isMongoId(),
     validate,
     asyncHandler(createUser)
   )               // POST /api/user
@@ -39,6 +41,8 @@ router
   .put(
     requirePerm(PERMISSIONS.USER_MANAGE),
     body('email').optional().isEmail().withMessage('Email is invalid'),
+    body('allowedClients').optional().isArray(),
+    body('allowedClients.*').optional().isMongoId(),
     validate,
     asyncHandler(updateUser)
   )                // PUT    /api/user/:id

--- a/server/tests/user.test.js
+++ b/server/tests/user.test.js
@@ -6,6 +6,7 @@ import userRoutes from '../src/routes/user.routes.js'
 import authRoutes from '../src/routes/auth.routes.js'
 import Role from '../src/models/role.model.js'
 import User from '../src/models/user.model.js'
+import Client from '../src/models/client.model.js'
 import dotenv from 'dotenv'
 
 dotenv.config({ override: true })
@@ -14,6 +15,7 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
 let mongo
 let app
 let token
+let client1
 
 beforeAll(async () => {
   mongo = await MongoMemoryServer.create()
@@ -34,6 +36,8 @@ beforeAll(async () => {
     roleId: managerRole._id
   })
 
+  client1 = await Client.create({ name: 'ClientA' })
+
   const res = await request(app)
     .post('/api/auth/login')
     .send({ username: 'admin', password: 'mypwd' })
@@ -50,7 +54,7 @@ describe('create user then login', () => {
     await request(app)
       .post('/api/user')
       .set('Authorization', `Bearer ${token}`)
-      .send({ username: 'u1', name: 'U1', email: 'u1@example.com', role: 'employee', password: 'pwd' })
+      .send({ username: 'u1', name: 'U1', email: 'u1@example.com', role: 'employee', password: 'pwd', allowedClients: [client1._id] })
       .expect(201)
 
     const res = await request(app)
@@ -59,6 +63,7 @@ describe('create user then login', () => {
       .expect(200)
 
     expect(res.body).toHaveProperty('token')
+    expect(res.body.user.allowedClients[0]).toEqual(client1._id.toString())
   })
 })
 


### PR DESCRIPTION
## Summary
- 新增使用者可訪問客戶欄位與關聯模型
- 後端 API 與登入流程返回可用客戶 ID
- 後台介面支援設定使用者可查看的客戶

## Testing
- `npm test` *(失敗: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56462ca74832994764929d0e79df0