### PR TITLE
feat: 新增工作日誌模組

### DIFF
--- a/server/src/controllers/workDiary.controller.js
+++ b/server/src/controllers/workDiary.controller.js
@@ -1,0 +1,358 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import mongoose from 'mongoose'
+import { t } from '../i18n/messages.js'
+import WorkDiary from '../models/workDiary.model.js'
+import { uploadFile, getSignedUrl } from '../utils/gcs.js'
+import { decodeFilename } from '../utils/decodeFilename.js'
+import logger from '../config/logger.js'
+import { ROLES } from '../config/roles.js'
+
+const PUBLIC_VISIBILITY = ['team', 'company']
+const ALLOWED_VISIBILITIES = ['private', 'team', 'company', 'custom']
+const AUTHOR_ALLOWED_STATUSES = new Set(['draft', 'submitted'])
+const REVIEW_STATUSES = new Set(['approved', 'rejected'])
+
+const isManager = user => user?.roleId?.name === ROLES.MANAGER
+
+const normalizeDate = value => {
+  if (!value) return undefined
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw Object.assign(new Error('INVALID_DATE'), { status: 400 })
+  }
+  const normalized = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+  return normalized
+}
+
+const parseJSONField = (value, defaultValue) => {
+  if (value === undefined || value === null || value === '') return defaultValue
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value)
+    } catch (err) {
+      throw Object.assign(new Error('INVALID_JSON'), { status: 400 })
+    }
+  }
+  return value
+}
+
+const parseKeepImages = keep => {
+  if (keep === undefined) return undefined
+  const arr = Array.isArray(keep) ? keep : [keep]
+  return arr.filter(Boolean)
+}
+
+const parseVisibleTo = value => {
+  if (value === undefined) return undefined
+  const list = Array.isArray(value) ? value : [value]
+  return list.filter(Boolean).map(id => {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw Object.assign(new Error('INVALID_ID'), { status: 400 })
+    }
+    return id
+  })
+}
+
+const uploadImages = async files => {
+  if (!files?.length) return []
+  const paths = await Promise.all(
+    files.map(async file => {
+      const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`
+      const originalName = decodeFilename(file.originalname)
+      const ext = path.extname(originalName)
+      const filename = `work-diaries/${unique}${ext}`
+      const storedPath = await uploadFile(file.path, filename, file.mimetype)
+      await fs.unlink(file.path)
+      return storedPath
+    })
+  )
+  logger.debug('work diary uploaded images:', paths)
+  return paths
+}
+
+const appendSignedUrls = async diary => {
+  if (!diary) return diary
+  const obj = diary.toObject ? diary.toObject({ virtuals: true }) : diary
+  if (!obj.images?.length) return obj
+  const images = await Promise.all(
+    obj.images.map(async filePath => {
+      try {
+        const url = await getSignedUrl(filePath)
+        return { path: filePath, url }
+      } catch (err) {
+        logger.warn('failed to get signed url for diary image %s: %s', filePath, err.message)
+        return { path: filePath, url: '' }
+      }
+    })
+  )
+  return { ...obj, images }
+}
+
+const ensureCanAccess = (user, diary) => {
+  if (!diary) return false
+  if (isManager(user)) return true
+  const authorId = diary.author?._id?.toString?.() || diary.author?.toString?.()
+  const userId = user?._id?.toString?.()
+  if (authorId && userId && authorId === userId) return true
+  if (PUBLIC_VISIBILITY.includes(diary.visibility)) return true
+  if (Array.isArray(diary.visibleTo)) {
+    const visible = diary.visibleTo.some(person => person?.toString?.() === userId)
+    if (visible) return true
+  }
+  return false
+}
+
+const ensureCanEdit = (user, diary) => {
+  if (isManager(user)) return true
+  const authorId = diary.author?._id?.toString?.() || diary.author?.toString?.()
+  const userId = user?._id?.toString?.()
+  return authorId === userId
+}
+
+export const listWorkDiaries = async (req, res) => {
+  const query = {}
+
+  if (req.query.author) {
+    if (!mongoose.Types.ObjectId.isValid(req.query.author)) {
+      return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+    }
+    query.author = req.query.author
+  }
+
+  if (req.query.date) {
+    try {
+      const date = normalizeDate(req.query.date)
+      const next = new Date(date)
+      next.setUTCDate(next.getUTCDate() + 1)
+      query.date = { $gte: date, $lt: next }
+    } catch (err) {
+      return res.status(err.status || 400).json({ message: t('DATA_FORMAT_ERROR') })
+    }
+  } else {
+    const { startDate, endDate } = req.query
+    if (startDate || endDate) {
+      try {
+        const range = {}
+        if (startDate) range.$gte = normalizeDate(startDate)
+        if (endDate) {
+          const end = normalizeDate(endDate)
+          const next = new Date(end)
+          next.setUTCDate(next.getUTCDate() + 1)
+          range.$lt = next
+        }
+        query.date = range
+      } catch (err) {
+        return res.status(err.status || 400).json({ message: t('DATA_FORMAT_ERROR') })
+      }
+    }
+  }
+
+  if (!isManager(req.user)) {
+    query.$or = [
+      { author: req.user._id },
+      { visibility: { $in: PUBLIC_VISIBILITY } },
+      { visibleTo: req.user._id }
+    ]
+  }
+
+  const diaries = await WorkDiary.find(query)
+    .sort({ date: -1 })
+    .populate('author', 'username name email roleId')
+    .populate('managerComment.commentedBy', 'username name email roleId')
+
+  const diariesWithUrls = await Promise.all(diaries.map(appendSignedUrls))
+  res.json(diariesWithUrls)
+}
+
+export const getWorkDiary = async (req, res) => {
+  const diary = await WorkDiary.findById(req.params.diaryId)
+    .populate('author', 'username name email roleId')
+    .populate('managerComment.commentedBy', 'username name email roleId')
+  if (!diary) return res.status(404).json({ message: t('DIARY_NOT_FOUND') })
+  if (!ensureCanAccess(req.user, diary)) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+  const diaryWithUrls = await appendSignedUrls(diary)
+  res.json(diaryWithUrls)
+}
+
+export const createWorkDiary = async (req, res) => {
+  const { title, status, visibility } = req.body
+  if (!title) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+  }
+  let date
+  try {
+    date = normalizeDate(req.body.date)
+  } catch (err) {
+    return res.status(err.status || 400).json({ message: t('DATA_FORMAT_ERROR') })
+  }
+  if (!date) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+  }
+
+  let contentBlocks
+  try {
+    contentBlocks = parseJSONField(req.body.contentBlocks, [])
+  } catch (err) {
+    return res.status(err.status || 400).json({ message: t('DATA_FORMAT_ERROR') })
+  }
+  if (!Array.isArray(contentBlocks)) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+  }
+
+  let visibleTo
+  try {
+    visibleTo = parseVisibleTo(req.body.visibleTo)
+  } catch {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+  }
+
+  const images = await uploadImages(req.files)
+
+  let authorId = req.user._id
+  if (isManager(req.user) && req.body.author) {
+    if (!mongoose.Types.ObjectId.isValid(req.body.author)) {
+      return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+    }
+    authorId = req.body.author
+  }
+
+  const diaryData = {
+    author: authorId,
+    date,
+    title,
+    contentBlocks,
+    images,
+    visibility: visibility || 'private'
+  }
+  if (visibleTo !== undefined) diaryData.visibleTo = visibleTo
+
+  if (status) {
+    if (isManager(req.user) || AUTHOR_ALLOWED_STATUSES.has(status)) {
+      diaryData.status = status
+    } else {
+      return res.status(403).json({ message: t('DIARY_EDIT_FORBIDDEN') })
+    }
+  }
+
+  if (visibility && !ALLOWED_VISIBILITIES.includes(visibility)) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+  }
+
+  try {
+    const diary = await WorkDiary.create(diaryData)
+    const populated = await diary
+      .populate('author', 'username name email roleId')
+      .populate('managerComment.commentedBy', 'username name email roleId')
+    const diaryWithUrls = await appendSignedUrls(populated)
+    res.status(201).json(diaryWithUrls)
+  } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ message: t('DIARY_DUPLICATE') })
+    }
+    throw err
+  }
+}
+
+export const updateWorkDiary = async (req, res) => {
+  const diary = await WorkDiary.findById(req.params.diaryId)
+  if (!diary) return res.status(404).json({ message: t('DIARY_NOT_FOUND') })
+  if (!ensureCanEdit(req.user, diary)) {
+    return res.status(403).json({ message: t('DIARY_EDIT_FORBIDDEN') })
+  }
+
+  const update = {}
+
+  if (req.body.title !== undefined) update.title = req.body.title
+
+  if (req.body.date) {
+    try {
+      update.date = normalizeDate(req.body.date)
+    } catch (err) {
+      return res.status(err.status || 400).json({ message: t('DATA_FORMAT_ERROR') })
+    }
+  }
+
+  if (req.body.contentBlocks !== undefined) {
+    try {
+      update.contentBlocks = parseJSONField(req.body.contentBlocks, [])
+    } catch (err) {
+      return res.status(err.status || 400).json({ message: t('DATA_FORMAT_ERROR') })
+    }
+    if (!Array.isArray(update.contentBlocks)) {
+      return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+    }
+  }
+
+  if (req.body.visibility) {
+    if (!ALLOWED_VISIBILITIES.includes(req.body.visibility)) {
+      return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+    }
+    update.visibility = req.body.visibility
+  }
+
+  if (req.body.visibleTo !== undefined) {
+    try {
+      update.visibleTo = parseVisibleTo(req.body.visibleTo)
+    } catch (err) {
+      return res.status(err.status || 400).json({ message: t('DATA_FORMAT_ERROR') })
+    }
+  }
+
+  if (req.body.status) {
+    const requestedStatus = req.body.status
+    if (isManager(req.user) || AUTHOR_ALLOWED_STATUSES.has(requestedStatus)) {
+      update.status = requestedStatus
+    } else {
+      return res.status(403).json({ message: t('DIARY_EDIT_FORBIDDEN') })
+    }
+  }
+
+  const keep = parseKeepImages(req.body.keepImages)
+  let images = keep !== undefined ? [...keep] : undefined
+  if (req.files?.length) {
+    const uploaded = await uploadImages(req.files)
+    images = images ? [...images, ...uploaded] : uploaded
+  }
+  if (images !== undefined) {
+    update.images = images
+  }
+
+  Object.assign(diary, update)
+  await diary.save()
+  await diary.populate('author', 'username name email roleId')
+  await diary.populate('managerComment.commentedBy', 'username name email roleId')
+  const diaryWithUrls = await appendSignedUrls(diary)
+  res.json(diaryWithUrls)
+}
+
+export const reviewWorkDiary = async (req, res) => {
+  if (!isManager(req.user)) {
+    return res.status(403).json({ message: t('DIARY_REVIEW_FORBIDDEN') })
+  }
+
+  const { status, comment } = req.body
+  if (!status || !REVIEW_STATUSES.has(status)) {
+    return res.status(400).json({ message: t('DATA_FORMAT_ERROR') })
+  }
+
+  const update = {
+    status,
+    managerComment: {
+      text: comment || '',
+      commentedBy: req.user._id,
+      commentedAt: new Date()
+    }
+  }
+
+  const diary = await WorkDiary.findByIdAndUpdate(req.params.diaryId, update, { new: true })
+    .populate('author', 'username name email roleId')
+    .populate('managerComment.commentedBy', 'username name email roleId')
+
+  if (!diary) return res.status(404).json({ message: t('DIARY_NOT_FOUND') })
+
+  const diaryWithUrls = await appendSignedUrls(diary)
+  res.json(diaryWithUrls)
+}

--- a/server/src/i18n/messages.js
+++ b/server/src/i18n/messages.js
@@ -39,6 +39,10 @@ export const languages = {
     MISSING_FILENAME: '缺少档名',
     MISSING_FILENAME_OR_PATH: '缺少档名或路径',
     MISSING_CLIENT_ID: '缺少 clientId',
+    DIARY_NOT_FOUND: '找不到工作日誌',
+    DIARY_DUPLICATE: '當日工作日誌已存在',
+    DIARY_EDIT_FORBIDDEN: '無權編輯此工作日誌',
+    DIARY_REVIEW_FORBIDDEN: '無權審核此工作日誌',
     UPDATED: '已更新',
     MOVED: '已移动',
     DELETED: '已删除'

--- a/server/src/models/workDiary.model.js
+++ b/server/src/models/workDiary.model.js
@@ -1,0 +1,56 @@
+import mongoose from 'mongoose'
+
+const contentBlockSchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      enum: ['text', 'todo', 'link', 'custom'],
+      default: 'text'
+    },
+    value: { type: String, default: '' },
+    order: { type: Number, default: 0 }
+  },
+  { _id: false }
+)
+
+const managerCommentSchema = new mongoose.Schema(
+  {
+    text: { type: String, default: '' },
+    commentedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    commentedAt: { type: Date }
+  },
+  { _id: false }
+)
+
+const workDiarySchema = new mongoose.Schema(
+  {
+    author: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    date: { type: Date, required: true },
+    title: { type: String, required: true, trim: true },
+    contentBlocks: { type: [contentBlockSchema], default: [] },
+    images: { type: [String], default: [] },
+    managerComment: { type: managerCommentSchema, default: {} },
+    status: {
+      type: String,
+      enum: ['draft', 'submitted', 'approved', 'rejected'],
+      default: 'draft'
+    },
+    visibility: {
+      type: String,
+      enum: ['private', 'team', 'company', 'custom'],
+      default: 'private'
+    },
+    visibleTo: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'User',
+      default: []
+    }
+  },
+  { timestamps: true }
+)
+
+workDiarySchema.index({ author: 1, date: 1 }, { unique: true })
+workDiarySchema.index({ date: -1 })
+workDiarySchema.index({ status: 1 })
+
+export default mongoose.model('WorkDiary', workDiarySchema)

--- a/server/src/routes/workDiary.routes.js
+++ b/server/src/routes/workDiary.routes.js
@@ -1,0 +1,35 @@
+import { Router } from 'express'
+import { protect } from '../middleware/auth.js'
+import { authorize } from '../middleware/roleGuard.js'
+import { upload } from '../middleware/upload.js'
+import asyncHandler from '../utils/asyncHandler.js'
+import { ROLES } from '../config/roles.js'
+import {
+  listWorkDiaries,
+  getWorkDiary,
+  createWorkDiary,
+  updateWorkDiary,
+  reviewWorkDiary
+} from '../controllers/workDiary.controller.js'
+
+const router = Router()
+
+router.use(protect)
+
+router
+  .route('/')
+  .get(asyncHandler(listWorkDiaries))
+  .post(upload.array('images'), asyncHandler(createWorkDiary))
+
+router
+  .route('/:diaryId')
+  .get(asyncHandler(getWorkDiary))
+  .put(upload.array('images'), asyncHandler(updateWorkDiary))
+
+router.patch(
+  '/:diaryId/review',
+  authorize(ROLES.MANAGER),
+  asyncHandler(reviewWorkDiary)
+)
+
+export default router

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -89,6 +89,7 @@ import dashboardRoutes    from './routes/dashboard.routes.js'
 import departmentRoutes   from './routes/department.routes.js'
 import popularContentRoutes from './routes/popularContent.routes.js'
 import scriptIdeaRoutes   from './routes/scriptIdea.routes.js'
+import workDiaryRoutes    from './routes/workDiary.routes.js'
 
 app.use('/api/auth',     authRoutes)
 app.use('/api/user',     userRoutes)
@@ -105,6 +106,7 @@ app.use('/api/clients/:clientId/platforms/:platformId/ad-daily', adDailyRoutes)
 app.use('/api/clients/:clientId/platforms/:platformId/weekly-notes', weeklyNoteRoutes)
 app.use('/api/clients/:clientId/popular-contents', popularContentRoutes)
 app.use('/api/clients/:clientId/script-ideas', scriptIdeaRoutes)
+app.use('/api/work-diaries', workDiaryRoutes)
 app.use('/api/permissions', permissionsRoutes)
 app.use('/api/menus', menusRoutes)
 app.use('/api/review-stages', reviewStageRoutes)

--- a/server/tests/workDiary.test.js
+++ b/server/tests/workDiary.test.js
@@ -1,0 +1,219 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach
+} from '@jest/globals'
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let uploadFileMock
+let getSignedUrlMock
+let managerToken
+let employeeToken
+let otherEmployeeToken
+let employeeId
+let managerId
+let diaryId
+let firstImagePath
+
+let Role
+let User
+beforeAll(async () => {
+  jest.unstable_mockModule('../src/utils/gcs.js', () => ({
+    uploadFile: jest.fn().mockImplementation((_path, destination) => Promise.resolve(destination)),
+    getSignedUrl: jest
+      .fn()
+      .mockImplementation(filePath => `https://signed.example.com/${filePath}`)
+  }))
+
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  const [{ default: workDiaryRoutes }, { default: authRoutes }] = await Promise.all([
+    import('../src/routes/workDiary.routes.js'),
+    import('../src/routes/auth.routes.js')
+  ])
+
+  ;[{ default: Role }, { default: User }] = await Promise.all([
+    import('../src/models/role.model.js'),
+    import('../src/models/user.model.js')
+  ])
+
+  const gcs = await import('../src/utils/gcs.js')
+  uploadFileMock = gcs.uploadFile
+  getSignedUrlMock = gcs.getSignedUrl
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/work-diaries', workDiaryRoutes)
+
+  const managerRole = await Role.create({ name: 'manager' })
+  const employeeRole = await Role.create({ name: 'employee' })
+
+  const manager = await User.create({
+    username: 'manager',
+    password: 'pass123',
+    email: 'manager@test.com',
+    roleId: managerRole._id
+  })
+  managerId = manager._id.toString()
+
+  const employee = await User.create({
+    username: 'alice',
+    password: 'pass123',
+    email: 'alice@test.com',
+    roleId: employeeRole._id
+  })
+  employeeId = employee._id.toString()
+
+  const otherEmployee = await User.create({
+    username: 'bob',
+    password: 'pass123',
+    email: 'bob@test.com',
+    roleId: employeeRole._id
+  })
+
+  const managerLogin = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'manager', password: 'pass123' })
+    .expect(200)
+  managerToken = managerLogin.body.token
+
+  const employeeLogin = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'alice', password: 'pass123' })
+    .expect(200)
+  employeeToken = employeeLogin.body.token
+
+  const otherEmployeeLogin = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'bob', password: 'pass123' })
+    .expect(200)
+  otherEmployeeToken = otherEmployeeLogin.body.token
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+beforeEach(() => {
+  uploadFileMock.mockClear()
+  getSignedUrlMock.mockClear()
+})
+
+describe('Work Diary API', () => {
+  it('員工可以建立自己的工作日誌並附帶圖片簽名網址', async () => {
+    const res = await request(app)
+      .post('/api/work-diaries')
+      .set('Authorization', `Bearer ${employeeToken}`)
+      .field('date', '2024-05-20')
+      .field('title', '第一天工作紀錄')
+      .field('contentBlocks', JSON.stringify([{ type: 'text', value: '完成需求整理' }]))
+      .attach('images', Buffer.from('hello'), 'note.png')
+      .expect(201)
+
+    expect(uploadFileMock).toHaveBeenCalled()
+    expect(res.body.title).toBe('第一天工作紀錄')
+    expect(res.body.images).toHaveLength(1)
+    expect(res.body.images[0].url).toContain('https://signed.example.com/')
+    diaryId = res.body._id
+    firstImagePath = res.body.images[0].path
+  })
+
+  it('其他員工無法檢視或編輯私有日誌', async () => {
+    await request(app)
+      .get(`/api/work-diaries/${diaryId}`)
+      .set('Authorization', `Bearer ${otherEmployeeToken}`)
+      .expect(403)
+
+    await request(app)
+      .put(`/api/work-diaries/${diaryId}`)
+      .set('Authorization', `Bearer ${otherEmployeeToken}`)
+      .field('title', '嘗試竄改')
+      .expect(403)
+  })
+
+  it('列表支援篩選並依角色限制可見資料', async () => {
+    await request(app)
+      .post('/api/work-diaries')
+      .set('Authorization', `Bearer ${otherEmployeeToken}`)
+      .field('date', '2024-05-21')
+      .field('title', '第二位員工日誌')
+      .field('status', 'submitted')
+      .expect(201)
+
+    const managerList = await request(app)
+      .get('/api/work-diaries')
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200)
+    expect(managerList.body.length).toBeGreaterThanOrEqual(2)
+
+    const employeeList = await request(app)
+      .get('/api/work-diaries')
+      .set('Authorization', `Bearer ${employeeToken}`)
+      .expect(200)
+    expect(employeeList.body.every(diary => diary.author._id === employeeId)).toBe(true)
+
+    const filterByAuthor = await request(app)
+      .get(`/api/work-diaries?author=${employeeId}`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200)
+    expect(filterByAuthor.body.every(diary => diary.author._id === employeeId)).toBe(true)
+
+    const filterByDate = await request(app)
+      .get('/api/work-diaries?startDate=2024-05-20&endDate=2024-05-20')
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200)
+    expect(filterByDate.body.every(diary => diary.date.startsWith('2024-05-20'))).toBe(true)
+  })
+
+  it('員工更新自己的日誌可保留舊圖片並新增新圖片', async () => {
+    const res = await request(app)
+      .put(`/api/work-diaries/${diaryId}`)
+      .set('Authorization', `Bearer ${employeeToken}`)
+      .field('title', '第一天工作紀錄（更新）')
+      .field('keepImages', firstImagePath)
+      .attach('images', Buffer.from('new file'), 'new.png')
+      .expect(200)
+
+    expect(uploadFileMock).toHaveBeenCalled()
+    expect(res.body.images).toHaveLength(2)
+    const paths = res.body.images.map(img => img.path)
+    expect(paths).toContain(firstImagePath)
+  })
+
+  it('非主管不得審核工作日誌', async () => {
+    await request(app)
+      .patch(`/api/work-diaries/${diaryId}/review`)
+      .set('Authorization', `Bearer ${employeeToken}`)
+      .send({ status: 'approved', comment: '自審不允許' })
+      .expect(403)
+  })
+
+  it('主管可審核並留下留言', async () => {
+    const res = await request(app)
+      .patch(`/api/work-diaries/${diaryId}/review`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send({ status: 'approved', comment: '做得很好' })
+      .expect(200)
+
+    expect(getSignedUrlMock).toHaveBeenCalled()
+    expect(res.body.status).toBe('approved')
+    expect(res.body.managerComment.text).toBe('做得很好')
+    expect(res.body.managerComment.commentedBy._id).toBe(managerId)
+  })
+})


### PR DESCRIPTION
## Summary
- 建立工作日誌模型與唯一索引，涵蓋作者、日期、內容、權限欄位
- 實作工作日誌控制器與路由，支援查詢、編輯、審核與圖片簽名網址
- 新增工作日誌整合測試覆蓋 CRUD、權限驗證與圖片流程

## Testing
- `npm --prefix server test` *(因環境缺少 jest 套件無法執行)*

------
https://chatgpt.com/codex/tasks/task_e_68dbea526af0832980943a0f7c8a0b71