### PR TITLE
新增使用者客戶授權管理功能

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -16,6 +16,7 @@ import ReviewSettings from '../views/ReviewSettings.vue'
 import AdClients from '../views/AdClients.vue'
 import AdPlatforms from '../views/AdPlatforms.vue'
 import AdData from '../views/AdData.vue'
+import UserClientAccess from '../views/UserClientAccess.vue'
 
 
 const routes = [
@@ -39,6 +40,7 @@ const routes = [
       { path: 'products/:folderId?', name: 'Products', component: ProductLibrary, meta: { menu: 'products' } },
 
       { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { menu: 'employees' } },
+      { path: 'employees/:userId/clients', name: 'UserClientAccess', component: UserClientAccess, meta: { menu: 'employees' } },
       { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { menu: 'roles' } },
       { path: 'tags', name: 'TagManager', component: TagManager, meta: { menu: 'tags' } },
       { path: 'review-settings', name: 'ReviewSettings', component: ReviewSettings, meta: { menu: 'review-stages' } },

--- a/client/src/services/user.js
+++ b/client/src/services/user.js
@@ -12,3 +12,9 @@ export const updateUser = (id, data) =>
 
 export const deleteUser = id =>
   api.delete(`/user/${id}`).then(r => r.data) // DELETE /api/user/:id
+
+export const fetchUserClients = id =>
+  api.get(`/user/${id}/clients`).then(r => r.data) // GET /api/user/:id/clients
+
+export const updateUserClients = (id, clients) =>
+  api.put(`/user/${id}/clients`, { clients }).then(r => r.data) // PUT /api/user/:id/clients

--- a/client/src/views/EmployeeManager.vue
+++ b/client/src/views/EmployeeManager.vue
@@ -19,6 +19,7 @@
         </Column>
         <Column header="操作" :exportable="false" style="min-width:8rem">
           <template #body="{ data }">
+            <Button icon="pi pi-users" class="p-button-rounded p-button-info mr-2" @click="goClients(data)" />
             <Button icon="pi pi-pencil" class="p-button-rounded p-button-success mr-2" @click="openEdit(data)" />
             <Button icon="pi pi-trash" class="p-button-rounded p-button-warning" @click="confirmDeleteUser(data)" />
           </template>
@@ -154,6 +155,10 @@ const openEdit = (user) => {
   editing.value = true
   form.value = { ...user, password: '', allowedClients: user.allowedClients || [] }
   dialog.value = true
+}
+
+const goClients = (user) => {
+  router.push(`/employees/${user._id}/clients`)
 }
 
 const submit = async () => {

--- a/client/src/views/UserClientAccess.vue
+++ b/client/src/views/UserClientAccess.vue
@@ -1,0 +1,69 @@
+<template>
+  <Card>
+    <template #title>
+      <div class="flex justify-content-between align-items-center">
+        <h1 class="text-2xl font-bold">使用者客戶授權</h1>
+        <Button label="儲存" icon="pi pi-save" @click="save" />
+      </div>
+    </template>
+    <template #content>
+      <DataTable
+        v-model:selection="selected"
+        v-model:filters="filters"
+        :globalFilterFields="['name']"
+        :value="clients"
+        dataKey="_id"
+        :paginator="true"
+        :rows="10"
+        filterDisplay="menu"
+      >
+        <template #header>
+          <div class="flex justify-content-end">
+            <span class="p-input-icon-left">
+              <i class="pi pi-search" />
+              <InputText v-model="filters['global'].value" placeholder="搜尋客戶" />
+            </span>
+          </div>
+        </template>
+        <Column selectionMode="multiple" headerStyle="width:3rem"></Column>
+        <Column field="name" header="客戶名稱" sortable></Column>
+      </DataTable>
+    </template>
+  </Card>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import { FilterMatchMode } from 'primevue/api'
+import { fetchClients } from '../services/clients'
+import { fetchUserClients, updateUserClients } from '../services/user'
+import Card from 'primevue/card'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+const userId = route.params.userId
+const clients = ref([])
+const selected = ref([])
+const filters = ref({
+  global: { value: null, matchMode: FilterMatchMode.CONTAINS }
+})
+
+onMounted(async () => {
+  clients.value = await fetchClients()
+  const userClients = await fetchUserClients(userId)
+  selected.value = clients.value.filter(c => userClients.some(u => u._id === c._id))
+})
+
+const save = async () => {
+  await updateUserClients(userId, selected.value.map(c => c._id))
+  toast.add({ severity: 'success', summary: '成功', detail: '已更新', life: 3000 })
+  router.back()
+}
+</script>

--- a/server/src/routes/user.routes.js
+++ b/server/src/routes/user.routes.js
@@ -9,7 +9,9 @@ import {
   updateUser,
   deleteUser,
   getProfile,
-  updateProfile
+  updateProfile,
+  getUserClients,
+  updateUserClients
 } from '../controllers/user.controller.js'
 import asyncHandler from '../utils/asyncHandler.js'
 import { validate } from '../middleware/validate.js'
@@ -47,5 +49,16 @@ router
     asyncHandler(updateUser)
   )                // PUT    /api/user/:id
   .delete(requirePerm(PERMISSIONS.USER_MANAGE), asyncHandler(deleteUser))             // DELETE /api/user/:id
+
+router
+  .route('/:id/clients')
+  .get(requirePerm(PERMISSIONS.USER_MANAGE), asyncHandler(getUserClients))
+  .put(
+    requirePerm(PERMISSIONS.USER_MANAGE),
+    body('clients').isArray(),
+    body('clients.*').isMongoId(),
+    validate,
+    asyncHandler(updateUserClients)
+  )
 
 export default router

--- a/server/tests/user.test.js
+++ b/server/tests/user.test.js
@@ -121,3 +121,30 @@ describe('授權客戶清單管理', () => {
     expect(removed.body.allowedClients.length).toBe(0)
   })
 })
+
+describe('使用者客戶授權 API', () => {
+  it('可取得與更新客戶授權清單', async () => {
+    const client2 = await Client.create({ name: 'ClientC' })
+
+    const created = await request(app)
+      .post('/api/user')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ username: 'u5', name: 'U5', email: 'u5@example.com', role: 'employee', password: 'pwd' })
+      .expect(201)
+
+    await request(app)
+      .put(`/api/user/${created.body._id}/clients`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ clients: [client1._id, client2._id] })
+      .expect(200)
+
+    const res = await request(app)
+      .get(`/api/user/${created.body._id}/clients`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    const ids = res.body.map(c => c._id.toString())
+    expect(ids).toContain(client1._id.toString())
+    expect(ids).toContain(client2._id.toString())
+  })
+})


### PR DESCRIPTION
## 概述
- 新增 `GET /user/:id/clients` 與 `PUT /user/:id/clients` API
- 管理介面加入使用者客戶授權頁面，可搜尋、分頁並設定可訪問客戶
- 員工列表提供入口前往客戶授權設定

## 測試
- ⚠️ `npm install` (server)：403 Forbidden 無法安裝套件
- ⚠️ `npm test` (server)：因缺少套件無法執行
- ⚠️ `npm install` (client)：403 Forbidden 無法安裝套件
- ⚠️ `npm test` (client)：因缺少套件無法執行

------
https://chatgpt.com/codex/tasks/task_e_68c568794ff0832987773e2c640fb5a5