### PR TITLE
限制廣告查詢僅回傳授權客戶資料

### DIFF
--- a/server/src/controllers/adDaily.controller.js
+++ b/server/src/controllers/adDaily.controller.js
@@ -92,6 +92,10 @@ export const createAdDaily = async (req, res) => {
 }
 
 export const getAdDaily = async (req, res) => {
+  const allowed = req.user.allowedClients || []
+  if (allowed.length && !allowed.some(id => id.equals(req.params.clientId))) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
   const query = { clientId: req.params.clientId, platformId: req.params.platformId }
   if (req.query.start && req.query.end) {
     query.date = { $gte: new Date(req.query.start), $lte: new Date(req.query.end) }
@@ -158,6 +162,10 @@ export const getAdDaily = async (req, res) => {
 }
 
 export const getWeeklyData = async (req, res) => {
+  const allowed = req.user.allowedClients || []
+  if (allowed.length && !allowed.some(id => id.equals(req.params.clientId))) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
   const match = {
     clientId: new mongoose.Types.ObjectId(req.params.clientId),
     platformId: new mongoose.Types.ObjectId(req.params.platformId)


### PR DESCRIPTION
## 摘要
- 於廣告與儀表板 API 加入 allowedClients 檢查，僅回傳授權客戶資料
- 新增測試確保未授權客戶查詢會收到 403 錯誤

## 測試
- `npm test -- tests/adDaily.controller.test.js tests/dashboard.test.js` *(因缺少相依套件而無法執行)*


------
https://chatgpt.com/codex/tasks/task_e_68c565874c3c83298c2a2b4ed1aed9a4