### PR TITLE
新增爆款數據模組前後端整合

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -112,6 +112,7 @@ const mainMenuItems = computed(() => [
       ? String(notificationStore.productUnreadCount)
       : null
   },
+  { path: '/popular-data', label: '爆款数据', icon: 'pi pi-bolt', badge: null },
 
   // { path: '/ad-data', label: '广告数据', icon: 'pi pi-chart-line', badge: null }
 ])

--- a/client/src/menuNames.js
+++ b/client/src/menuNames.js
@@ -7,6 +7,7 @@ export const MENU_NAMES = {
   roles: '角色设定',
   tags: '标签管理',
   'review-stages': '审查关卡',
+  'popular-data': '爆款数据',
   'ad-data': '广告数据',
   'ad-platforms': '平台設定',
   account: '帐号资讯'

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -17,6 +17,9 @@ import AdClients from '../views/AdClients.vue'
 import AdPlatforms from '../views/AdPlatforms.vue'
 import AdData from '../views/AdData.vue'
 import UserClientAccess from '../views/UserClientAccess.vue'
+import PopularDataClients from '../views/popular-data/PopularData.vue'
+import PopularDataPlatforms from '../views/popular-data/PopularDataPlatforms.vue'
+import PopularDataXhs from '../views/popular-data/PopularDataXhs.vue'
 
 
 const routes = [
@@ -38,6 +41,27 @@ const routes = [
       { path: 'products/asset/:assetId', name: 'ProductAssetDetailRoot', component: ProductLibrary, meta: { menu: 'products' } },
       { path: 'products/:folderId/asset/:assetId', name: 'ProductAssetDetail', component: ProductLibrary, meta: { menu: 'products' } },
       { path: 'products/:folderId?', name: 'Products', component: ProductLibrary, meta: { menu: 'products' } },
+
+      {
+        path: 'popular-data',
+        name: 'PopularDataClients',
+        component: PopularDataClients,
+        meta: { menu: 'popular-data' }
+      },
+      {
+        path: 'popular-data/:clientId',
+        name: 'PopularDataPlatforms',
+        component: PopularDataPlatforms,
+        props: true,
+        meta: { menu: 'popular-data' }
+      },
+      {
+        path: 'popular-data/:clientId/xhs',
+        name: 'PopularDataXhs',
+        component: PopularDataXhs,
+        props: true,
+        meta: { menu: 'popular-data' }
+      },
 
       { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { menu: 'employees' } },
       { path: 'employees/:userId/clients', name: 'UserClientAccess', component: UserClientAccess, meta: { menu: 'employees' } },

--- a/client/src/services/popularData.js
+++ b/client/src/services/popularData.js
@@ -1,0 +1,33 @@
+import api from './api'
+
+export const POPULAR_DATA_PLATFORMS = Object.freeze({
+  XHS: 'xhs',
+  TIKTOK: 'tiktok',
+  FACEBOOK: 'facebook'
+})
+
+export const listPopularContents = (clientId, platformKey) =>
+  api
+    .get(`/clients/${clientId}/popular-contents`, {
+      params: { platformKey }
+    })
+    .then((res) => res.data)
+
+export const createPopularContent = (clientId, payload) =>
+  api.post(`/clients/${clientId}/popular-contents`, payload).then((res) => res.data)
+
+export const updatePopularContent = (clientId, contentId, payload) =>
+  api.put(`/clients/${clientId}/popular-contents/${contentId}`, payload).then((res) => res.data)
+
+export const deletePopularContent = (clientId, contentId) =>
+  api.delete(`/clients/${clientId}/popular-contents/${contentId}`).then((res) => res.data)
+
+export const uploadPopularContentCover = (clientId, contentId, file) => {
+  const formData = new FormData()
+  formData.append('cover', file)
+  return api
+    .post(`/clients/${clientId}/popular-contents/${contentId}/cover`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    .then((res) => res.data)
+}

--- a/client/src/views/PopularData.test.js
+++ b/client/src/views/PopularData.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+const toastMock = { add: vi.fn() }
+vi.mock('primevue/usetoast', () => ({ useToast: () => toastMock }))
+
+const clientsModuleMock = vi.hoisted(() => ({
+  fetchClients: vi.fn(() => Promise.resolve([])),
+  getClient: vi.fn(() => Promise.resolve({ name: '測試客戶' }))
+}))
+vi.mock('@/services/clients', () => clientsModuleMock)
+
+const popularDataModuleMock = vi.hoisted(() => ({
+  listPopularContents: vi.fn(() => Promise.resolve([])),
+  createPopularContent: vi.fn(() => Promise.resolve({ _id: '1' })),
+  updatePopularContent: vi.fn((_, __, payload) => Promise.resolve({ _id: '1', ...payload })),
+  deletePopularContent: vi.fn(() => Promise.resolve({})),
+  uploadPopularContentCover: vi.fn(() => Promise.resolve({}))
+}))
+vi.mock('@/services/popularData', () => popularDataModuleMock)
+
+const { fetchClients: fetchClientsMock, getClient: getClientMock } = clientsModuleMock
+const {
+  listPopularContents: listPopularContentsMock,
+  createPopularContent: createPopularContentMock,
+  updatePopularContent: updatePopularContentMock,
+  deletePopularContent: deletePopularContentMock,
+  uploadPopularContentCover: uploadPopularContentCoverMock
+} = popularDataModuleMock
+
+const ButtonStub = defineComponent({
+  name: 'Button',
+  props: ['label', 'disabled'],
+  emits: ['click'],
+  setup(props, { emit, slots, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: ['button-stub', attrs.class].filter(Boolean).join(' '),
+          disabled: props.disabled ?? attrs.disabled ?? false,
+          onClick: (e) => {
+            if (props.disabled ?? attrs.disabled) return
+            emit('click', e)
+            attrs.onClick?.(e)
+          }
+        },
+        slots.default ? slots.default() : props.label
+      )
+  }
+})
+
+const InputTextStub = defineComponent({
+  name: 'InputText',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('input', {
+        value: props.modelValue,
+        onInput: (event) => emit('update:modelValue', event.target.value)
+      })
+  }
+})
+
+const CardStub = defineComponent({
+  name: 'Card',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'card-stub' }, slots.content ? slots.content() : slots.default?.())
+  }
+})
+
+const FileUploadStub = defineComponent({
+  name: 'FileUpload',
+  emits: ['select', 'clear'],
+  setup(_, { slots }) {
+    return () => h('div', { class: 'file-upload-stub' }, slots.default ? slots.default() : [])
+  }
+})
+
+const globalStubs = {
+  Button: ButtonStub,
+  InputText: InputTextStub,
+  Card: CardStub,
+  FileUpload: FileUploadStub
+}
+
+const createTestRouter = async (initialRoute = { path: '/' }) => {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'root', component: { template: '<div />' } },
+      { path: '/popular-data/:clientId', name: 'PopularDataPlatforms', component: { template: '<div />' } },
+      { path: '/popular-data/:clientId/xhs', name: 'PopularDataXhs', component: { template: '<div />' } }
+    ]
+  })
+  await router.push(initialRoute)
+  await router.isReady()
+  return router
+}
+
+import PopularData from './popular-data/PopularData.vue'
+import PopularDataPlatforms from './popular-data/PopularDataPlatforms.vue'
+import PopularDataCardDialog from './popular-data/PopularDataCardDialog.vue'
+
+describe('PopularData 客戶列表', () => {
+  beforeEach(() => {
+    toastMock.add.mockClear()
+    fetchClientsMock.mockReset()
+  })
+
+  it('載入客戶並可搜尋', async () => {
+    fetchClientsMock.mockResolvedValueOnce([
+      { _id: '1', name: '星光集團' },
+      { _id: '2', name: '晨曦品牌' }
+    ])
+
+    const router = await createTestRouter()
+    const pushSpy = vi.spyOn(router, 'push')
+    const wrapper = mount(PopularData, { global: { stubs: globalStubs, plugins: [router] } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('星光集團')
+    expect(wrapper.text()).toContain('晨曦品牌')
+
+    const input = wrapper.find('input')
+    await input.setValue('晨曦')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('晨曦品牌')
+    expect(wrapper.text()).not.toContain('星光集團')
+
+    await wrapper.findAll('button')[0].trigger('click')
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'PopularDataPlatforms', params: { clientId: '2' } })
+  })
+})
+
+describe('PopularData 平台選擇', () => {
+  beforeEach(() => {
+    getClientMock.mockResolvedValue({ name: '行銷客戶' })
+  })
+
+  it('禁用 TikTok 與 Facebook 並導向小紅書', async () => {
+    const router = await createTestRouter({ path: '/', query: { clientName: '測試客戶' } })
+    const pushSpy = vi.spyOn(router, 'push')
+    const wrapper = mount(PopularDataPlatforms, {
+      props: { clientId: '123' },
+      global: { stubs: { Button: ButtonStub }, plugins: [router] }
+    })
+    await flushPromises()
+
+    const buttons = wrapper.findAll('.platforms-grid .button-stub')
+    expect(buttons[0].classes()).toContain('platform-button--muted')
+    expect(buttons[1].classes()).toContain('platform-button--muted')
+    expect(buttons[2].classes()).toContain('platform-button--active')
+
+    await buttons[0].trigger('click')
+    await buttons[1].trigger('click')
+    expect(pushSpy).not.toHaveBeenCalled()
+
+    await buttons[2].trigger('click')
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'PopularDataXhs', params: { clientId: '123' } })
+  })
+})
+
+describe('PopularDataCardDialog 指標提示', () => {
+  it('低於閾值時顯示紅色警示', async () => {
+    const wrapper = mount(PopularDataCardDialog, {
+      props: {
+        modelValue: true,
+        content: {
+          title: '測試影片',
+          publishDate: '2024-01-01',
+          exposure: 1000,
+          viewCount: 200,
+          coverCtr: 10,
+          avgWatchSeconds: 5,
+          completionRate: 5,
+          twoSecondDropRate: 45
+        }
+      }
+    })
+
+    await flushPromises()
+    const alerts = wrapper.findAll('.metric-alert')
+    expect(alerts.length).toBeGreaterThan(0)
+    expect(wrapper.text()).toContain('建議曝光需達 3000 以上')
+    expect(wrapper.text()).toContain('平均觀看建議超過 10 秒')
+    expect(wrapper.text()).toContain('2 秒退出率建議低於 30%')
+  })
+})

