### PR TITLE
新增工作日誌頁面與相關狀態管理

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -114,6 +114,7 @@ const mainMenuItems = computed(() => [
   },
   { path: '/popular-data', label: '爆款数据', icon: 'pi pi-bolt', badge: null },
   { path: '/script-ideas', label: '腳本創意', icon: 'pi pi-pencil', badge: null },
+  { path: '/work-diaries', label: '工作日誌', icon: 'pi pi-calendar', badge: null },
 
   // { path: '/ad-data', label: '广告数据', icon: 'pi pi-chart-line', badge: null }
 ])

--- a/client/src/menuNames.js
+++ b/client/src/menuNames.js
@@ -11,5 +11,6 @@ export const MENU_NAMES = {
   'ad-data': '广告数据',
   'ad-platforms': '平台設定',
   'script-ideas': '腳本創意',
+  'work-diaries': '工作日誌',
   account: '帐号资讯'
 }

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -23,6 +23,7 @@ import PopularDataXhs from '../views/popular-data/PopularDataXhs.vue'
 import ScriptIdeas from '../views/script-ideas/ScriptIdeas.vue'
 import ScriptIdeasRecords from '../views/script-ideas/ScriptIdeasRecords.vue'
 import ScriptIdeasDetail from '../views/script-ideas/ScriptIdeasDetail.vue'
