### PR TITLE
feat: 新增腳本創意管理模組

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -113,6 +113,7 @@ const mainMenuItems = computed(() => [
       : null
   },
   { path: '/popular-data', label: '爆款数据', icon: 'pi pi-bolt', badge: null },
+  { path: '/script-ideas', label: '腳本創意', icon: 'pi pi-pencil', badge: null },
 
   // { path: '/ad-data', label: '广告数据', icon: 'pi pi-chart-line', badge: null }
 ])

--- a/client/src/menuNames.js
+++ b/client/src/menuNames.js
@@ -10,5 +10,6 @@ export const MENU_NAMES = {
   'popular-data': '爆款数据',
   'ad-data': '广告数据',
   'ad-platforms': '平台設定',
+  'script-ideas': '腳本創意',
   account: '帐号资讯'
 }

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -20,6 +20,9 @@ import UserClientAccess from '../views/UserClientAccess.vue'
 import PopularDataClients from '../views/popular-data/PopularData.vue'
 import PopularDataPlatforms from '../views/popular-data/PopularDataPlatforms.vue'
 import PopularDataXhs from '../views/popular-data/PopularDataXhs.vue'
+import ScriptIdeas from '../views/script-ideas/ScriptIdeas.vue'
+import ScriptIdeasRecords from '../views/script-ideas/ScriptIdeasRecords.vue'
+import ScriptIdeasDetail from '../views/script-ideas/ScriptIdeasDetail.vue'
 
 
 const routes = [
@@ -61,6 +64,42 @@ const routes = [
         component: PopularDataXhs,
         props: true,
         meta: { menu: 'popular-data' }
+      },
+
+      {
+        path: 'script-ideas',
+        component: { template: '<router-view />' },
+        meta: { menu: 'script-ideas' },
+        children: [
+          {
+            path: '',
+            name: 'ScriptIdeasClients',
+            component: ScriptIdeas,
+            meta: { menu: 'script-ideas' }
+          },
+          {
+            path: ':clientId',
+            component: { template: '<router-view />' },
+            props: true,
+            meta: { menu: 'script-ideas' },
+            children: [
+              {
+                path: '',
+                name: 'ScriptIdeasRecords',
+                component: ScriptIdeasRecords,
+                props: true,
+                meta: { menu: 'script-ideas' }
+              },
+              {
+                path: 'records/:recordId',
+                name: 'ScriptIdeasDetail',
+                component: ScriptIdeasDetail,
+                props: true,
+                meta: { menu: 'script-ideas' }
+              }
+            ]
+          }
+        ]
       },
 
       { path: 'employees', name: 'EmployeeManager', component: EmployeeManager, meta: { menu: 'employees' } },

--- a/client/src/services/scriptIdeas.js
+++ b/client/src/services/scriptIdeas.js
@@ -1,0 +1,62 @@
+import api from './api'
+
+export const SCRIPT_IDEA_STATUS = Object.freeze({
+  PENDING: 'pending',
+  APPROVED: 'approved',
+  REVISION: 'revision'
+})
+
+const toFormData = (data = {}) => {
+  const formData = new FormData()
+  Object.entries(data).forEach(([key, value]) => {
+    if (value === undefined || value === null) return
+    if (Array.isArray(value)) {
+      value.forEach((item) => formData.append(key, item))
+      return
+    }
+    formData.append(key, value)
+  })
+  return formData
+}
+
+export const listScriptIdeas = (clientId, params = {}) =>
+  api
+    .get(`/clients/${clientId}/script-ideas`, { params })
+    .then((res) => res.data)
+
+export const createScriptIdea = (clientId, payload) => {
+  const formData = toFormData(payload)
+  return api
+    .post(`/clients/${clientId}/script-ideas`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    .then((res) => res.data)
+}
+
+export const updateScriptIdea = (clientId, ideaId, payload) => {
+  const formData = toFormData(payload)
+  return api
+    .put(`/clients/${clientId}/script-ideas/${ideaId}`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    .then((res) => res.data)
+}
+
+export const deleteScriptIdea = (clientId, ideaId) =>
+  api
+    .delete(`/clients/${clientId}/script-ideas/${ideaId}`)
+    .then((res) => res.data)
+
+export const getScriptIdea = (clientId, ideaId) =>
+  api
+    .get(`/clients/${clientId}/script-ideas/${ideaId}`)
+    .then((res) => res.data)
+
+export const uploadScriptIdeaVideo = (clientId, ideaId, file, extra = {}) => {
+  const formData = toFormData({ ...extra, video: file })
+  return api
+    .post(`/clients/${clientId}/script-ideas/${ideaId}/video`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    .then((res) => res.data)
+}

--- a/client/src/test/setup.js
+++ b/client/src/test/setup.js
@@ -1,0 +1,8 @@
+import { vi } from 'vitest'
+
+vi.mock('primevue/useconfirm', () => ({
+  useConfirm: () => ({
+    require: vi.fn(),
+    close: vi.fn()
+  })
+}))

--- a/client/src/views/script-ideas/ScriptIdeas.test.js
+++ b/client/src/views/script-ideas/ScriptIdeas.test.js
@@ -1,0 +1,395 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { defineComponent, h } from 'vue'
+
+const toastMock = { add: vi.fn() }
+vi.mock('primevue/usetoast', () => ({ useToast: () => toastMock }))
+
+const clientsModuleMock = vi.hoisted(() => ({
+  fetchClients: vi.fn(() => Promise.resolve([])),
+  getClient: vi.fn(() => Promise.resolve({ name: '客戶' }))
+}))
+vi.mock('@/services/clients', () => clientsModuleMock)
+
+const scriptIdeasModuleMock = vi.hoisted(() => ({
+  listScriptIdeas: vi.fn(() => Promise.resolve([])),
+  createScriptIdea: vi.fn(() => Promise.resolve({})),
+  updateScriptIdea: vi.fn(() => Promise.resolve({})),
+  deleteScriptIdea: vi.fn(() => Promise.resolve({})),
+  getScriptIdea: vi.fn(() => Promise.resolve({
+    _id: 'idea-1',
+    clientId: 'client-1',
+    summaryScript: '原始腳本',
+    headline: '原始標題',
+    videoUrl: '',
+    videoName: ''
+  }))
+}))
+vi.mock('@/services/scriptIdeas', () => ({
+  ...scriptIdeasModuleMock,
+  SCRIPT_IDEA_STATUS: { PENDING: 'pending', APPROVED: 'approved', REVISION: 'revision' }
+}))
+
+const {
+  fetchClients: fetchClientsMock,
+  getClient: getClientMock
+} = clientsModuleMock
+
+const {
+  listScriptIdeas: listScriptIdeasMock,
+  createScriptIdea: createScriptIdeaMock,
+  updateScriptIdea: updateScriptIdeaMock,
+  deleteScriptIdea: deleteScriptIdeaMock,
+  getScriptIdea: getScriptIdeaMock
+} = scriptIdeasModuleMock
+
+const ButtonStub = defineComponent({
+  name: 'Button',
+  props: ['label', 'icon', 'severity', 'disabled', 'loading'],
+  emits: ['click'],
+  setup(props, { emit, slots, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          'data-label': props.label,
+          'data-icon': props.icon,
+          disabled: props.disabled || attrs.disabled || props.loading,
+          onClick: (event) => {
+            if (props.disabled || attrs.disabled || props.loading) return
+            emit('click', event)
+            attrs.onClick?.(event)
+          }
+        },
+        slots.default ? slots.default() : props.label
+      )
+  }
+})
+
+const InputTextStub = defineComponent({
+  name: 'InputText',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h('input', {
+        ...attrs,
+        value: props.modelValue ?? '',
+        onInput: (event) => emit('update:modelValue', event.target.value)
+      })
+  }
+})
+
+const TextareaStub = defineComponent({
+  name: 'Textarea',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h('textarea', {
+        ...attrs,
+        value: props.modelValue ?? '',
+        onInput: (event) => emit('update:modelValue', event.target.value)
+      })
+  }
+})
+
+const DropdownStub = defineComponent({
+  name: 'Dropdown',
+  props: ['modelValue', 'options', 'optionLabel', 'optionValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h(
+        'select',
+        {
+          ...attrs,
+          value: props.modelValue ?? '',
+          onChange: (event) => emit('update:modelValue', event.target.value)
+        },
+        (props.options || []).map((option) =>
+          h('option', { value: option[props.optionValue || 'value'] }, option[props.optionLabel || 'label'])
+        )
+      )
+  }
+})
+
+const InputNumberStub = defineComponent({
+  name: 'InputNumber',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h('input', {
+        ...attrs,
+        type: 'number',
+        value: props.modelValue ?? 0,
+        onInput: (event) => emit('update:modelValue', Number(event.target.value))
+      })
+  }
+})
+
+const CalendarStub = defineComponent({
+  name: 'Calendar',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h('input', {
+        ...attrs,
+        type: 'date',
+        value: props.modelValue ? new Date(props.modelValue).toISOString().slice(0, 10) : '',
+        onInput: (event) => emit('update:modelValue', new Date(event.target.value))
+      })
+  }
+})
+
+const DialogStub = defineComponent({
+  name: 'Dialog',
+  props: ['visible'],
+  emits: ['update:visible'],
+  setup(props, { slots }) {
+    return () => (props.visible ? h('div', { class: 'dialog-stub' }, [slots.default?.(), slots.footer?.()]) : null)
+  }
+})
+
+const CardStub = defineComponent({
+  name: 'Card',
+  setup(_, { slots }) {
+    return () => h('section', { class: 'card-stub' }, [slots.title?.(), slots.content?.()])
+  }
+})
+
+const DataTableStub = defineComponent({
+  name: 'DataTable',
+  props: ['value'],
+  setup(props) {
+    return () =>
+      h(
+        'div',
+        { class: 'datatable-stub' },
+        (props.value || []).map((row) => h('div', { class: 'datatable-row' }, JSON.stringify(row)))
+      )
+  }
+})
+
+const ColumnStub = defineComponent({ name: 'Column' })
+
+const TagStub = defineComponent({
+  name: 'Tag',
+  props: ['value'],
+  setup(props) {
+    return () => h('span', { class: 'tag-stub' }, props.value)
+  }
+})
+
+const FileUploadStub = defineComponent({
+  name: 'FileUpload',
+  emits: ['select', 'remove', 'update:files'],
+  setup(_, { slots, emit }) {
+    return () =>
+      h('div', { class: 'file-upload-stub' }, [
+        h(
+          'button',
+          {
+            type: 'button',
+            'data-action': 'select',
+            onClick: () => {
+              const files = [{ name: 'demo.mp4' }]
+              emit('update:files', files)
+              emit('select', { files })
+            }
+          },
+          '選擇檔案'
+        ),
+        slots.empty?.()
+      ])
+  }
+})
+
+const globalStubs = {
+  Button: ButtonStub,
+  InputText: InputTextStub,
+  Textarea: TextareaStub,
+  Dropdown: DropdownStub,
+  InputNumber: InputNumberStub,
+  Calendar: CalendarStub,
+  Dialog: DialogStub,
+  Card: CardStub,
+  DataTable: DataTableStub,
+  Column: ColumnStub,
+  Tag: TagStub,
+  FileUpload: FileUploadStub
+}
+
+const createTestRouter = async (initialRoute = '/') => {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'ScriptIdeasClients', component: { template: '<div />' } },
+      { path: '/script-ideas/:clientId', name: 'ScriptIdeasRecords', component: { template: '<div />' } },
+      { path: '/script-ideas/:clientId/records/:recordId', name: 'ScriptIdeasDetail', component: { template: '<div />' } }
+    ]
+  })
+  await router.push(initialRoute)
+  await router.isReady()
+  return router
+}
+
+import ScriptIdeas from './ScriptIdeas.vue'
+import ScriptIdeasRecords from './ScriptIdeasRecords.vue'
+import ScriptIdeasDetail from './ScriptIdeasDetail.vue'
+
+describe('ScriptIdeas 客戶列表', () => {
+  beforeEach(() => {
+    fetchClientsMock.mockReset()
+    toastMock.add.mockClear()
+  })
+
+  it('載入客戶並能搜尋與導航', async () => {
+    fetchClientsMock.mockResolvedValueOnce([
+      { _id: 'c1', name: '星光企業' },
+      { _id: 'c2', name: '晨曦品牌' }
+    ])
+
+    const router = await createTestRouter()
+    const pushSpy = vi.spyOn(router, 'push')
+    const wrapper = mount(ScriptIdeas, { global: { plugins: [router], stubs: globalStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('星光企業')
+    expect(wrapper.text()).toContain('晨曦品牌')
+
+    const searchInput = wrapper.find('input')
+    await searchInput.setValue('晨曦')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('晨曦品牌')
+    expect(wrapper.text()).not.toContain('星光企業')
+
+    const manageButton = wrapper.find('button[data-label="管理腳本"]')
+    await manageButton.trigger('click')
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'ScriptIdeasRecords', params: { clientId: 'c2' } })
+  })
+})
+
+describe('ScriptIdeasRecords 管理腳本記錄', () => {
+  beforeEach(() => {
+    listScriptIdeasMock.mockReset()
+    createScriptIdeaMock.mockReset()
+    updateScriptIdeaMock.mockReset()
+    deleteScriptIdeaMock.mockReset()
+    getClientMock.mockReset()
+    toastMock.add.mockClear()
+  })
+
+  it('可以新增與刪除腳本記錄', async () => {
+    getClientMock.mockResolvedValueOnce({ _id: 'client-1', name: '影片客戶' })
+    listScriptIdeasMock
+      .mockResolvedValueOnce([
+        { _id: 'idea-1', date: '2024-01-02T00:00:00.000Z', location: '台北', scriptCount: 3, status: 'pending' }
+      ])
+      .mockResolvedValueOnce([
+        { _id: 'idea-1', date: '2024-01-02T00:00:00.000Z', location: '台北', scriptCount: 3, status: 'pending' },
+        { _id: 'idea-2', date: '2024-01-05T00:00:00.000Z', location: '台中', scriptCount: 2, status: 'approved' }
+      ])
+      .mockResolvedValueOnce([
+        { _id: 'idea-1', date: '2024-01-02T00:00:00.000Z', location: '台北', scriptCount: 3, status: 'pending' }
+      ])
+    createScriptIdeaMock.mockResolvedValue({ _id: 'idea-2' })
+    deleteScriptIdeaMock.mockResolvedValue({ success: true })
+    const router = await createTestRouter('/script-ideas/client-1')
+    const wrapper = mount(ScriptIdeasRecords, {
+      props: { clientId: 'client-1' },
+      global: { plugins: [router], stubs: globalStubs }
+    })
+    await flushPromises()
+
+    expect(listScriptIdeasMock).toHaveBeenCalledWith('client-1')
+    expect(wrapper.vm.records).toHaveLength(1)
+
+    await wrapper.vm.openCreate()
+    wrapper.vm.form.date = new Date('2024-01-05T00:00:00.000Z')
+    wrapper.vm.form.location = '台中'
+    wrapper.vm.form.scriptCount = 2
+    wrapper.vm.form.status = 'approved'
+    await wrapper.vm.submitForm()
+    await flushPromises()
+
+    expect(createScriptIdeaMock).toHaveBeenCalledWith(
+      'client-1',
+      expect.objectContaining({
+        date: expect.stringContaining('2024-01-05'),
+        location: '台中',
+        scriptCount: 2,
+        status: 'approved'
+      })
+    )
+    expect(listScriptIdeasMock).toHaveBeenCalledTimes(2)
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    await wrapper.vm.confirmDelete({ _id: 'idea-1' })
+    await flushPromises()
+
+    expect(deleteScriptIdeaMock).toHaveBeenCalledWith('client-1', 'idea-1')
+    expect(listScriptIdeasMock).toHaveBeenCalledTimes(3)
+    confirmSpy.mockRestore()
+  })
+})
+
+describe('ScriptIdeasDetail 編輯詳情', () => {
+  beforeEach(() => {
+    getScriptIdeaMock.mockReset()
+    updateScriptIdeaMock.mockReset()
+    toastMock.add.mockClear()
+  })
+
+  it('可移除影片並儲存腳本內容', async () => {
+    getScriptIdeaMock.mockResolvedValueOnce({
+      _id: 'idea-1',
+      clientId: 'client-1',
+      summaryScript: '原始腳本',
+      headline: '原始標題',
+      firstParagraph: '',
+      dialogue: '',
+      keyLines: '',
+      feedback: '',
+      videoUrl: 'https://example.com/demo.mp4',
+      videoName: 'demo.mp4'
+    })
+    getScriptIdeaMock.mockResolvedValueOnce({
+      _id: 'idea-1',
+      clientId: 'client-1',
+      summaryScript: '更新後腳本',
+      headline: '更新後標題',
+      firstParagraph: '',
+      dialogue: '',
+      keyLines: '',
+      feedback: '',
+      videoUrl: '',
+      videoName: ''
+    })
+    const router = await createTestRouter('/script-ideas/client-1/records/idea-1')
+    const wrapper = mount(ScriptIdeasDetail, {
+      props: { clientId: 'client-1', recordId: 'idea-1' },
+      global: { plugins: [router], stubs: globalStubs }
+    })
+    await flushPromises()
+
+    expect(getScriptIdeaMock).toHaveBeenCalledWith('client-1', 'idea-1')
+    expect(wrapper.vm.form.summaryScript).toBe('原始腳本')
+
+    await wrapper.vm.toggleRemove()
+    wrapper.vm.form.summaryScript = '更新後腳本'
+    await wrapper.vm.save()
+    await flushPromises()
+
+    expect(updateScriptIdeaMock).toHaveBeenCalledWith('client-1', 'idea-1', expect.objectContaining({
+      summaryScript: '更新後腳本',
+      removeVideo: 'true'
+    }))
+    expect(getScriptIdeaMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/client/src/views/script-ideas/ScriptIdeas.vue
+++ b/client/src/views/script-ideas/ScriptIdeas.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="script-ideas">
+    <header class="script-ideas__header">
+      <div>
+        <h1>腳本創意</h1>
+        <p class="subtitle">挑選客戶以管理腳本記錄</p>
+      </div>
+      <span class="search">
+        <i class="pi pi-search"></i>
+        <InputText v-model="keyword" placeholder="搜尋客戶名稱" />
+      </span>
+    </header>
+
+    <section v-if="loading" class="loading">載入客戶中…</section>
+
+    <section v-else class="script-ideas__content">
+      <p v-if="filteredClients.length === 0" class="empty">目前沒有符合條件的客戶</p>
+      <div v-else class="client-grid">
+        <Card v-for="client in filteredClients" :key="client._id" class="client-card">
+          <template #content>
+            <h2>{{ client.name }}</h2>
+            <p class="client-meta">{{ client.industry || '未設定產業' }}</p>
+            <Button label="管理腳本" icon="pi pi-chevron-right" class="p-button-rounded"
+              @click="goToRecords(client)" />
+          </template>
+        </Card>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import Card from 'primevue/card'
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+import { fetchClients } from '@/services/clients'
+
+const router = useRouter()
+const toast = useToast()
+
+const keyword = ref('')
+const clients = ref([])
+const loading = ref(true)
+
+const filteredClients = computed(() => {
+  const k = keyword.value.trim().toLowerCase()
+  if (!k) return clients.value
+  return clients.value.filter((client) => client.name?.toLowerCase().includes(k))
+})
+
+const goToRecords = (client) => {
+  router.push({ name: 'ScriptIdeasRecords', params: { clientId: client._id } })
+}
+
+const loadClients = async () => {
+  loading.value = true
+  try {
+    clients.value = await fetchClients()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '載入失敗', detail: '無法取得客戶列表', life: 3000 })
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadClients)
+</script>
+
+<style scoped>
+.script-ideas {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.script-ideas__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.script-ideas__header h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.search {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  background: #fff;
+}
+
+.search i {
+  color: #9ca3af;
+}
+
+.loading {
+  text-align: center;
+  color: #6b7280;
+}
+
+.script-ideas__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.client-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.client-card {
+  text-align: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.client-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.15);
+}
+
+.client-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  color: #111827;
+}
+
+.client-meta {
+  margin: 0 0 1rem;
+  color: #6b7280;
+}
+
+.empty {
+  text-align: center;
+  color: #9ca3af;
+}
+
+@media (max-width: 600px) {
+  .script-ideas {
+    padding: 1.5rem;
+  }
+
+  .search {
+    width: 100%;
+    justify-content: center;
+  }
+}
+</style>

--- a/client/src/views/script-ideas/ScriptIdeasDetail.vue
+++ b/client/src/views/script-ideas/ScriptIdeasDetail.vue
@@ -1,0 +1,309 @@
+<template>
+  <div class="script-ideas-detail">
+    <header class="detail-header">
+      <div>
+        <h2>{{ idea?.headline || '腳本詳情' }}</h2>
+        <p class="subtitle">上傳影片素材並維護腳本文案內容</p>
+      </div>
+      <div class="actions">
+        <Button label="返回列表" icon="pi pi-arrow-left" severity="secondary" @click="goBack" />
+        <Button label="儲存變更" icon="pi pi-save" :loading="saving" @click="save" />
+      </div>
+    </header>
+
+    <div v-if="loading" class="loading">載入腳本詳情中…</div>
+
+    <div v-else class="detail-content">
+      <Card class="detail-card">
+        <template #title>影片上傳</template>
+        <template #content>
+          <p class="description">上傳影片檔案，供腳本團隊參考。支援常見影片格式。</p>
+          <div class="upload-area">
+            <FileUpload name="video" accept="video/*" :auto="false" :showUploadButton="false"
+              :showCancelButton="false" :maxFileSize="1024 * 1024 * 1024" v-model:files="videoFiles"
+              @select="onVideoSelect" @remove="onVideoRemove">
+              <template #empty>
+                <span class="upload-placeholder">
+                  <i class="pi pi-cloud-upload"></i>
+                  <span>拖曳或選擇影片檔案</span>
+                </span>
+              </template>
+            </FileUpload>
+            <div v-if="idea?.videoUrl && !removeVideo" class="current-video">
+              <p>目前檔案：<a :href="idea.videoUrl" target="_blank" rel="noopener">{{ idea.videoName }}</a></p>
+              <Button label="清除既有檔案" severity="secondary" text @click="toggleRemove" />
+            </div>
+            <div v-else-if="removeVideo" class="current-video muted">
+              <p>儲存後將移除現有影片</p>
+              <Button label="取消移除" severity="secondary" text @click="toggleRemove" />
+            </div>
+          </div>
+        </template>
+      </Card>
+
+      <Card class="detail-card">
+        <template #title>腳本內容</template>
+        <template #content>
+          <div class="form-grid">
+            <span class="field">
+              <label for="summary">綜合腳本</label>
+              <Textarea id="summary" v-model="form.summaryScript" rows="4" autoResize />
+            </span>
+            <span class="field">
+              <label for="title">標題</label>
+              <InputText id="title" v-model="form.headline" />
+            </span>
+            <span class="field">
+              <label for="first">第一段</label>
+              <Textarea id="first" v-model="form.firstParagraph" rows="3" autoResize />
+            </span>
+            <span class="field">
+              <label for="lines">台詞</label>
+              <Textarea id="lines" v-model="form.dialogue" rows="4" autoResize />
+            </span>
+            <span class="field">
+              <label for="keyLines">要講的台詞</label>
+              <Textarea id="keyLines" v-model="form.keyLines" rows="3" autoResize />
+            </span>
+            <span class="field">
+              <label for="feedback">修改意見</label>
+              <Textarea id="feedback" v-model="form.feedback" rows="4" autoResize />
+            </span>
+          </div>
+        </template>
+      </Card>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, reactive, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import Button from 'primevue/button'
+import Card from 'primevue/card'
+import FileUpload from 'primevue/fileupload'
+import Textarea from 'primevue/textarea'
+import InputText from 'primevue/inputtext'
+import {
+  getScriptIdea,
+  updateScriptIdea
+} from '@/services/scriptIdeas'
+
+const props = defineProps({
+  clientId: {
+    type: String,
+    required: true
+  },
+  recordId: {
+    type: String,
+    required: true
+  }
+})
+
+const router = useRouter()
+const toast = useToast()
+
+const loading = ref(true)
+const saving = ref(false)
+const idea = ref(null)
+const videoFiles = ref([])
+const videoFile = ref(null)
+const removeVideo = ref(false)
+
+const form = reactive({
+  summaryScript: '',
+  headline: '',
+  firstParagraph: '',
+  dialogue: '',
+  keyLines: '',
+  feedback: ''
+})
+
+const assignForm = (data) => {
+  form.summaryScript = data.summaryScript || ''
+  form.headline = data.headline || ''
+  form.firstParagraph = data.firstParagraph || ''
+  form.dialogue = data.dialogue || ''
+  form.keyLines = data.keyLines || ''
+  form.feedback = data.feedback || ''
+}
+
+const loadDetail = async () => {
+  loading.value = true
+  try {
+    const data = await getScriptIdea(props.clientId, props.recordId)
+    idea.value = data
+    assignForm(data)
+    removeVideo.value = false
+    videoFiles.value = []
+    videoFile.value = null
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '載入失敗', detail: '無法取得腳本詳情', life: 3000 })
+  } finally {
+    loading.value = false
+  }
+}
+
+const onVideoSelect = (event) => {
+  const file = event.files?.[0]
+  videoFile.value = file || null
+  removeVideo.value = false
+}
+
+const onVideoRemove = () => {
+  videoFile.value = null
+}
+
+const toggleRemove = () => {
+  removeVideo.value = !removeVideo.value
+  if (removeVideo.value) {
+    videoFiles.value = []
+    videoFile.value = null
+  }
+}
+
+const buildPayload = () => ({
+  ...form,
+  video: videoFile.value || undefined,
+  removeVideo: removeVideo.value ? 'true' : undefined
+})
+
+const save = async () => {
+  saving.value = true
+  try {
+    await updateScriptIdea(props.clientId, props.recordId, buildPayload())
+    toast.add({ severity: 'success', summary: '已儲存', detail: '腳本詳情更新成功', life: 2500 })
+    await loadDetail()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '儲存失敗', detail: '請稍後再試', life: 3000 })
+  } finally {
+    saving.value = false
+  }
+}
+
+const goBack = () => {
+  router.push({ name: 'ScriptIdeasRecords', params: { clientId: props.clientId } })
+}
+
+onMounted(loadDetail)
+
+watch(
+  () => [props.clientId, props.recordId],
+  () => {
+    loadDetail()
+  }
+)
+</script>
+
+<style scoped>
+.script-ideas-detail {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.loading {
+  text-align: center;
+  color: #6b7280;
+}
+
+.detail-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 1.5rem;
+}
+
+.detail-card {
+  height: 100%;
+}
+
+.description {
+  margin-bottom: 1rem;
+  color: #6b7280;
+}
+
+.upload-area {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.upload-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  color: #6b7280;
+}
+
+.upload-placeholder i {
+  font-size: 2rem;
+}
+
+.current-video {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  background: #f3f4f6;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+}
+
+.current-video.muted {
+  color: #6b7280;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field label {
+  font-weight: 600;
+  color: #374151;
+}
+
+@media (max-width: 640px) {
+  .script-ideas-detail {
+    padding: 1.5rem;
+  }
+
+  .detail-content {
+    grid-template-columns: 1fr;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/client/src/views/script-ideas/ScriptIdeasRecords.vue
+++ b/client/src/views/script-ideas/ScriptIdeasRecords.vue
@@ -1,0 +1,319 @@
+<template>
+  <div class="script-ideas-records">
+    <header class="records-header">
+      <div>
+        <h2>{{ client?.name || '客戶腳本記錄' }}</h2>
+        <p class="subtitle">管理腳本日期、地點、腳本數量與審核狀態</p>
+      </div>
+      <div class="actions">
+        <Button label="返回客戶列表" icon="pi pi-arrow-left" severity="secondary" @click="goBack" />
+        <Button label="新增腳本記錄" icon="pi pi-plus" @click="openCreate" />
+      </div>
+    </header>
+
+    <DataTable :value="records" :loading="loading" dataKey="_id" responsiveLayout="stack" breakpoint="960px">
+      <Column field="date" header="腳本日期">
+        <template #body="{ data }">{{ formatDate(data.date) }}</template>
+      </Column>
+      <Column field="location" header="地點" />
+      <Column field="scriptCount" header="腳本數量" />
+      <Column field="status" header="審核狀態">
+        <template #body="{ data }">
+          <Tag :value="statusText(data.status)" :severity="statusSeverity(data.status)" />
+        </template>
+      </Column>
+      <Column header="操作" bodyClass="actions-cell">
+        <template #body="{ data }">
+          <div class="row-actions">
+            <Button icon="pi pi-search" rounded severity="secondary" @click="goToDetail(data)" />
+            <Button icon="pi pi-pencil" rounded severity="info" @click="openEdit(data)" />
+            <Button icon="pi pi-trash" rounded severity="danger" @click="confirmDelete(data)" />
+          </div>
+        </template>
+      </Column>
+    </DataTable>
+
+    <Dialog v-model:visible="dialogVisible" :header="isEditing ? '編輯腳本記錄' : '新增腳本記錄'" modal style="width: 520px">
+      <div class="form-grid">
+        <span class="field">
+          <label for="date">腳本日期</label>
+          <Calendar id="date" v-model="form.date" dateFormat="yy-mm-dd" showIcon />
+        </span>
+        <span class="field">
+          <label for="location">地點</label>
+          <InputText id="location" v-model="form.location" placeholder="例如：台北市內湖" />
+        </span>
+        <span class="field">
+          <label for="scriptCount">腳本數量</label>
+          <InputNumber id="scriptCount" v-model="form.scriptCount" :min="0" :maxFractionDigits="0" />
+        </span>
+        <span class="field">
+          <label for="status">審核狀態</label>
+          <Dropdown id="status" v-model="form.status" :options="statusOptions" optionLabel="label" optionValue="value" />
+        </span>
+      </div>
+
+      <template #footer>
+        <Button label="取消" severity="secondary" @click="closeDialog" />
+        <Button label="儲存" :loading="saving" @click="submitForm" />
+      </template>
+    </Dialog>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import Button from 'primevue/button'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Dialog from 'primevue/dialog'
+import Calendar from 'primevue/calendar'
+import Dropdown from 'primevue/dropdown'
+import InputText from 'primevue/inputtext'
+import InputNumber from 'primevue/inputnumber'
+import Tag from 'primevue/tag'
+import { getClient } from '@/services/clients'
+import {
+  createScriptIdea,
+  deleteScriptIdea,
+  listScriptIdeas,
+  updateScriptIdea,
+  SCRIPT_IDEA_STATUS
+} from '@/services/scriptIdeas'
+
+const props = defineProps({
+  clientId: {
+    type: String,
+    required: true
+  }
+})
+
+const router = useRouter()
+const toast = useToast()
+
+const client = ref(null)
+const records = ref([])
+const loading = ref(true)
+const dialogVisible = ref(false)
+const saving = ref(false)
+const editingId = ref(null)
+
+const form = reactive({
+  date: null,
+  location: '',
+  scriptCount: 0,
+  status: SCRIPT_IDEA_STATUS.PENDING
+})
+
+const statusOptions = [
+  { label: '待審核', value: SCRIPT_IDEA_STATUS.PENDING },
+  { label: '審核完畢', value: SCRIPT_IDEA_STATUS.APPROVED },
+  { label: '待修改', value: SCRIPT_IDEA_STATUS.REVISION }
+]
+
+const isEditing = computed(() => Boolean(editingId.value))
+
+const resetForm = () => {
+  form.date = null
+  form.location = ''
+  form.scriptCount = 0
+  form.status = SCRIPT_IDEA_STATUS.PENDING
+}
+
+const openCreate = () => {
+  editingId.value = null
+  resetForm()
+  dialogVisible.value = true
+}
+
+const openEdit = (record) => {
+  editingId.value = record._id
+  form.date = record.date ? new Date(record.date) : null
+  form.location = record.location || ''
+  form.scriptCount = record.scriptCount ?? 0
+  form.status = record.status || SCRIPT_IDEA_STATUS.PENDING
+  dialogVisible.value = true
+}
+
+const closeDialog = () => {
+  dialogVisible.value = false
+}
+
+const buildPayload = () => ({
+  date: form.date ? form.date.toISOString() : '',
+  location: form.location,
+  scriptCount: form.scriptCount,
+  status: form.status
+})
+
+const submitForm = async () => {
+  if (!form.date) {
+    toast.add({ severity: 'warn', summary: '日期必填', detail: '請選擇腳本日期', life: 2500 })
+    return
+  }
+
+  saving.value = true
+  try {
+    if (isEditing.value) {
+      await updateScriptIdea(props.clientId, editingId.value, buildPayload())
+      toast.add({ severity: 'success', summary: '更新成功', detail: '腳本記錄已更新', life: 2500 })
+    } else {
+      await createScriptIdea(props.clientId, buildPayload())
+      toast.add({ severity: 'success', summary: '新增成功', detail: '已建立新的腳本記錄', life: 2500 })
+    }
+    dialogVisible.value = false
+    await loadRecords()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '儲存失敗', detail: '請稍後再試', life: 3000 })
+  } finally {
+    saving.value = false
+  }
+}
+
+const confirmDelete = async (record) => {
+  if (!window.confirm('確定要刪除此腳本記錄嗎？')) return
+  try {
+    await deleteScriptIdea(props.clientId, record._id)
+    toast.add({ severity: 'success', summary: '刪除成功', detail: '腳本記錄已刪除', life: 2500 })
+    await loadRecords()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '刪除失敗', detail: '請稍後再試', life: 3000 })
+  }
+}
+
+const goToDetail = (record) => {
+  router.push({ name: 'ScriptIdeasDetail', params: { clientId: props.clientId, recordId: record._id } })
+}
+
+const goBack = () => {
+  router.push({ name: 'ScriptIdeasClients' })
+}
+
+const formatDate = (value) => {
+  if (!value) return '-'
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return '-'
+  return new Intl.DateTimeFormat('zh-TW', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(date)
+}
+
+const statusText = (value) => {
+  switch (value) {
+    case SCRIPT_IDEA_STATUS.APPROVED:
+      return '審核完畢'
+    case SCRIPT_IDEA_STATUS.REVISION:
+      return '待修改'
+    default:
+      return '待審核'
+  }
+}
+
+const statusSeverity = (value) => {
+  switch (value) {
+    case SCRIPT_IDEA_STATUS.APPROVED:
+      return 'success'
+    case SCRIPT_IDEA_STATUS.REVISION:
+      return 'warning'
+    default:
+      return 'info'
+  }
+}
+
+const loadRecords = async () => {
+  loading.value = true
+  try {
+    records.value = await listScriptIdeas(props.clientId)
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '載入失敗', detail: '無法取得腳本記錄', life: 3000 })
+  } finally {
+    loading.value = false
+  }
+}
+
+const loadClient = async () => {
+  try {
+    client.value = await getClient(props.clientId)
+  } catch (error) {
+    client.value = null
+  }
+}
+
+onMounted(() => {
+  loadClient()
+  loadRecords()
+})
+
+watch(
+  () => props.clientId,
+  () => {
+    loadClient()
+    loadRecords()
+  }
+)
+</script>
+
+<style scoped>
+.script-ideas-records {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.records-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.row-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.actions-cell {
+  text-align: center;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field label {
+  font-weight: 600;
+  color: #374151;
+}
+
+@media (max-width: 640px) {
+  .script-ideas-records {
+    padding: 1.5rem;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig({
     }
   },
   test: {
-    environment: 'jsdom'
+    environment: 'jsdom',
+    setupFiles: 'src/test/setup.js'
   }
 })

--- a/server/src/config/menus.js
+++ b/server/src/config/menus.js
@@ -8,5 +8,6 @@ export const MENUS = Object.freeze({
   REVIEW_STAGES: 'review-stages',
   POPULAR_DATA: 'popular-data',
   AD_DATA: 'ad-data',
+  SCRIPT_IDEAS: 'script-ideas',
   ACCOUNT: 'account'
 })

--- a/server/src/controllers/scriptIdea.controller.js
+++ b/server/src/controllers/scriptIdea.controller.js
@@ -1,0 +1,193 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import ScriptIdea from '../models/scriptIdea.model.js'
+import { decodeFilename } from '../utils/decodeFilename.js'
+import { uploadFile, getSignedUrl } from '../utils/gcs.js'
+import { getCache, setCache, delCache } from '../utils/cache.js'
+
+const listCacheKey = (clientId) => `scriptIdeas:list:${clientId}`
+const detailCacheKey = (ideaId) => `scriptIdeas:detail:${ideaId}`
+
+const normalizeDate = (value) => {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date
+}
+
+const normalizeNumber = (value, defaultValue = 0) => {
+  if (value === '' || value === null || value === undefined) return defaultValue
+  const num = Number(value)
+  return Number.isNaN(num) ? defaultValue : num
+}
+
+const normalizeStatus = (value) => {
+  const allowed = ['pending', 'approved', 'revision']
+  return allowed.includes(value) ? value : 'pending'
+}
+
+const uploadVideo = async (file, clientId) => {
+  if (!file) return null
+  const unique = Date.now() + '-' + Math.round(Math.random() * 1e9)
+  const originalName = decodeFilename(file.originalname)
+  const ext = path.extname(originalName)
+  const destination = `script-ideas/${clientId}/${unique}${ext}`
+  try {
+    const storedPath = await uploadFile(file.path, destination, file.mimetype)
+    return { path: storedPath, name: originalName }
+  } finally {
+    await fs.unlink(file.path).catch(() => {})
+  }
+}
+
+const appendVideoInfo = async (idea) => {
+  if (!idea) return idea
+  const obj = idea.toObject ? idea.toObject() : { ...idea }
+  if (!obj.videoPath) {
+    return { ...obj, videoUrl: '', videoName: obj.videoName || '' }
+  }
+  try {
+    const url = await getSignedUrl(obj.videoPath)
+    return {
+      ...obj,
+      videoUrl: url,
+      videoName: obj.videoName || path.basename(obj.videoPath)
+    }
+  } catch {
+    return { ...obj, videoUrl: '', videoName: obj.videoName || path.basename(obj.videoPath) }
+  }
+}
+
+export const listScriptIdeas = async (req, res) => {
+  const clientId = req.params.clientId
+  const cacheKey = listCacheKey(clientId)
+  const cached = await getCache(cacheKey)
+  if (cached) return res.json(cached)
+  const ideas = await ScriptIdea.find({ clientId }).sort({ date: -1, createdAt: -1 }).lean()
+  await setCache(cacheKey, ideas)
+  res.json(ideas)
+}
+
+export const createScriptIdea = async (req, res) => {
+  const clientId = req.params.clientId
+  const date = normalizeDate(req.body.date)
+  if (!date) {
+    return res.status(400).json({ message: '腳本日期為必填欄位' })
+  }
+  const payload = {
+    clientId,
+    date,
+    location: req.body.location || '',
+    scriptCount: normalizeNumber(req.body.scriptCount, 0),
+    status: normalizeStatus(req.body.status),
+    summaryScript: req.body.summaryScript || '',
+    headline: req.body.headline || '',
+    firstParagraph: req.body.firstParagraph || '',
+    dialogue: req.body.dialogue || '',
+    keyLines: req.body.keyLines || '',
+    feedback: req.body.feedback || ''
+  }
+  if (req.file) {
+    const uploaded = await uploadVideo(req.file, clientId)
+    if (uploaded) {
+      payload.videoPath = uploaded.path
+      payload.videoName = uploaded.name
+    }
+  }
+  const idea = await ScriptIdea.create(payload)
+  await delCache(listCacheKey(clientId))
+  const result = await appendVideoInfo(idea)
+  res.status(201).json(result)
+}
+
+export const getScriptIdea = async (req, res) => {
+  const cacheKey = detailCacheKey(req.params.ideaId)
+  const cached = await getCache(cacheKey)
+  if (cached) {
+    const withVideo = await appendVideoInfo(cached)
+    return res.json(withVideo)
+  }
+  const idea = await ScriptIdea.findOne({ _id: req.params.ideaId, clientId: req.params.clientId })
+  if (!idea) {
+    return res.status(404).json({ message: '找不到腳本記錄' })
+  }
+  const plain = idea.toObject()
+  await setCache(cacheKey, plain)
+  const withVideo = await appendVideoInfo(plain)
+  res.json(withVideo)
+}
+
+export const updateScriptIdea = async (req, res) => {
+  const clientId = req.params.clientId
+  const ideaId = req.params.ideaId
+  const update = {}
+  if (Object.prototype.hasOwnProperty.call(req.body, 'location')) {
+    update.location = req.body.location || ''
+  }
+  if (Object.prototype.hasOwnProperty.call(req.body, 'scriptCount')) {
+    update.scriptCount = normalizeNumber(req.body.scriptCount, 0)
+  }
+  if (Object.prototype.hasOwnProperty.call(req.body, 'status')) {
+    update.status = normalizeStatus(req.body.status)
+  }
+  if (Object.prototype.hasOwnProperty.call(req.body, 'summaryScript')) {
+    update.summaryScript = req.body.summaryScript || ''
+  }
+  if (Object.prototype.hasOwnProperty.call(req.body, 'headline')) {
+    update.headline = req.body.headline || ''
+  }
+  if (Object.prototype.hasOwnProperty.call(req.body, 'firstParagraph')) {
+    update.firstParagraph = req.body.firstParagraph || ''
+  }
+  if (Object.prototype.hasOwnProperty.call(req.body, 'dialogue')) {
+    update.dialogue = req.body.dialogue || ''
+  }
+  if (Object.prototype.hasOwnProperty.call(req.body, 'keyLines')) {
+    update.keyLines = req.body.keyLines || ''
+  }
+  if (Object.prototype.hasOwnProperty.call(req.body, 'feedback')) {
+    update.feedback = req.body.feedback || ''
+  }
+  if (req.body.date) {
+    const parsed = normalizeDate(req.body.date)
+    if (!parsed) {
+      return res.status(400).json({ message: '腳本日期格式錯誤' })
+    }
+    update.date = parsed
+  }
+  if (req.body.removeVideo === 'true' || req.body.removeVideo === true) {
+    update.videoPath = ''
+    update.videoName = ''
+  }
+  if (req.file) {
+    const uploaded = await uploadVideo(req.file, clientId)
+    if (uploaded) {
+      update.videoPath = uploaded.path
+      update.videoName = uploaded.name
+    }
+  }
+  const idea = await ScriptIdea.findOneAndUpdate(
+    { _id: ideaId, clientId },
+    update,
+    { new: true }
+  )
+  if (!idea) {
+    return res.status(404).json({ message: '找不到腳本記錄' })
+  }
+  await delCache(listCacheKey(clientId))
+  await delCache(detailCacheKey(ideaId))
+  const withVideo = await appendVideoInfo(idea)
+  res.json(withVideo)
+}
+
+export const deleteScriptIdea = async (req, res) => {
+  const clientId = req.params.clientId
+  const ideaId = req.params.ideaId
+  const idea = await ScriptIdea.findOneAndDelete({ _id: ideaId, clientId })
+  if (!idea) {
+    return res.status(404).json({ message: '找不到腳本記錄' })
+  }
+  await delCache(listCacheKey(clientId))
+  await delCache(detailCacheKey(ideaId))
+  res.json({ success: true })
+}

--- a/server/src/models/scriptIdea.model.js
+++ b/server/src/models/scriptIdea.model.js
@@ -1,0 +1,65 @@
+import mongoose from 'mongoose'
+
+const scriptIdeaSchema = new mongoose.Schema(
+  {
+    clientId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Client',
+      required: true,
+      index: true
+    },
+    date: {
+      type: Date,
+      required: true
+    },
+    location: {
+      type: String,
+      trim: true,
+      default: ''
+    },
+    scriptCount: {
+      type: Number,
+      default: 0
+    },
+    status: {
+      type: String,
+      enum: ['pending', 'approved', 'revision'],
+      default: 'pending'
+    },
+    videoPath: {
+      type: String,
+      default: ''
+    },
+    videoName: {
+      type: String,
+      default: ''
+    },
+    summaryScript: {
+      type: String,
+      default: ''
+    },
+    headline: {
+      type: String,
+      default: ''
+    },
+    firstParagraph: {
+      type: String,
+      default: ''
+    },
+    dialogue: {
+      type: String,
+      default: ''
+    },
+    keyLines: {
+      type: String,
+      default: ''
+    },
+    feedback: {
+      type: String,
+      default: ''
+    }
+  },
+  { timestamps: true }
+)
+
+export default mongoose.model('ScriptIdea', scriptIdeaSchema)

--- a/server/src/routes/scriptIdea.routes.js
+++ b/server/src/routes/scriptIdea.routes.js
@@ -1,0 +1,45 @@
+import { Router } from 'express'
+import { body } from 'express-validator'
+import { protect } from '../middleware/auth.js'
+import { upload } from '../middleware/upload.js'
+import { validate } from '../middleware/validate.js'
+import asyncHandler from '../utils/asyncHandler.js'
+import {
+  listScriptIdeas,
+  createScriptIdea,
+  getScriptIdea,
+  updateScriptIdea,
+  deleteScriptIdea
+} from '../controllers/scriptIdea.controller.js'
+
+const router = Router({ mergeParams: true })
+
+router.use(protect)
+
+router.get('/', asyncHandler(listScriptIdeas))
+
+router.post(
+  '/',
+  upload.single('video'),
+  body('date').notEmpty().withMessage('腳本日期為必填').isISO8601().withMessage('腳本日期格式錯誤'),
+  body('scriptCount').optional().isNumeric().withMessage('腳本數量需為數字'),
+  body('status').optional().isIn(['pending', 'approved', 'revision']).withMessage('審核狀態不正確'),
+  validate,
+  asyncHandler(createScriptIdea)
+)
+
+router.get('/:ideaId', asyncHandler(getScriptIdea))
+
+router.put(
+  '/:ideaId',
+  upload.single('video'),
+  body('date').optional().isISO8601().withMessage('腳本日期格式錯誤'),
+  body('scriptCount').optional().isNumeric().withMessage('腳本數量需為數字'),
+  body('status').optional().isIn(['pending', 'approved', 'revision']).withMessage('審核狀態不正確'),
+  validate,
+  asyncHandler(updateScriptIdea)
+)
+
+router.delete('/:ideaId', asyncHandler(deleteScriptIdea))
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -88,6 +88,7 @@ import weeklyNoteRoutes   from './routes/weeklyNote.routes.js'
 import dashboardRoutes    from './routes/dashboard.routes.js'
 import departmentRoutes   from './routes/department.routes.js'
 import popularContentRoutes from './routes/popularContent.routes.js'
+import scriptIdeaRoutes   from './routes/scriptIdea.routes.js'
 
 app.use('/api/auth',     authRoutes)
 app.use('/api/user',     userRoutes)
@@ -103,6 +104,7 @@ app.use('/api/platforms', platformTransferRoutes)
 app.use('/api/clients/:clientId/platforms/:platformId/ad-daily', adDailyRoutes)
 app.use('/api/clients/:clientId/platforms/:platformId/weekly-notes', weeklyNoteRoutes)
 app.use('/api/clients/:clientId/popular-contents', popularContentRoutes)
+app.use('/api/clients/:clientId/script-ideas', scriptIdeaRoutes)
 app.use('/api/permissions', permissionsRoutes)
 app.use('/api/menus', menusRoutes)
 app.use('/api/review-stages', reviewStageRoutes)

--- a/server/tests/scriptIdeas.routes.test.js
+++ b/server/tests/scriptIdeas.routes.test.js
@@ -1,0 +1,174 @@
+import { jest, describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals'
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let token
+let clientId
+let ideaId
+let uploadFileMock
+let getSignedUrlMock
+let Role
+let User
+let Client
+let ScriptIdea
+
+beforeAll(async () => {
+  jest.unstable_mockModule('../src/utils/gcs.js', () => ({
+    uploadFile: jest.fn().mockImplementation((_filePath, destination) => Promise.resolve(destination)),
+    getSignedUrl: jest.fn().mockImplementation((filePath) => `https://signed.example.com/${filePath}`)
+  }))
+
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  const [
+    { default: scriptIdeaRoutes },
+    { default: authRoutes },
+    { default: clientRoutes }
+  ] = await Promise.all([
+    import('../src/routes/scriptIdea.routes.js'),
+    import('../src/routes/auth.routes.js'),
+    import('../src/routes/client.routes.js')
+  ])
+
+  ;[{ default: User }, { default: Role }, { default: Client }, { default: ScriptIdea }] = await Promise.all([
+    import('../src/models/user.model.js'),
+    import('../src/models/role.model.js'),
+    import('../src/models/client.model.js'),
+    import('../src/models/scriptIdea.model.js')
+  ])
+
+  const gcs = await import('../src/utils/gcs.js')
+  uploadFileMock = gcs.uploadFile
+  getSignedUrlMock = gcs.getSignedUrl
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/clients', clientRoutes)
+  app.use('/api/clients/:clientId/script-ideas', scriptIdeaRoutes)
+
+  const role = await Role.create({ name: 'script-manager', menus: ['script-ideas'] })
+  await User.create({ username: 'admin', password: 'pwd', email: 'admin@test.com', roleId: role._id })
+
+  const loginRes = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'admin', password: 'pwd' })
+    .expect(200)
+
+  token = loginRes.body.token
+  const client = await Client.create({ name: '腳本客戶' })
+  clientId = client._id.toString()
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+beforeEach(() => {
+  uploadFileMock.mockClear()
+  getSignedUrlMock.mockClear()
+})
+
+describe('Script Ideas API', () => {
+  it('建立腳本記錄', async () => {
+    const res = await request(app)
+      .post(`/api/clients/${clientId}/script-ideas`)
+      .set('Authorization', `Bearer ${token}`)
+      .field('date', '2024-02-01T00:00:00.000Z')
+      .field('location', '台北')
+      .field('scriptCount', '3')
+      .field('status', 'pending')
+      .expect(201)
+
+    expect(res.body.location).toBe('台北')
+    expect(res.body.scriptCount).toBe(3)
+    ideaId = res.body._id
+  })
+
+  it('列出腳本記錄並使用快取', async () => {
+    const first = await request(app)
+      .get(`/api/clients/${clientId}/script-ideas`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(first.body).toHaveLength(1)
+    expect(first.body[0].location).toBe('台北')
+
+    const second = await request(app)
+      .get(`/api/clients/${clientId}/script-ideas`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(second.body).toHaveLength(1)
+  })
+
+  it('更新腳本詳情並上傳影片', async () => {
+    const videoDir = path.join(process.cwd(), 'server', 'tests', 'tmp')
+    const videoPath = path.join(videoDir, 'idea.mp4')
+    await fs.mkdir(videoDir, { recursive: true })
+    await fs.writeFile(videoPath, 'video')
+
+    const res = await request(app)
+      .put(`/api/clients/${clientId}/script-ideas/${ideaId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .field('summaryScript', '更新後腳本')
+      .field('headline', '更新後標題')
+      .attach('video', videoPath)
+      .expect(200)
+
+    await fs.unlink(videoPath)
+
+    expect(uploadFileMock).toHaveBeenCalled()
+    expect(res.body.summaryScript).toBe('更新後腳本')
+    expect(res.body.videoName).toBe('idea.mp4')
+  })
+
+  it('取得腳本詳情時附帶簽署網址', async () => {
+    const res = await request(app)
+      .get(`/api/clients/${clientId}/script-ideas/${ideaId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(getSignedUrlMock).toHaveBeenCalled()
+    expect(res.body.videoUrl).toContain('https://signed.example.com/')
+  })
+
+  it('移除影片並刪除腳本記錄', async () => {
+    await request(app)
+      .put(`/api/clients/${clientId}/script-ideas/${ideaId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .field('removeVideo', 'true')
+      .expect(200)
+
+    const detail = await request(app)
+      .get(`/api/clients/${clientId}/script-ideas/${ideaId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(detail.body.videoUrl).toBe('')
+
+    await request(app)
+      .delete(`/api/clients/${clientId}/script-ideas/${ideaId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    const afterDelete = await request(app)
+      .get(`/api/clients/${clientId}/script-ideas`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(afterDelete.body).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add script ideas menu item and nested routes for client, record, and detail views
- implement script ideas CRUD UI, PrimeVue upload integration, and vitest coverage
- create script ideas model, controller, routes, and integration tests with mocked GCS

## Testing
- `npm --prefix client test -- run src/views/script-ideas/ScriptIdeas.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68db7dfdfb948329bb45276b5a33cb24