--- a/client/src/views/popular-data/PopularData.vue
+++ b/client/src/views/popular-data/PopularData.vue
@@ -1,0 +1,164 @@
+<template>
+  <div class="popular-data">
+    <header class="popular-data__header">
+      <div>
+        <h1>爆款數據</h1>
+        <p class="subtitle">選擇客戶以檢視不同平台的爆款內容</p>
+      </div>
+      <span class="search">
+        <i class="pi pi-search"></i>
+        <InputText v-model="keyword" placeholder="搜尋客戶名稱" />
+      </span>
+    </header>
+
+    <section v-if="loading" class="loading">載入客戶中…</section>
+
+    <section v-else class="popular-data__content">
+      <p v-if="filteredClients.length === 0" class="empty">目前沒有符合條件的客戶</p>
+      <div v-else class="client-grid">
+        <Card v-for="client in filteredClients" :key="client._id" class="client-card">
+          <template #content>
+            <h2>{{ client.name }}</h2>
+            <p class="client-meta">{{ client.industry || '未設定產業' }}</p>
+            <Button label="選擇" icon="pi pi-chevron-right" class="p-button-rounded" @click="goToPlatforms(client)" />
+          </template>
+        </Card>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import Card from 'primevue/card'
+import InputText from 'primevue/inputtext'
+import Button from 'primevue/button'
+import { fetchClients } from '@/services/clients'
+
+const router = useRouter()
+const toast = useToast()
+
+const loading = ref(true)
+const keyword = ref('')
+const clients = ref([])
+
+const filteredClients = computed(() => {
+  const k = keyword.value.trim().toLowerCase()
+  if (!k) return clients.value
+  return clients.value.filter((client) => client.name?.toLowerCase().includes(k))
+})
+
+const loadClients = async () => {
+  loading.value = true
+  try {
+    clients.value = await fetchClients()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '載入失敗', detail: '無法取得客戶列表', life: 3000 })
+  } finally {
+    loading.value = false
+  }
+}
+
+const goToPlatforms = (client) => {
+  router.push({ name: 'PopularDataPlatforms', params: { clientId: client._id } })
+}
+
+onMounted(loadClients)
+</script>
+
+<style scoped>
+.popular-data {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.popular-data__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.popular-data__header h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.search {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  background: #fff;
+}
+
+.search i {
+  color: #9ca3af;
+}
+
+.loading {
+  text-align: center;
+  color: #6b7280;
+}
+
+.popular-data__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.client-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.client-card {
+  text-align: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.client-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.15);
+}
+
+.client-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  color: #111827;
+}
+
+.client-meta {
+  margin: 0 0 1rem;
+  color: #6b7280;
+}
+
+.empty {
+  text-align: center;
+  color: #9ca3af;
+}
+
+@media (max-width: 600px) {
+  .popular-data {
+    padding: 1.5rem;
+  }
+  .search {
+    width: 100%;
+    justify-content: center;
+  }
+}
+</style>