+import WorkDiary from '../views/WorkDiary.vue'
 
 
 const routes = [
@@ -107,6 +108,12 @@ const routes = [
       { path: 'roles', name: 'RoleSettings', component: RoleSettings, meta: { menu: 'roles' } },
       { path: 'tags', name: 'TagManager', component: TagManager, meta: { menu: 'tags' } },
       { path: 'review-settings', name: 'ReviewSettings', component: ReviewSettings, meta: { menu: 'review-stages' } },
+      {
+        path: 'work-diaries/:date?/:userId?',
+        name: 'WorkDiaries',
+        component: WorkDiary,
+        meta: { menu: 'work-diaries' }
+      },
       { path: 'ad-clients', name: 'AdClients', component: AdClients, meta: { menu: 'ad-data' } },
       { path: 'clients/:clientId/platforms', name: 'AdPlatforms', component: AdPlatforms, meta: { menu: 'ad-data' } },
       { path: 'clients/:clientId/platforms/:platformId/data', name: 'AdData', component: AdData }

--- a/client/src/services/workDiary.js
+++ b/client/src/services/workDiary.js
@@ -1,0 +1,52 @@
+import api from './api'
+
+const toArray = (value) => {
+  if (Array.isArray(value)) return value
+  if (value && typeof value === 'object' && Array.isArray(value.records)) return value.records
+  return []
+}
+
+export const listWorkDiaries = (params = {}) =>
+  api
+    .get('/work-diaries', { params })
+    .then((res) => res.data)
+
+export const getWorkDiary = (diaryId) =>
+  api
+    .get(`/work-diaries/${diaryId}`)
+    .then((res) => res.data)
+
+export const updateWorkDiary = (diaryId, payload) =>
+  api
+    .put(`/work-diaries/${diaryId}`, payload)
+    .then((res) => res.data)
+
+export const updateWorkDiaryStatus = (diaryId, status, extra = {}) =>
+  updateWorkDiary(diaryId, { ...extra, status })
+
+export const uploadWorkDiaryImages = (diaryId, files = []) => {
+  const formData = new FormData()
+  toArray(files).forEach((file) => {
+    const payload = file?.raw || file?.file || file
+    if (payload) formData.append('images', payload)
+  })
+  return api
+    .post(`/work-diaries/${diaryId}/images`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    .then((res) => res.data)
+}
+
+export const removeWorkDiaryImage = (diaryId, imageId) =>
+  api
+    .delete(`/work-diaries/${diaryId}/images/${imageId}`)
+    .then((res) => res.data)
+
+export default {
+  listWorkDiaries,
+  getWorkDiary,
+  updateWorkDiary,
+  updateWorkDiaryStatus,
+  uploadWorkDiaryImages,
+  removeWorkDiaryImage
+}

--- a/client/src/stores/workDiary.js
+++ b/client/src/stores/workDiary.js
@@ -1,0 +1,182 @@
+import { defineStore } from 'pinia'
+import {
+  listWorkDiaries,
+  getWorkDiary,
+  updateWorkDiary,
+  uploadWorkDiaryImages,
+  removeWorkDiaryImage
+} from '../services/workDiary'
+
+export const WORK_DIARY_STATUS = Object.freeze({
+  DRAFT: 'draft',
+  SUBMITTED: 'submitted',
+  APPROVED: 'approved',
+  REVISION: 'revision'
+})
+
+export const WORK_DIARY_STATUS_META = Object.freeze({
+  [WORK_DIARY_STATUS.DRAFT]: { label: '草稿', severity: 'info' },
+  [WORK_DIARY_STATUS.SUBMITTED]: { label: '待審核', severity: 'warning' },
+  [WORK_DIARY_STATUS.APPROVED]: { label: '已核准', severity: 'success' },
+  [WORK_DIARY_STATUS.REVISION]: { label: '退回修改', severity: 'danger' }
+})
+
+const normalizeList = (payload) => {
+  if (Array.isArray(payload)) return payload
+  if (payload && typeof payload === 'object') {
+    if (Array.isArray(payload.records)) return payload.records
+    if (Array.isArray(payload.items)) return payload.items
+  }
+  return []
+}
+
+export const useWorkDiaryStore = defineStore('workDiary', {
+  state: () => ({
+    diaries: [],
+    loading: false,
+    saving: false,
+    uploading: false,
+    error: null,
+    selectedDiaryId: null,
+    filters: {
+      date: null,
+      userId: null
+    }
+  }),
+  getters: {
+    selectedDiary(state) {
+      return state.diaries.find((diary) => diary.id === state.selectedDiaryId) || null
+    },
+    authorOptions(state) {
+      const map = new Map()
+      state.diaries.forEach((diary) => {
+        const author = diary.author || diary.owner
+        if (!author) return
+        const id = author._id || author.id
+        if (!id || map.has(id)) return
+        map.set(id, {
+          value: id,
+          label: author.name || author.displayName || author.username || '未命名'
+        })
+      })
+      return Array.from(map.values())
+    }
+  },
+  actions: {
+    setFilters(partial) {
+      this.filters = { ...this.filters, ...partial }
+    },
+    selectDiary(diaryId) {
+      this.selectedDiaryId = diaryId
+    },
+    updateLocalDiary(diaryId, patch = {}) {
+      const index = this.diaries.findIndex((diary) => diary.id === diaryId)
+      if (index === -1) return
+      const merged = {
+        ...this.diaries[index],
+        ...patch,
+        id: diaryId,
+        detailLoaded: patch.detailLoaded ?? this.diaries[index].detailLoaded ?? false
+      }
+      this.diaries.splice(index, 1, merged)
+      if (this.selectedDiaryId === diaryId && this.selectedDiary?.id === diaryId) {
+        this.selectedDiaryId = diaryId
+      }
+    },
+    async loadDiaries(params = {}) {
+      this.loading = true
+      this.error = null
+      try {
+        const result = await listWorkDiaries(params)
+        const diaries = normalizeList(result).map((item) => ({
+          ...item,
+          id: item.id || item._id,
+          detailLoaded: Boolean(item.content)
+        }))
+        this.diaries = diaries
+        this.filters = {
+          date: params.date ?? this.filters.date,
+          userId: params.userId ?? this.filters.userId
+        }
+        if (!this.selectedDiaryId || !this.diaries.some((d) => d.id === this.selectedDiaryId)) {
+          this.selectedDiaryId = this.diaries[0]?.id ?? null
+        }
+        return diaries
+      } catch (error) {
+        this.error = error
+        throw error
+      } finally {
+        this.loading = false
+      }
+    },
+    async fetchDiaryDetail(diaryId) {
+      if (!diaryId) return null
+      try {
+        const detail = await getWorkDiary(diaryId)
+        this.updateLocalDiary(diaryId, {
+          ...detail,
+          id: detail.id || detail._id || diaryId,
+          detailLoaded: true
+        })
+        return detail
+      } catch (error) {
+        this.error = error
+        throw error
+      }
+    },
+    async saveDiary(diaryId, payload) {
+      if (!diaryId) return null
+      this.saving = true
+      this.error = null
+      try {
+        const updated = await updateWorkDiary(diaryId, payload)
+        this.updateLocalDiary(diaryId, {
+          ...updated,
+          id: updated.id || updated._id || diaryId,
+          detailLoaded: true
+        })
+        return updated
+      } catch (error) {
+        this.error = error
+        throw error
+      } finally {
+        this.saving = false
+      }
+    },
+    async uploadImages(diaryId, files) {
+      if (!diaryId) return null
+      this.uploading = true
+      this.error = null
+      try {
+        const updated = await uploadWorkDiaryImages(diaryId, files)
+        this.updateLocalDiary(diaryId, {
+          ...updated,
+          id: updated.id || updated._id || diaryId,
+          detailLoaded: true
+        })
+        return updated
+      } catch (error) {
+        this.error = error
+        throw error
+      } finally {
+        this.uploading = false
+      }
+    },
+    async removeImage(diaryId, imageId) {
+      if (!diaryId || !imageId) return null
+      this.error = null
+      try {
+        const updated = await removeWorkDiaryImage(diaryId, imageId)
+        this.updateLocalDiary(diaryId, {
+          ...updated,
+          id: updated.id || updated._id || diaryId,
+          detailLoaded: true
+        })
+        return updated
+      } catch (error) {
+        this.error = error
+        throw error
+      }
+    }
+  }
+})

--- a/client/src/views/WorkDiary.test.js
+++ b/client/src/views/WorkDiary.test.js
@@ -1,0 +1,330 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+
+import WorkDiary from './WorkDiary.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const toastMock = { add: vi.fn() }
+vi.mock('primevue/usetoast', () => ({ useToast: () => toastMock }))
+
+const workDiaryServiceMock = vi.hoisted(() => ({
+  listWorkDiaries: vi.fn(),
+  getWorkDiary: vi.fn(),
+  updateWorkDiary: vi.fn(),
+  uploadWorkDiaryImages: vi.fn(),
+  removeWorkDiaryImage: vi.fn()
+}))
+
+vi.mock('@/services/workDiary', () => workDiaryServiceMock)
+
+const {
+  listWorkDiaries: listWorkDiariesMock,
+  getWorkDiary: getWorkDiaryMock,
+  updateWorkDiary: updateWorkDiaryMock
+} = workDiaryServiceMock
+
+const formatInputDate = (value) => {
+  if (!value) return ''
+  const date = typeof value === 'string' ? new Date(value) : value
+  if (Number.isNaN(date?.getTime?.())) return ''
+  const yyyy = date.getFullYear()
+  const mm = String(date.getMonth() + 1).padStart(2, '0')
+  const dd = String(date.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+const CalendarStub = defineComponent({
+  name: 'CalendarStub',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('input', {
+        class: 'calendar-stub',
+        value: formatInputDate(props.modelValue),
+        onInput: (event) => emit('update:modelValue', new Date(event.target.value))
+      })
+  }
+})
+
+const DropdownStub = defineComponent({
+  name: 'DropdownStub',
+  props: ['modelValue', 'options', 'disabled'],
+  emits: ['update:modelValue', 'change'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h(
+        'select',
+        {
+          class: ['dropdown-stub', attrs.class].filter(Boolean).join(' '),
+          value: props.modelValue ?? '',
+          disabled: props.disabled,
+          onChange: (event) => {
+            const value = event.target.value || null
+            emit('update:modelValue', value)
+            emit('change', value)
+          }
+        },
+        (props.options || []).map((option) =>
+          h('option', { value: option.value }, option.label)
+        )
+      )
+  }
+})
+
+const ButtonStub = defineComponent({
+  name: 'ButtonStub',
+  props: ['label', 'icon', 'loading', 'disabled'],
+  emits: ['click'],
+  setup(props, { emit, slots, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: ['button-stub', attrs.class].filter(Boolean).join(' '),
+          disabled: props.disabled ?? attrs.disabled ?? false,
+          onClick: (event) => {
+            if (props.disabled ?? attrs.disabled) return
+            emit('click', event)
+            attrs.onClick?.(event)
+          }
+        },
+        slots.default?.() || props.label || props.icon || 'button'
+      )
+  }
+})
+
+const TextareaStub = defineComponent({
+  name: 'TextareaStub',
+  props: ['modelValue', 'readonly'],
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h('textarea', {
+        class: ['textarea-stub', attrs.class].filter(Boolean).join(' '),
+        value: props.modelValue ?? '',
+        readOnly: props.readonly ?? attrs.readonly ?? false,
+        onInput: (event) => emit('update:modelValue', event.target.value)
+      })
+  }
+})
+
+const InputTextStub = defineComponent({
+  name: 'InputTextStub',
+  props: ['modelValue', 'disabled'],
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h('input', {
+        class: ['input-stub', attrs.class].filter(Boolean).join(' '),
+        value: props.modelValue ?? '',
+        disabled: props.disabled ?? attrs.disabled ?? false,
+        onInput: (event) => emit('update:modelValue', event.target.value)
+      })
+  }
+})
+
+const TagStub = defineComponent({
+  name: 'TagStub',
+  props: ['value', 'severity'],
+  setup(props) {
+    return () =>
+      h(
+        'span',
+        { class: ['tag-stub', props.severity ? `tag-${props.severity}` : ''] },
+        props.value
+      )
+  }
+})
+
+const CardStub = defineComponent({
+  name: 'CardStub',
+  setup(_, { slots }) {
+    return () =>
+      h('section', { class: 'card-stub' }, [
+        slots.title?.(),
+        slots.content?.(),
+        slots.default?.()
+      ])
+  }
+})
+
+const FileUploadStub = defineComponent({
+  name: 'FileUploadStub',
+  emits: ['select'],
+  setup(_, { slots }) {
+    return () => h('div', { class: 'file-upload-stub' }, slots.default?.())
+  }
+})
+
+const DividerStub = defineComponent({
+  name: 'DividerStub',
+  setup() {
+    return () => h('hr', { class: 'divider-stub' })
+  }
+})
+
+const SkeletonStub = defineComponent({
+  name: 'SkeletonStub',
+  setup() {
+    return () => h('div', { class: 'skeleton-stub' })
+  }
+})
+
+const globalStubs = {
+  Card: CardStub,
+  Calendar: CalendarStub,
+  Dropdown: DropdownStub,
+  Button: ButtonStub,
+  Textarea: TextareaStub,
+  InputText: InputTextStub,
+  Tag: TagStub,
+  FileUpload: FileUploadStub,
+  Divider: DividerStub,
+  Skeleton: SkeletonStub
+}
+
+const createTestRouter = async (initialPath = '/work-diaries') => {
+  const { createRouter, createMemoryHistory } = await import('vue-router')
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: '/work-diaries/:date?/:userId?',
+        name: 'WorkDiaries',
+        component: { template: '<div />' }
+      }
+    ]
+  })
+  await router.push(initialPath)
+  await router.isReady()
+  return router
+}
+
+const mountWorkDiary = async ({ user, path = '/work-diaries' }) => {
+  listWorkDiariesMock.mockResolvedValueOnce([
+    {
+      id: 'd1',
+      title: '日誌 A',
+      status: 'submitted',
+      author: { _id: 'emp1', name: '一般員工' }
+    }
+  ])
+
+  const detail = {
+    id: 'd1',
+    title: '日誌 A',
+    content: '今日完成任務。',
+    status: 'submitted',
+    supervisorComment: '請再補充銷售結果',
+    images: []
+  }
+
+  getWorkDiaryMock.mockResolvedValueOnce(detail)
+  updateWorkDiaryMock.mockImplementation((id, payload) =>
+    Promise.resolve({ ...detail, id, ...payload })
+  )
+
+  const router = await createTestRouter(path)
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const authStore = useAuthStore()
+  authStore.$patch(user)
+
+  const wrapper = mount(WorkDiary, {
+    global: {
+      plugins: [pinia, router],
+      stubs: globalStubs
+    }
+  })
+
+  await flushPromises()
+  await flushPromises()
+
+  return { wrapper, router }
+}
+
+describe('WorkDiary.vue', () => {
+  beforeEach(() => {
+    toastMock.add.mockClear()
+    listWorkDiariesMock.mockReset()
+    getWorkDiaryMock.mockReset()
+    updateWorkDiaryMock.mockReset()
+  })
+
+  afterAll(() => {
+    vi.resetModules()
+  })
+
+  it('一般員工僅可編輯自身內容且不可調整狀態', async () => {
+    const user = {
+      token: 'token',
+      user: {
+        _id: 'emp1',
+        name: '一般員工',
+        permissions: [],
+        menus: ['work-diaries']
+      }
+    }
+
+    const { wrapper } = await mountWorkDiary({ user })
+
+    expect(listWorkDiariesMock).toHaveBeenCalled()
+    expect(getWorkDiaryMock).toHaveBeenCalledWith('d1')
+
+    const statusDropdown = wrapper.find('select.status-dropdown')
+    expect(statusDropdown.exists()).toBe(false)
+
+    const statusTag = wrapper.find('.status-control .tag-stub')
+    expect(statusTag.exists()).toBe(true)
+    expect(statusTag.text()).toContain('待審核')
+
+    const supervisorTextarea = wrapper.find('.supervisor-comment textarea')
+    expect(supervisorTextarea.exists()).toBe(true)
+    expect(supervisorTextarea.element.readOnly).toBe(true)
+
+    const saveButton = wrapper.find('button.save-button')
+    expect(saveButton.exists()).toBe(true)
+    expect(saveButton.element.disabled).toBe(false)
+  })
+
+  it('主管可調整狀態並寫入留言', async () => {
+    const user = {
+      token: 'token',
+      user: {
+        _id: 'leader',
+        name: '主管',
+        permissions: ['work-diary:review'],
+        menus: ['work-diaries']
+      }
+    }
+
+    const { wrapper } = await mountWorkDiary({ user, path: '/work-diaries/2024-05-01' })
+
+    await flushPromises()
+
+    const statusDropdown = wrapper.find('select.status-dropdown')
+    expect(statusDropdown.exists()).toBe(true)
+    expect(statusDropdown.element.disabled).toBe(false)
+
+    await statusDropdown.setValue('approved')
+
+    const supervisorTextarea = wrapper.find('.supervisor-comment textarea')
+    expect(supervisorTextarea.element.readOnly).toBe(false)
+    await supervisorTextarea.setValue('辛苦了，保持品質。')
+
+    const saveButton = wrapper.find('button.save-button')
+    await saveButton.trigger('click')
+    await flushPromises()
+
+    expect(updateWorkDiaryMock).toHaveBeenCalledWith('d1', {
+      title: '日誌 A',
+      content: '今日完成任務。',
+      status: 'approved',
+      supervisorComment: '辛苦了，保持品質。'
+    })
+  })
+})