--- a/client/src/views/popular-data/PopularDataCardDialog.vue
+++ b/client/src/views/popular-data/PopularDataCardDialog.vue
@@ -1,0 +1,332 @@
+<template>
+  <div v-if="modelValue" class="dialog-wrapper">
+    <div class="dialog-mask" @click="close"></div>
+    <div class="dialog-panel">
+      <header class="dialog-header">
+        <h2>{{ form.title || '影片詳情' }}</h2>
+        <button class="icon-button" @click="close" aria-label="關閉">
+          <i class="pi pi-times"></i>
+        </button>
+      </header>
+
+      <section class="dialog-body">
+        <div class="field-group">
+          <label>發布日</label>
+          <input type="date" v-model="form.publishDate" disabled />
+        </div>
+        <div class="field-group" :class="{ 'metric-alert': alerts.dueDate }">
+          <label>截至日期</label>
+          <input type="date" v-model="form.dueDate" />
+          <small v-if="alerts.dueDate" class="alert-text">截至日期不可早於發布日</small>
+        </div>
+
+        <div class="metrics-grid">
+          <div class="metric" :class="{ 'metric-alert': alerts.exposure }">
+            <label>曝光數據</label>
+            <input type="number" min="0" v-model.number="form.exposure" />
+            <small v-if="alerts.exposure" class="alert-text">建議曝光需達 3000 以上</small>
+          </div>
+          <div class="metric" :class="{ 'metric-alert': alerts.viewCount }">
+            <label>觀看數</label>
+            <input type="number" min="0" v-model.number="form.viewCount" />
+            <small v-if="alerts.viewCount" class="alert-text">觀看數建議達 500 以上</small>
+          </div>
+          <div class="metric" :class="{ 'metric-alert': alerts.coverCtr }">
+            <label>封面點擊率 (%)</label>
+            <input type="number" min="0" max="100" step="0.1" v-model.number="form.coverCtr" />
+            <small v-if="alerts.coverCtr" class="alert-text">封面 CTR 建議 30% 以上</small>
+          </div>
+          <div class="metric" :class="{ 'metric-alert': alerts.avgWatchSeconds }">
+            <label>平均觀看秒數</label>
+            <input type="number" min="0" step="0.1" v-model.number="form.avgWatchSeconds" />
+            <small v-if="alerts.avgWatchSeconds" class="alert-text">平均觀看建議超過 10 秒</small>
+          </div>
+          <div class="metric" :class="{ 'metric-alert': alerts.completionRate }">
+            <label>完播率 (%)</label>
+            <input type="number" min="0" max="100" step="0.1" v-model.number="form.completionRate" />
+            <small v-if="alerts.completionRate" class="alert-text">完播率建議超過 10%</small>
+          </div>
+          <div class="metric" :class="{ 'metric-alert': alerts.twoSecondDropRate }">
+            <label>2 秒退出率 (%)</label>
+            <input type="number" min="0" max="100" step="0.1" v-model.number="form.twoSecondDropRate" />
+            <small v-if="alerts.twoSecondDropRate" class="alert-text">2 秒退出率建議低於 30%</small>
+          </div>
+        </div>
+
+        <div class="field-group">
+          <label>趨勢追蹤連結</label>
+          <input type="text" v-model="form.trendLink" placeholder="https://" />
+        </div>
+
+        <div class="field-group">
+          <label>提醒事項</label>
+          <textarea v-model="form.reminderNotes" rows="2" placeholder="記錄需要跟進的事項"></textarea>
+        </div>
+
+        <div class="field-group">
+          <label>復盤 / 修改意見</label>
+          <textarea v-model="form.reviewNotes" rows="4" placeholder="紀錄優化建議或心得"></textarea>
+        </div>
+      </section>
+
+      <footer class="dialog-footer">
+        <button class="secondary" @click="close">取消</button>
+        <button class="primary" @click="save">儲存變更</button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, reactive, watch } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  content: {
+    type: Object,
+    default: () => ({})
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'save'])
+
+const defaultForm = () => ({
+  title: '',
+  publishDate: '',
+  dueDate: '',
+  exposure: 0,
+  viewCount: 0,
+  coverCtr: 0,
+  avgWatchSeconds: 0,
+  completionRate: 0,
+  twoSecondDropRate: 0,
+  reviewNotes: '',
+  trendLink: '',
+  reminderNotes: ''
+})
+
+const form = reactive(defaultForm())
+
+const toDateInput = (value) => {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toISOString().split('T')[0]
+}
+
+const computeDueDate = (publishDate, dueDate) => {
+  if (dueDate) return toDateInput(dueDate)
+  if (!publishDate) return ''
+  const d = new Date(publishDate)
+  if (Number.isNaN(d.getTime())) return ''
+  d.setDate(d.getDate() + 7)
+  return d.toISOString().split('T')[0]
+}
+
+watch(
+  () => props.content,
+  (value) => {
+    const next = value || {}
+    form.title = next.title || ''
+    form.publishDate = toDateInput(next.publishDate)
+    form.dueDate = computeDueDate(next.publishDate, next.dueDate)
+    form.exposure = next.exposure ?? 0
+    form.viewCount = next.viewCount ?? 0
+    form.coverCtr = next.coverCtr ?? 0
+    form.avgWatchSeconds = next.avgWatchSeconds ?? 0
+    form.completionRate = next.completionRate ?? 0
+    form.twoSecondDropRate = next.twoSecondDropRate ?? 0
+    form.reviewNotes = next.reviewNotes || ''
+    form.trendLink = next.trendLink || ''
+    form.reminderNotes = next.reminderNotes || ''
+  },
+  { immediate: true }
+)
+
+const alerts = computed(() => {
+  const publishDate = form.publishDate ? new Date(form.publishDate) : null
+  const dueDate = form.dueDate ? new Date(form.dueDate) : null
+  const dueDateInvalid = publishDate && dueDate && dueDate.getTime() < publishDate.getTime()
+  return {
+    dueDate: Boolean(dueDateInvalid),
+    exposure: Number(form.exposure) < 3000,
+    viewCount: Number(form.viewCount) < 500,
+    coverCtr: Number(form.coverCtr) < 30,
+    avgWatchSeconds: Number(form.avgWatchSeconds) < 10,
+    completionRate: Number(form.completionRate) < 10,
+    twoSecondDropRate: Number(form.twoSecondDropRate) >= 30
+  }
+})
+
+const close = () => {
+  emit('update:modelValue', false)
+}
+
+const save = () => {
+  if (alerts.value.dueDate) return
+  emit('save', {
+    dueDate: form.dueDate ? new Date(form.dueDate).toISOString() : null,
+    exposure: Number(form.exposure) || 0,
+    viewCount: Number(form.viewCount) || 0,
+    coverCtr: Number(form.coverCtr) || 0,
+    avgWatchSeconds: Number(form.avgWatchSeconds) || 0,
+    completionRate: Number(form.completionRate) || 0,
+    twoSecondDropRate: Number(form.twoSecondDropRate) || 0,
+    reviewNotes: form.reviewNotes,
+    trendLink: form.trendLink,
+    reminderNotes: form.reminderNotes
+  })
+}
+</script>
+
+<style scoped>
+.dialog-wrapper {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1300;
+}
+
+.dialog-mask {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.dialog-panel {
+  position: relative;
+  width: min(640px, 95vw);
+  max-height: 90vh;
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  overflow-y: auto;
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dialog-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.icon-button {
+  border: none;
+  background: transparent;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: #6b7280;
+}
+
+.dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field-group label {
+  font-weight: 600;
+  color: #374151;
+}
+
+.field-group input,
+.field-group textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.field-group textarea {
+  resize: vertical;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.metric label {
+  font-weight: 600;
+  color: #374151;
+}
+
+.metric input {
+  border: 1px solid #d1d5db;
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+}
+
+.metric-alert label,
+.metric-alert input,
+.metric-alert textarea {
+  color: #b91c1c;
+  border-color: #f87171;
+}
+
+.alert-text {
+  color: #dc2626;
+  font-size: 0.85rem;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.dialog-footer .secondary,
+.dialog-footer .primary {
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+}
+
+.dialog-footer .secondary {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.dialog-footer .primary {
+  background: linear-gradient(135deg, #f97316, #fb7185);
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(251, 113, 133, 0.35);
+}
+
+.dialog-footer .primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/client/src/views/popular-data/PopularDataPlatforms.vue
+++ b/client/src/views/popular-data/PopularDataPlatforms.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="popular-platforms">
+    <header class="platforms-header">
+      <Button label="返回" icon="pi pi-arrow-left" class="p-button-text" @click="goBack" />
+      <div class="title-group">
+        <h1>{{ clientName || '選擇平台' }}</h1>
+        <p>請選擇要查看的爆款數據平台</p>
+      </div>
+    </header>
+
+    <section class="platforms-grid">
+      <Button label="TikTok" icon="pi pi-video" disabled class="platform-button platform-button--muted" />
+      <Button label="Facebook" icon="pi pi-facebook" disabled class="platform-button platform-button--muted" />
+      <Button label="小紅書" icon="pi pi-book" class="platform-button platform-button--active" @click="goXhs" />
+    </section>
+
+    <p class="hint">TikTok 與 Facebook 功能即將推出，敬請期待。</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import Button from 'primevue/button'
+import { getClient } from '@/services/clients'
+
+const props = defineProps({
+  clientId: {
+    type: String,
+    required: true
+  }
+})
+
+const router = useRouter()
+const route = useRoute()
+const clientName = ref(route.query.clientName || '')
+
+const goBack = () => {
+  router.push({ name: 'PopularDataClients' })
+}
+
+const goXhs = () => {
+  router.push({ name: 'PopularDataXhs', params: { clientId: props.clientId } })
+}
+
+onMounted(async () => {
+  if (!clientName.value) {
+    try {
+      const client = await getClient(props.clientId)
+      clientName.value = `${client.name}｜平台選擇`
+    } catch {
+      clientName.value = '平台選擇'
+    }
+  }
+})
+</script>
+
+<style scoped>
+.popular-platforms {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.platforms-header {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.title-group h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.title-group p {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.platforms-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.platform-button {
+  padding: 1.5rem 1rem;
+  border-radius: 1rem;
+  font-size: 1.25rem;
+}
+
+.platform-button--muted {
+  background: #f3f4f6 !important;
+  color: #9ca3af !important;
+  border: none !important;
+}
+
+.platform-button--active {
+  background: linear-gradient(135deg, #f87171, #f97316);
+  border: none;
+  color: #fff;
+  box-shadow: 0 15px 35px rgba(249, 115, 22, 0.25);
+}
+
+.platform-button--active:hover {
+  box-shadow: 0 20px 40px rgba(249, 115, 22, 0.35);
+}
+
+.hint {
+  color: #9ca3af;
+}
+</style>

--- a/client/src/views/popular-data/PopularDataXhs.vue
+++ b/client/src/views/popular-data/PopularDataXhs.vue
@@ -1,0 +1,412 @@
+<template>
+  <div class="popular-xhs">
+    <header class="xhs-header">
+      <Button label="返回平台" icon="pi pi-arrow-left" class="p-button-text" @click="goBack" />
+      <div class="title-group">
+        <h1>{{ clientName }}</h1>
+        <p>上傳小紅書爆款內容並追蹤關鍵指標</p>
+      </div>
+    </header>
+
+    <section class="upload-section">
+      <h2>新增影片</h2>
+      <div class="upload-grid">
+        <FileUpload
+          ref="fileUploadRef"
+          name="cover"
+          mode="basic"
+          :auto="false"
+          :customUpload="true"
+          accept="image/*"
+          chooseLabel="選擇封面截圖"
+          @select="handleFileSelect"
+          @clear="handleFileClear"
+        />
+        <input v-model="newVideo.title" type="text" placeholder="影片名稱" />
+        <input v-model="newVideo.publishDate" type="date" />
+        <Button label="儲存影片" icon="pi pi-save" class="p-button-rounded" @click="saveNewVideo" />
+      </div>
+      <p v-if="uploadError" class="error">{{ uploadError }}</p>
+    </section>
+
+    <section class="cards-section">
+      <header class="cards-header">
+        <h2>影片列表</h2>
+        <span class="hint">點擊卡片檢視與編輯指標</span>
+      </header>
+      <div v-if="loading" class="loading">載入小紅書爆款資料中…</div>
+      <p v-else-if="contents.length === 0" class="empty">目前尚未建立任何爆款紀錄</p>
+      <div v-else class="card-grid">
+        <article v-for="item in contents" :key="item._id" class="xhs-card" @click="openDialog(item)">
+          <div class="cover" :class="{ 'cover--empty': !item.coverUrl }">
+            <img v-if="item.coverUrl" :src="item.coverUrl" :alt="item.title" />
+            <span v-else>尚未上傳封面</span>
+          </div>
+          <div class="card-body">
+            <h3>{{ item.title }}</h3>
+            <p class="date">發布：{{ formatDate(item.publishDate) }}｜截止：{{ formatDate(item.dueDate) }}</p>
+            <ul class="metric-list">
+              <li>曝光：{{ formatNumber(item.exposure) }}</li>
+              <li>觀看：{{ formatNumber(item.viewCount) }}</li>
+              <li>CTR：{{ item.coverCtr ? item.coverCtr + '%' : '-' }}</li>
+            </ul>
+            <div v-if="item.trendLink" class="trend">趨勢連結：{{ item.trendLink }}</div>
+          </div>
+          <button class="delete-button" @click.stop="deleteContent(item)">
+            <i class="pi pi-trash"></i>
+          </button>
+        </article>
+      </div>
+    </section>
+
+    <PopularDataCardDialog
+      v-model="dialogVisible"
+      :content="activeContent"
+      @save="handleSave"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import Button from 'primevue/button'
+import FileUpload from 'primevue/fileupload'
+import { getClient } from '@/services/clients'
+import {
+  listPopularContents,
+  createPopularContent,
+  updatePopularContent,
+  deletePopularContent,
+  uploadPopularContentCover
+} from '@/services/popularData'
+import PopularDataCardDialog from './PopularDataCardDialog.vue'
+
+const props = defineProps({
+  clientId: {
+    type: String,
+    required: true
+  }
+})
+
+const router = useRouter()
+const toast = useToast()
+
+const clientName = ref('小紅書爆款數據')
+const fileUploadRef = ref(null)
+const newVideo = reactive({
+  title: '',
+  publishDate: '',
+  file: null
+})
+const uploadError = ref('')
+const loading = ref(true)
+const contents = ref([])
+const dialogVisible = ref(false)
+const activeContent = ref(null)
+
+const goBack = () => {
+  router.push({ name: 'PopularDataPlatforms', params: { clientId: props.clientId } })
+}
+
+const handleFileSelect = (event) => {
+  newVideo.file = event.files?.[0] || null
+}
+
+const handleFileClear = () => {
+  newVideo.file = null
+}
+
+const resetForm = () => {
+  newVideo.title = ''
+  newVideo.publishDate = ''
+  newVideo.file = null
+  uploadError.value = ''
+  fileUploadRef.value?.clear?.()
+}
+
+const loadContents = async () => {
+  loading.value = true
+  try {
+    const data = await listPopularContents(props.clientId, 'xhs')
+    contents.value = data.sort((a, b) => new Date(b.publishDate) - new Date(a.publishDate))
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '讀取失敗', detail: '無法取得爆款資料', life: 3000 })
+  } finally {
+    loading.value = false
+  }
+}
+
+const saveNewVideo = async () => {
+  if (!newVideo.title.trim()) {
+    uploadError.value = '請輸入影片名稱'
+    return
+  }
+  if (!newVideo.publishDate) {
+    uploadError.value = '請選擇發布日期'
+    return
+  }
+  if (!newVideo.file) {
+    uploadError.value = '請選擇封面截圖'
+    return
+  }
+
+  uploadError.value = ''
+  try {
+    const payload = {
+      platformKey: 'xhs',
+      title: newVideo.title,
+      publishDate: new Date(newVideo.publishDate).toISOString()
+    }
+    const created = await createPopularContent(props.clientId, payload)
+    await uploadPopularContentCover(props.clientId, created._id, newVideo.file)
+    toast.add({ severity: 'success', summary: '已建立', detail: '新影片已建立並上傳封面', life: 3000 })
+    resetForm()
+    await loadContents()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '建立失敗', detail: '請稍後再試', life: 3000 })
+  }
+}
+
+const openDialog = (item) => {
+  activeContent.value = { ...item }
+  dialogVisible.value = true
+}
+
+const handleSave = async (payload) => {
+  if (!activeContent.value) return
+  try {
+    const updated = await updatePopularContent(props.clientId, activeContent.value._id, payload)
+    toast.add({ severity: 'success', summary: '已更新', detail: '影片指標已更新', life: 3000 })
+    dialogVisible.value = false
+    contents.value = contents.value.map((item) => (item._id === updated._id ? updated : item))
+    activeContent.value = null
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '更新失敗', detail: '指標儲存失敗', life: 3000 })
+  }
+}
+
+const deleteContent = async (item) => {
+  const confirmDelete = window.confirm(`確定刪除「${item.title}」嗎？`)
+  if (!confirmDelete) return
+  try {
+    await deletePopularContent(props.clientId, item._id)
+    toast.add({ severity: 'success', summary: '已刪除', detail: '影片紀錄已刪除', life: 3000 })
+    contents.value = contents.value.filter((content) => content._id !== item._id)
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '刪除失敗', detail: '無法刪除影片', life: 3000 })
+  }
+}
+
+const formatDate = (value) => {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '-'
+  return date.toLocaleDateString('zh-TW')
+}
+
+const formatNumber = (value) => {
+  const num = Number(value)
+  if (!num) return '0'
+  return Intl.NumberFormat('zh-TW').format(num)
+}
+
+onMounted(async () => {
+  try {
+    const client = await getClient(props.clientId)
+    clientName.value = `${client.name}｜小紅書爆款` || '小紅書爆款數據'
+  } catch {
+    clientName.value = '小紅書爆款數據'
+  }
+  await loadContents()
+})
+</script>
+
+<style scoped>
+.popular-xhs {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.xhs-header {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.title-group h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.title-group p {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.upload-section {
+  background: #fff7ed;
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 45px rgba(249, 115, 22, 0.15);
+}
+
+.upload-section h2 {
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+  color: #fb7185;
+}
+
+.upload-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  align-items: end;
+}
+
+.upload-grid input[type='text'],
+.upload-grid input[type='date'] {
+  border: 1px solid #fbd1b8;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.error {
+  margin-top: 1rem;
+  color: #dc2626;
+}
+
+.cards-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cards-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.cards-header h2 {
+  margin: 0;
+}
+
+.hint {
+  color: #9ca3af;
+}
+
+.loading {
+  color: #6b7280;
+}
+
+.empty {
+  color: #9ca3af;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.xhs-card {
+  position: relative;
+  background: #ffffff;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.15);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.xhs-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.25);
+}
+
+.cover {
+  height: 180px;
+  background: linear-gradient(135deg, #fde68a, #f97316);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover--empty {
+  color: #fff7ed;
+  font-weight: 600;
+}
+
+.card-body {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card-body h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.date {
+  color: #6b7280;
+}
+
+.metric-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  color: #374151;
+}
+
+.trend {
+  color: #f97316;
+  word-break: break-all;
+}
+
+.delete-button {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  border: none;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  border-radius: 999px;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.delete-button:hover {
+  background: rgba(220, 38, 38, 0.85);
+}
+
+@media (max-width: 600px) {
+  .popular-xhs {
+    padding: 1.5rem;
+  }
+}
+</style>

--- a/server/src/config/menus.js
+++ b/server/src/config/menus.js
@@ -6,6 +6,7 @@ export const MENUS = Object.freeze({
   ROLES: 'roles',
   TAGS: 'tags',
   REVIEW_STAGES: 'review-stages',
+  POPULAR_DATA: 'popular-data',
   AD_DATA: 'ad-data',
   ACCOUNT: 'account'
 })

--- a/server/src/controllers/popularContent.controller.js
+++ b/server/src/controllers/popularContent.controller.js
@@ -1,0 +1,219 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { validationResult } from 'express-validator'
+import { t } from '../i18n/messages.js'
+import PopularContent from '../models/popularContent.model.js'
+import { uploadFile, getSignedUrl } from '../utils/gcs.js'
+import { decodeFilename } from '../utils/decodeFilename.js'
+import { getCache, setCache, delCache, clearCacheByPrefix } from '../utils/cache.js'
+
+const CACHE_PREFIX = 'popularContent:'
+const listCacheKey = (clientId, platformKey = 'all') => `${CACHE_PREFIX}list:${clientId}:${platformKey}`
+const itemCacheKey = (contentId) => `${CACHE_PREFIX}item:${contentId}`
+
+const ensureClientAccess = (req) => {
+  const allowed = req.user?.allowedClients || []
+  if (!allowed.length) return true
+  return allowed.some((id) => String(id) === String(req.params.clientId))
+}
+
+const toNumber = (value) => {
+  if (value === undefined || value === null || value === '') return undefined
+  const num = Number(value)
+  return Number.isNaN(num) ? undefined : num
+}
+
+const buildPayload = (body, options = {}) => {
+  const payload = {}
+  if (body.title !== undefined) payload.title = body.title
+  if (body.platformKey !== undefined) payload.platformKey = body.platformKey
+  if (body.publishDate !== undefined) {
+    const publish = new Date(body.publishDate)
+    if (!Number.isNaN(publish.getTime())) payload.publishDate = publish
+  }
+  if (body.dueDate !== undefined) {
+    const due = new Date(body.dueDate)
+    if (!Number.isNaN(due.getTime())) payload.dueDate = due
+  }
+  const fields = [
+    'exposure',
+    'viewCount',
+    'coverCtr',
+    'avgWatchSeconds',
+    'completionRate',
+    'twoSecondDropRate'
+  ]
+  for (const field of fields) {
+    const num = toNumber(body[field])
+    if (num !== undefined) payload[field] = num
+  }
+  if (body.reviewNotes !== undefined) payload.reviewNotes = body.reviewNotes
+  if (body.trendLink !== undefined) payload.trendLink = body.trendLink
+  if (body.reminderNotes !== undefined) payload.reminderNotes = body.reminderNotes
+
+  if (!payload.dueDate && payload.publishDate && options.forceDueDate) {
+    const due = new Date(payload.publishDate)
+    due.setDate(due.getDate() + 7)
+    payload.dueDate = due
+  }
+  return payload
+}
+
+const appendCoverUrl = async (doc) => {
+  if (!doc) return doc
+  const obj = doc.toObject ? doc.toObject() : { ...doc }
+  if (obj.coverPath) {
+    try {
+      obj.coverUrl = await getSignedUrl(obj.coverPath)
+    } catch {
+      obj.coverUrl = ''
+    }
+  } else {
+    obj.coverUrl = ''
+  }
+  return obj
+}
+
+export const listPopularContents = async (req, res) => {
+  if (!ensureClientAccess(req)) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+  const platformKey = req.query.platformKey || 'all'
+  const cacheKey = listCacheKey(req.params.clientId, platformKey)
+  const cached = await getCache(cacheKey)
+  if (cached) {
+    const withCovers = await Promise.all(cached.map((item) => appendCoverUrl(item)))
+    return res.json(withCovers)
+  }
+  const query = { clientId: req.params.clientId }
+  if (req.query.platformKey) query.platformKey = req.query.platformKey
+  const docs = await PopularContent.find(query).sort({ publishDate: -1 })
+  const plain = docs.map((doc) => doc.toObject())
+  await setCache(cacheKey, plain)
+  const withCovers = await Promise.all(plain.map((item) => appendCoverUrl(item)))
+  res.json(withCovers)
+}
+
+export const createPopularContent = async (req, res) => {
+  if (!ensureClientAccess(req)) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR'), errors: errors.array() })
+  }
+  const publishDate = new Date(req.body.publishDate)
+  const dueDate = req.body.dueDate ? new Date(req.body.dueDate) : new Date(publishDate)
+  if (!req.body.dueDate) dueDate.setDate(dueDate.getDate() + 7)
+  const payload = {
+    clientId: req.params.clientId,
+    platformKey: req.body.platformKey,
+    title: req.body.title,
+    publishDate,
+    dueDate,
+    reviewNotes: req.body.reviewNotes || '',
+    trendLink: req.body.trendLink || '',
+    reminderNotes: req.body.reminderNotes || ''
+  }
+  const numericPayload = buildPayload(req.body)
+  Object.assign(payload, numericPayload)
+  const created = await PopularContent.create(payload)
+  await clearCacheByPrefix(`${CACHE_PREFIX}list:${req.params.clientId}`)
+  const response = await appendCoverUrl(created)
+  res.status(201).json(response)
+}
+
+export const getPopularContent = async (req, res) => {
+  if (!ensureClientAccess(req)) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR'), errors: errors.array() })
+  }
+  const cacheKey = itemCacheKey(req.params.contentId)
+  const cached = await getCache(cacheKey)
+  if (cached) {
+    const withCover = await appendCoverUrl(cached)
+    return res.json(withCover)
+  }
+  const doc = await PopularContent.findOne({
+    _id: req.params.contentId,
+    clientId: req.params.clientId
+  })
+  if (!doc) return res.status(404).json({ message: t('RECORD_NOT_FOUND') })
+  await setCache(cacheKey, doc.toObject())
+  const withCover = await appendCoverUrl(doc)
+  res.json(withCover)
+}
+
+export const updatePopularContent = async (req, res) => {
+  if (!ensureClientAccess(req)) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR'), errors: errors.array() })
+  }
+  const update = buildPayload(req.body, { forceDueDate: Boolean(req.body.publishDate) })
+  const doc = await PopularContent.findOneAndUpdate(
+    { _id: req.params.contentId, clientId: req.params.clientId },
+    { $set: update },
+    { new: true }
+  )
+  if (!doc) return res.status(404).json({ message: t('RECORD_NOT_FOUND') })
+  await clearCacheByPrefix(`${CACHE_PREFIX}list:${req.params.clientId}`)
+  await delCache(itemCacheKey(req.params.contentId))
+  const response = await appendCoverUrl(doc)
+  res.json(response)
+}
+
+export const deletePopularContent = async (req, res) => {
+  if (!ensureClientAccess(req)) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR'), errors: errors.array() })
+  }
+  await PopularContent.findOneAndDelete({
+    _id: req.params.contentId,
+    clientId: req.params.clientId
+  })
+  await clearCacheByPrefix(`${CACHE_PREFIX}list:${req.params.clientId}`)
+  await delCache(itemCacheKey(req.params.contentId))
+  res.json({ message: t('RECORD_DELETED') })
+}
+
+export const uploadPopularContentCover = async (req, res) => {
+  if (!ensureClientAccess(req)) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR'), errors: errors.array() })
+  }
+  if (!req.file) {
+    return res.status(400).json({ message: t('FILE_NOT_UPLOADED') })
+  }
+  const doc = await PopularContent.findOne({
+    _id: req.params.contentId,
+    clientId: req.params.clientId
+  })
+  if (!doc) {
+    await fs.unlink(req.file.path)
+    return res.status(404).json({ message: t('RECORD_NOT_FOUND') })
+  }
+  const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`
+  const originalName = decodeFilename(req.file.originalname)
+  const ext = path.extname(originalName)
+  const destination = `popular-content/${req.params.clientId}/${unique}${ext}`
+  await uploadFile(req.file.path, destination, req.file.mimetype)
+  await fs.unlink(req.file.path)
+  doc.coverPath = destination
+  await doc.save()
+  await clearCacheByPrefix(`${CACHE_PREFIX}list:${req.params.clientId}`)
+  await delCache(itemCacheKey(req.params.contentId))
+  const response = await appendCoverUrl(doc)
+  res.json(response)
+}

--- a/server/src/models/popularContent.model.js
+++ b/server/src/models/popularContent.model.js
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose'
+
+const popularContentSchema = new mongoose.Schema(
+  {
+    clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true },
+    platformKey: { type: String, required: true },
+    title: { type: String, required: true },
+    publishDate: { type: Date, required: true },
+    dueDate: { type: Date, required: true },
+    coverPath: { type: String, default: '' },
+    exposure: { type: Number, default: 0 },
+    viewCount: { type: Number, default: 0 },
+    coverCtr: { type: Number, default: 0 },
+    avgWatchSeconds: { type: Number, default: 0 },
+    completionRate: { type: Number, default: 0 },
+    twoSecondDropRate: { type: Number, default: 0 },
+    reviewNotes: { type: String, default: '' },
+    trendLink: { type: String, default: '' },
+    reminderNotes: { type: String, default: '' }
+  },
+  { timestamps: true }
+)
+
+popularContentSchema.index({ clientId: 1, platformKey: 1, publishDate: -1 })
+
+export default mongoose.model('PopularContent', popularContentSchema)

--- a/server/src/routes/popularContent.routes.js
+++ b/server/src/routes/popularContent.routes.js
@@ -1,0 +1,63 @@
+import { Router } from 'express'
+import { body, param } from 'express-validator'
+import { protect } from '../middleware/auth.js'
+import { upload } from '../middleware/upload.js'
+import asyncHandler from '../utils/asyncHandler.js'
+import {
+  listPopularContents,
+  createPopularContent,
+  getPopularContent,
+  updatePopularContent,
+  deletePopularContent,
+  uploadPopularContentCover
+} from '../controllers/popularContent.controller.js'
+
+const router = Router({ mergeParams: true })
+
+router.use(protect)
+
+router
+  .route('/')
+  .get(asyncHandler(listPopularContents))
+  .post(
+    [
+      body('title').notEmpty(),
+      body('platformKey').notEmpty(),
+      body('publishDate').notEmpty(),
+      body('exposure').optional().isNumeric(),
+      body('viewCount').optional().isNumeric(),
+      body('coverCtr').optional().isNumeric(),
+      body('avgWatchSeconds').optional().isNumeric(),
+      body('completionRate').optional().isNumeric(),
+      body('twoSecondDropRate').optional().isNumeric()
+    ],
+    asyncHandler(createPopularContent)
+  )
+
+router
+  .route('/:contentId')
+  .get([param('contentId').isMongoId()], asyncHandler(getPopularContent))
+  .put(
+    [
+      param('contentId').isMongoId(),
+      body('dueDate').optional().isISO8601(),
+      body('publishDate').optional().isISO8601(),
+      body('exposure').optional().isNumeric(),
+      body('viewCount').optional().isNumeric(),
+      body('coverCtr').optional().isNumeric(),
+      body('avgWatchSeconds').optional().isNumeric(),
+      body('completionRate').optional().isNumeric(),
+      body('twoSecondDropRate').optional().isNumeric()
+    ],
+    asyncHandler(updatePopularContent)
+  )
+  .delete([param('contentId').isMongoId()], asyncHandler(deletePopularContent))
+
+router.post(
+  '/:contentId/cover',
+  [param('contentId').isMongoId()],
+  upload.single('cover'),
+  asyncHandler(uploadPopularContentCover)
+)
+
+export default router

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -34,6 +34,7 @@ const seed = async () => {
           MENUS.DASHBOARD,
           MENUS.ASSETS,
           MENUS.PRODUCTS,
+          MENUS.POPULAR_DATA,
           MENUS.ACCOUNT
         ]
       },

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -87,6 +87,7 @@ import adDailyRoutes      from './routes/adDaily.routes.js'
 import weeklyNoteRoutes   from './routes/weeklyNote.routes.js'
 import dashboardRoutes    from './routes/dashboard.routes.js'
 import departmentRoutes   from './routes/department.routes.js'
+import popularContentRoutes from './routes/popularContent.routes.js'
 
 app.use('/api/auth',     authRoutes)
 app.use('/api/user',     userRoutes)
@@ -101,6 +102,7 @@ app.use('/api/clients/:clientId/platforms', platformRoutes)
 app.use('/api/platforms', platformTransferRoutes)
 app.use('/api/clients/:clientId/platforms/:platformId/ad-daily', adDailyRoutes)
 app.use('/api/clients/:clientId/platforms/:platformId/weekly-notes', weeklyNoteRoutes)
+app.use('/api/clients/:clientId/popular-contents', popularContentRoutes)
 app.use('/api/permissions', permissionsRoutes)
 app.use('/api/menus', menusRoutes)
 app.use('/api/review-stages', reviewStageRoutes)

--- a/server/tests/popularContent.controller.test.js
+++ b/server/tests/popularContent.controller.test.js
@@ -1,0 +1,168 @@
+import { jest, describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals'
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+let clientId
+let uploadFileMock
+let getSignedUrlMock
+let Role
+let User
+let Client
+
+beforeAll(async () => {
+  jest.unstable_mockModule('../src/utils/gcs.js', () => ({
+    uploadFile: jest.fn().mockResolvedValue('popular-content/cover.png'),
+    getSignedUrl: jest.fn().mockImplementation((p) => `https://signed.example.com/${p}`)
+  }))
+
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  const [{ default: popularRoutes }, { default: authRoutes }, { default: clientRoutes }] = await Promise.all([
+    import('../src/routes/popularContent.routes.js'),
+    import('../src/routes/auth.routes.js'),
+    import('../src/routes/client.routes.js')
+  ])
+
+  const gcs = await import('../src/utils/gcs.js')
+  uploadFileMock = gcs.uploadFile
+  getSignedUrlMock = gcs.getSignedUrl
+
+  ;[{ default: User }, { default: Role }, { default: Client }] = await Promise.all([
+    import('../src/models/user.model.js'),
+    import('../src/models/role.model.js'),
+    import('../src/models/client.model.js')
+  ])
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/clients', clientRoutes)
+  app.use('/api/clients/:clientId/popular-contents', popularRoutes)
+
+  const role = await Role.create({ name: 'manager', menus: ['popular-data'] })
+  await User.create({ username: 'admin', password: 'pwd', email: 'admin@test.com', roleId: role._id })
+
+  const loginRes = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'admin', password: 'pwd' })
+
+  token = loginRes.body.token
+  const client = await Client.create({ name: '測試客戶' })
+  clientId = client._id.toString()
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+beforeEach(() => {
+  uploadFileMock.mockClear()
+  getSignedUrlMock.mockClear()
+})
+
+describe('Popular Content API', () => {
+  let contentId
+
+  it('建立爆款內容並預設截至日期', async () => {
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/popular-contents`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ platformKey: 'xhs', title: '影片一', publishDate: '2024-01-01T00:00:00.000Z' })
+      .expect(201)
+
+    contentId = res.body._id
+    expect(res.body.title).toBe('影片一')
+    const publish = new Date('2024-01-01T00:00:00.000Z')
+    const due = new Date(res.body.dueDate)
+    expect(Math.round((due - publish) / (1000 * 60 * 60 * 24))).toBe(7)
+  })
+
+  it('上傳封面並回傳簽名網址', async () => {
+    const coverPath = path.join(process.cwd(), 'server', 'tests', 'fixtures', 'cover.png')
+    await fs.mkdir(path.dirname(coverPath), { recursive: true })
+    await fs.writeFile(coverPath, 'cover')
+
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/popular-contents/${contentId}/cover`)
+      .set('Authorization', `Bearer ${token}`)
+      .attach('cover', coverPath)
+      .expect(200)
+
+    await fs.unlink(coverPath)
+
+    expect(uploadFileMock).toHaveBeenCalled()
+    expect(getSignedUrlMock).toHaveBeenCalled()
+    expect(res.body.coverUrl).toContain('https://signed.example.com/')
+  })
+
+  it('更新指標資料', async () => {
+    const res = await request(app)
+      .put(`/api/clients/${clientId}/popular-contents/${contentId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ exposure: 5200, viewCount: 1200 })
+      .expect(200)
+
+    expect(res.body.exposure).toBe(5200)
+    expect(res.body.viewCount).toBe(1200)
+  })
+
+  it('列出爆款內容', async () => {
+    const res = await request(app)
+      .get(`/api/clients/${clientId}/popular-contents?platformKey=xhs`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(res.body.length).toBe(1)
+    expect(res.body[0].coverUrl).toContain('https://signed.example.com/')
+  })
+
+  it('刪除爆款內容', async () => {
+    await request(app)
+      .delete(`/api/clients/${clientId}/popular-contents/${contentId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    const res = await request(app)
+      .get(`/api/clients/${clientId}/popular-contents`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(res.body).toHaveLength(0)
+  })
+
+  it('拒絕未授權客戶的請求', async () => {
+    const otherClient = await Client.create({ name: '其他客戶' })
+    const role = await Role.create({ name: 'staff' })
+    await User.create({
+      username: 'limited',
+      password: 'pwd',
+      email: 'limit@test.com',
+      roleId: role._id,
+      allowedClients: [otherClient._id]
+    })
+
+    const login = await request(app)
+      .post('/api/auth/login')
+      .send({ username: 'limited', password: 'pwd' })
+
+    const limitedToken = login.body.token
+
+    await request(app)
+      .get(`/api/clients/${clientId}/popular-contents`)
+      .set('Authorization', `Bearer ${limitedToken}`)
+      .expect(403)
+  })
+})


### PR DESCRIPTION
## Summary
- 新增爆款數據選單、路由與三層頁面，實作客戶列表、平台選擇與小紅書內容管理流程。
- 建立 popularData service、卡片指標對話框與警示邏輯，支援封面上傳與指標編輯。
- 後端新增 PopularContent 資料模型、路由與控制器，整合快取清除與授權驗證，並撰寫前後端測試。

## Testing
- npm --prefix client test -- run src/views/PopularData.test.js
- npm --prefix server test *(失敗：環境缺少 jest 指令)*

------
https://chatgpt.com/codex/tasks/task_e_68db742e913483299df3de105c04d627