--- a/client/src/views/WorkDiary.vue
+++ b/client/src/views/WorkDiary.vue
@@ -1,0 +1,680 @@
+<template>
+  <div class="work-diary-page">
+    <div class="work-diary-toolbar">
+      <Card>
+        <template #content>
+          <div class="toolbar-content">
+            <div class="toolbar-field">
+              <label class="field-label">選擇日期</label>
+              <Calendar
+                v-model="calendarValue"
+                dateFormat="yy-mm-dd"
+                :maxDate="new Date()"
+                showIcon
+              />
+            </div>
+            <div class="toolbar-field">
+              <label class="field-label">篩選成員</label>
+              <Dropdown
+                v-model="selectedUserId"
+                :options="userOptions"
+                optionLabel="label"
+                optionValue="value"
+                placeholder="全部成員"
+                showClear
+              />
+            </div>
+            <div class="toolbar-actions">
+              <Button
+                icon="pi pi-refresh"
+                label="重新整理"
+                class="p-button-outlined"
+                :loading="workDiaryStore.loading"
+                @click="reload"
+              />
+            </div>
+          </div>
+        </template>
+      </Card>
+    </div>
+
+    <div class="work-diary-body">
+      <div class="work-diary-list" data-test="work-diary-list">
+        <Card class="list-card">
+          <template #title>
+            <div class="list-header">
+              <h2>日誌列表</h2>
+              <span class="list-count">{{ diaries.length }} 筆</span>
+            </div>
+          </template>
+          <template #content>
+            <div v-if="workDiaryStore.loading" class="list-loading">
+              <Skeleton height="2.5rem" class="mb-2" v-for="n in 3" :key="n" />
+            </div>
+            <div v-else-if="!diaries.length" class="list-empty">
+              <i class="pi pi-inbox"></i>
+              <p>指定日期尚無日誌資料</p>
+            </div>
+            <div v-else class="list-items">
+              <div
+                v-for="diary in diaries"
+                :key="diary.id"
+                class="list-item"
+                :class="{ 'list-item--active': diary.id === workDiaryStore.selectedDiaryId }"
+                role="button"
+                tabindex="0"
+                @click="handleSelectDiary(diary)"
+                @keyup.enter="handleSelectDiary(diary)"
+              >
+                <div class="item-header">
+                  <div class="item-title">
+                    <h3>{{ diary.title || '未命名日誌' }}</h3>
+                    <small>作者：{{ diary.author?.name || diary.owner?.name || '未提供' }}</small>
+                  </div>
+                  <Tag
+                    :value="statusMeta(diary.status).label"
+                    :severity="statusMeta(diary.status).severity"
+                  />
+                </div>
+                <p class="item-preview">{{ diary.summary || diary.content || '尚未填寫內容' }}</p>
+              </div>
+            </div>
+          </template>
+        </Card>
+      </div>
+
+      <div class="work-diary-detail" data-test="work-diary-detail">
+        <Card>
+          <template #title>
+            <div class="detail-header">
+              <div>
+                <h2>日誌內容</h2>
+                <p class="detail-date">{{ formattedDate }}</p>
+              </div>
+              <Tag
+                v-if="activeStatusMeta"
+                :value="activeStatusMeta.label"
+                :severity="activeStatusMeta.severity"
+              />
+            </div>
+          </template>
+          <template #content>
+            <div v-if="!selectedDiary && !workDiaryStore.loading" class="detail-empty">
+              <i class="pi pi-file"></i>
+              <p>請先在左側選取日誌以檢視或編輯</p>
+            </div>
+
+            <div v-else>
+              <div v-if="workDiaryStore.loading && !selectedDiary" class="detail-loading">
+                <Skeleton height="2rem" class="mb-3" />
+                <Skeleton height="12rem" class="mb-3" />
+                <Skeleton height="6rem" />
+              </div>
+
+              <div v-else-if="detailForm" class="detail-form">
+                <div class="form-row">
+                  <label class="field-label" for="diary-title">標題</label>
+                  <InputText
+                    id="diary-title"
+                    v-model.trim="detailForm.title"
+                    :disabled="!canEditContent"
+                  />
+                </div>
+
+                <div class="form-row">
+                  <label class="field-label">狀態</label>
+                  <div class="status-control">
+                    <Dropdown
+                      v-if="canChangeStatus"
+                      class="status-dropdown"
+                      v-model="detailForm.status"
+                      :options="statusOptions"
+                      optionLabel="label"
+                      optionValue="value"
+                    />
+                    <Tag
+                      v-else
+                      :value="activeStatusMeta?.label"
+                      :severity="activeStatusMeta?.severity"
+                    />
+                  </div>
+                </div>
+
+                <div class="form-row">
+                  <label class="field-label" for="diary-content">日誌內容</label>
+                  <Textarea
+                    id="diary-content"
+                    v-model="detailForm.content"
+                    autoResize
+                    rows="8"
+                    :readonly="!canEditContent"
+                  />
+                </div>
+
+                <Divider />
+
+                <div class="form-row">
+                  <div class="field-label">圖片紀錄</div>
+                  <div class="image-grid">
+                    <div
+                      v-for="image in detailForm.images"
+                      :key="image.id || image.path"
+                      class="image-item"
+                    >
+                      <img :src="image.url || image.previewUrl" :alt="image.name || '日誌圖片'" />
+                      <Button
+                        v-if="canUploadImages"
+                        icon="pi pi-trash"
+                        severity="danger"
+                        class="p-button-rounded p-button-text"
+                        @click="handleRemoveImage(image)"
+                      />
+                    </div>
+                    <div v-if="canUploadImages" class="image-upload">
+                      <FileUpload
+                        name="work-diary-images"
+                        accept="image/*"
+                        :auto="false"
+                        :customUpload="true"
+                        :showUploadButton="false"
+                        :showCancelButton="false"
+                        @select="handleImageSelect"
+                      >
+                        <div class="upload-placeholder">
+                          <i class="pi pi-cloud-upload"></i>
+                          <p>拖曳或點擊以上傳圖片</p>
+                        </div>
+                      </FileUpload>
+                    </div>
+                  </div>
+                </div>
+
+                <Divider />
+
+                <div class="form-row supervisor-comment">
+                  <label class="field-label" for="diary-supervisor">主管留言</label>
+                  <Textarea
+                    id="diary-supervisor"
+                    v-model="detailForm.supervisorComment"
+                    autoResize
+                    rows="5"
+                    :readonly="!isSupervisor"
+                  />
+                </div>
+
+                <div class="form-actions">
+                  <Button
+                    class="save-button"
+                    icon="pi pi-save"
+                    label="儲存更新"
+                    :disabled="!canSave || workDiaryStore.saving"
+                    :loading="workDiaryStore.saving"
+                    @click="handleSave"
+                  />
+                </div>
+              </div>
+            </div>
+          </template>
+        </Card>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useToast } from 'primevue/usetoast'
+import { useAuthStore } from '@/stores/auth'
+import {
+  useWorkDiaryStore,
+  WORK_DIARY_STATUS,
+  WORK_DIARY_STATUS_META
+} from '@/stores/workDiary'
+
+import Card from 'primevue/card'
+import Calendar from 'primevue/calendar'
+import Dropdown from 'primevue/dropdown'
+import Button from 'primevue/button'
+import Textarea from 'primevue/textarea'
+import InputText from 'primevue/inputtext'
+import Tag from 'primevue/tag'
+import FileUpload from 'primevue/fileupload'
+import Divider from 'primevue/divider'
+import Skeleton from 'primevue/skeleton'
+
+const router = useRouter()
+const route = useRoute()
+const toast = useToast()
+const authStore = useAuthStore()
+const workDiaryStore = useWorkDiaryStore()
+
+const formatDate = (date) => {
+  if (!date) return ''
+  const normalized = typeof date === 'string' ? new Date(date) : date
+  if (Number.isNaN(normalized?.getTime?.())) return ''
+  const yyyy = normalized.getFullYear()
+  const mm = String(normalized.getMonth() + 1).padStart(2, '0')
+  const dd = String(normalized.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+const parseDate = (value) => {
+  if (!value) return null
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+const initialDateString = route.params.date || route.query.date || formatDate(new Date())
+const calendarValue = ref(parseDate(initialDateString) || new Date())
+const selectedUserId = ref(route.params.userId || route.query.user || 'all')
+
+const diaries = computed(() => workDiaryStore.diaries)
+const selectedDiary = computed(() => workDiaryStore.selectedDiary)
+
+const statusMeta = (status) =>
+  WORK_DIARY_STATUS_META[status] || { label: status || '未設定', severity: 'info' }
+
+const activeStatusMeta = computed(() =>
+  selectedDiary.value ? statusMeta(selectedDiary.value.status) : null
+)
+
+const statusOptions = Object.values(WORK_DIARY_STATUS).map((value) => ({
+  value,
+  label: WORK_DIARY_STATUS_META[value]?.label || value
+}))
+
+const userOptions = computed(() => {
+  const options = workDiaryStore.authorOptions.map((option) => ({
+    ...option,
+    label: option.label
+  }))
+  return [
+    { label: '全部成員', value: 'all' },
+    ...options
+  ]
+})
+
+const formattedDate = computed(() => formatDate(calendarValue.value))
+
+const isSupervisor = computed(() => !!authStore.hasPermission('work-diary:review'))
+const canEditContent = computed(() => {
+  if (!selectedDiary.value) return false
+  const authorId = selectedDiary.value.author?._id || selectedDiary.value.author?.id
+  const userId = authStore.user?._id || authStore.user?.id
+  return isSupervisor.value || (authorId && userId && authorId === userId)
+})
+const canChangeStatus = computed(() => isSupervisor.value)
+const canUploadImages = computed(() => canEditContent.value)
+const canSave = computed(() => canEditContent.value || canChangeStatus.value)
+
+const detailForm = ref(null)
+
+const syncRouteParams = async () => {
+  const params = {}
+  const dateString = formatDate(calendarValue.value)
+  if (dateString) params.date = dateString
+  const userId = selectedUserId.value
+  if (userId && userId !== 'all') params.userId = userId
+
+  const currentDate = route.params.date || route.query.date || null
+  const currentUser = route.params.userId || route.query.user || null
+
+  if (currentDate !== params.date || currentUser !== params.userId) {
+    await router.replace({ name: 'WorkDiaries', params })
+  }
+}
+
+const loadDiaries = async () => {
+  const payload = {
+    date: formatDate(calendarValue.value)
+  }
+  if (selectedUserId.value && selectedUserId.value !== 'all') {
+    payload.userId = selectedUserId.value
+  }
+  try {
+    await workDiaryStore.loadDiaries(payload)
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: '讀取失敗',
+      detail: '無法載入工作日誌，請稍後再試',
+      life: 3000
+    })
+  }
+}
+
+watch(
+  () => route.params,
+  (params) => {
+    const nextDate = parseDate(params.date) || parseDate(route.query.date)
+    if (nextDate && formatDate(nextDate) !== formatDate(calendarValue.value)) {
+      calendarValue.value = nextDate
+    }
+    const nextUser = params.userId || route.query.user || 'all'
+    if (selectedUserId.value !== nextUser) {
+      selectedUserId.value = nextUser
+    }
+  }
+)
+
+watch(
+  [calendarValue, selectedUserId],
+  async () => {
+    await syncRouteParams()
+    await loadDiaries()
+  },
+  { immediate: true }
+)
+
+watch(
+  () => workDiaryStore.selectedDiaryId,
+  async (diaryId) => {
+    if (!diaryId) return
+    const diary = workDiaryStore.diaries.find((item) => item.id === diaryId)
+    if (diary?.detailLoaded) return
+    try {
+      await workDiaryStore.fetchDiaryDetail(diaryId)
+    } catch (error) {
+      toast.add({
+        severity: 'error',
+        summary: '讀取失敗',
+        detail: '無法載入日誌內容',
+        life: 3000
+      })
+    }
+  },
+  { immediate: true }
+)
+
+watch(
+  selectedDiary,
+  (diary) => {
+    if (!diary) {
+      detailForm.value = null
+      return
+    }
+    detailForm.value = {
+      title: diary.title || '',
+      content: diary.content || '',
+      supervisorComment: diary.supervisorComment || '',
+      status: diary.status || WORK_DIARY_STATUS.DRAFT,
+      images: Array.isArray(diary.images) ? [...diary.images] : []
+    }
+  },
+  { immediate: true }
+)
+
+const handleSelectDiary = async (diary) => {
+  if (!diary?.id) return
+  workDiaryStore.selectDiary(diary.id)
+  if (!diary.detailLoaded) {
+    try {
+      await workDiaryStore.fetchDiaryDetail(diary.id)
+    } catch (error) {
+      toast.add({
+        severity: 'error',
+        summary: '讀取失敗',
+        detail: '無法載入日誌內容',
+        life: 3000
+      })
+    }
+  }
+}
+
+const handleSave = async () => {
+  if (!workDiaryStore.selectedDiaryId || !detailForm.value) return
+  if (!canSave.value) {
+    toast.add({ severity: 'warn', summary: '權限不足', detail: '無法儲存此日誌', life: 3000 })
+    return
+  }
+  const payload = {
+    title: detailForm.value.title,
+    content: detailForm.value.content,
+    status: canChangeStatus.value
+      ? detailForm.value.status
+      : workDiaryStore.selectedDiary?.status,
+    supervisorComment: isSupervisor.value
+      ? detailForm.value.supervisorComment
+      : workDiaryStore.selectedDiary?.supervisorComment
+  }
+  try {
+    await workDiaryStore.saveDiary(workDiaryStore.selectedDiaryId, payload)
+    toast.add({ severity: 'success', summary: '儲存成功', detail: '日誌已更新', life: 3000 })
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '儲存失敗', detail: '請稍後再試', life: 3000 })
+  }
+}
+
+const handleImageSelect = async (event) => {
+  if (!canUploadImages.value) {
+    toast.add({ severity: 'warn', summary: '權限不足', detail: '您沒有上傳權限', life: 3000 })
+    event?.options?.clear?.()
+    return
+  }
+  const files = event?.files || []
+  if (!files.length) return
+  try {
+    await workDiaryStore.uploadImages(workDiaryStore.selectedDiaryId, files)
+    toast.add({ severity: 'success', summary: '上傳完成', detail: '圖片已新增', life: 3000 })
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '上傳失敗', detail: '請稍後再試', life: 3000 })
+  } finally {
+    event?.options?.clear?.()
+  }
+}
+
+const handleRemoveImage = async (image) => {
+  if (!canUploadImages.value) {
+    toast.add({ severity: 'warn', summary: '權限不足', detail: '您沒有刪除圖片的權限', life: 3000 })
+    return
+  }
+  try {
+    await workDiaryStore.removeImage(workDiaryStore.selectedDiaryId, image.id || image.path)
+    toast.add({ severity: 'success', summary: '已移除圖片', detail: '圖片刪除成功', life: 3000 })
+  } catch (error) {
+    toast.add({ severity: 'error', summary: '刪除失敗', detail: '請稍後再試', life: 3000 })
+  }
+}
+
+const reload = async () => {
+  await loadDiaries()
+}
+</script>
+
+<style scoped>
+.work-diary-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.work-diary-toolbar .toolbar-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.toolbar-field {
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+}
+
+.field-label {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.toolbar-actions {
+  margin-left: auto;
+}
+
+.work-diary-body {
+  display: grid;
+  grid-template-columns: minmax(260px, 380px) 1fr;
+  gap: 1.5rem;
+}
+
+.list-card {
+  height: 100%;
+}
+
+.list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.list-count {
+  font-size: 0.875rem;
+  color: var(--surface-500);
+}
+
+.list-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.list-item {
+  border: 1px solid var(--surface-200);
+  border-radius: 10px;
+  padding: 1rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.list-item:hover {
+  border-color: var(--primary-color);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.list-item--active {
+  border-color: var(--primary-color);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.item-title h3 {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.item-title small {
+  color: var(--surface-500);
+}
+
+.item-preview {
+  margin-top: 0.75rem;
+  color: var(--surface-600);
+  font-size: 0.95rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.list-empty,
+.list-loading,
+.detail-empty {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 240px;
+  color: var(--surface-500);
+  text-align: center;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.detail-date {
+  margin: 0;
+  color: var(--surface-500);
+}
+
+.detail-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.status-control {
+  display: flex;
+  align-items: center;
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.image-item {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--surface-200);
+}
+
+.image-item img {
+  width: 100%;
+  height: 140px;
+  object-fit: cover;
+  display: block;
+}
+
+.image-item .p-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+}
+
+.image-upload {
+  border: 2px dashed var(--surface-300);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 140px;
+}
+
+.upload-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--surface-500);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 1024px) {
+  .work-diary-body {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- 新增 WorkDiary 頁面提供日期篩選、日誌列表與詳細內容編輯
- 建立 workDiary store 與 service 以串接日誌查詢、更新與圖片操作
- 更新路由與選單配置，並補充 WorkDiary 單元測試

## Testing
- `npm --prefix client test -- --run src/views/WorkDiary.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68dbdc835aa883299b3f9448574f4b27