### PR TITLE
feat: 新增工作日誌權限與通知流程

### DIFF
--- a/client/src/permissionNames.js
+++ b/client/src/permissionNames.js
@@ -10,5 +10,9 @@ export const PERMISSION_NAMES = {
   'review:manage': '成品审查流程',
   'tag:manage': '标签管理',
   'role:manage': '角色权限设定',
-  'analytics:view': '查看统计资料'
+  'analytics:view': '查看统计资料',
+  'work-diary:read-all': '檢視所有工作日誌',
+  'work-diary:read-own': '檢視個人工作日誌',
+  'work-diary:review': '審核工作日誌',
+  'work-diary:comment': '主管留言工作日誌'
 }

--- a/client/src/services/notifications.js
+++ b/client/src/services/notifications.js
@@ -1,4 +1,4 @@
 import api from './api'
 
 export const fetchNotifications = (limit = 10) =>
-  api.get('/assets/recent', { params: { limit } }).then(res => res.data)
+  api.get('/notifications', { params: { limit } }).then(res => res.data)

--- a/client/src/stores/notifications.js
+++ b/client/src/stores/notifications.js
@@ -13,18 +13,14 @@ export const useNotificationStore = defineStore('notifications', {
   actions: {
     async fetch() {
       const data = await fetchNotifications()
-      this.list = data.map(item => {
-        const base = item.fileType === 'edited' ? '/products' : '/assets'
-        const folderPath = item.folderId ? `${base}/${item.folderId}` : base
-        const detailPath = item._id ? `${folderPath}/asset/${item._id}` : folderPath
-        return {
-          id: item._id,
-          title: item.fileName,
-          type: item.fileType,
-          link: detailPath,
-          read: false
-        }
-      })
+      this.list = data.map(item => ({
+        id: item.id || item._id,
+        title: item.title || item.message || '通知',
+        message: item.message || '',
+        type: item.type || 'general',
+        link: item.link || '#',
+        read: Boolean(item.read)
+      }))
     },
     markAsRead(id) {
       const target = this.list.find(n => n.id === id)

--- a/client/src/views/WorkDiary.test.js
+++ b/client/src/views/WorkDiary.test.js
@@ -265,7 +265,7 @@ describe('WorkDiary.vue', () => {
       user: {
         _id: 'emp1',
         name: '一般員工',
-        permissions: [],
+        permissions: ['work-diary:read-own'],
         menus: ['work-diaries']
       }
     }
@@ -273,7 +273,14 @@ describe('WorkDiary.vue', () => {
     const { wrapper } = await mountWorkDiary({ user })
 
     expect(listWorkDiariesMock).toHaveBeenCalled()
+    expect(listWorkDiariesMock).toHaveBeenCalledWith({
+      date: expect.any(String),
+      userId: 'emp1'
+    })
     expect(getWorkDiaryMock).toHaveBeenCalledWith('d1')
+
+    const userFilter = wrapper.find('.work-diary-toolbar .dropdown-stub')
+    expect(userFilter.exists()).toBe(false)
 
     const statusDropdown = wrapper.find('select.status-dropdown')
     expect(statusDropdown.exists()).toBe(false)
@@ -297,7 +304,12 @@ describe('WorkDiary.vue', () => {
       user: {
         _id: 'leader',
         name: '主管',
-        permissions: ['work-diary:review'],
+        permissions: [
+          'work-diary:read-all',
+          'work-diary:read-own',
+          'work-diary:review',
+          'work-diary:comment'
+        ],
         menus: ['work-diaries']
       }
     }
@@ -305,6 +317,9 @@ describe('WorkDiary.vue', () => {
     const { wrapper } = await mountWorkDiary({ user, path: '/work-diaries/2024-05-01' })
 
     await flushPromises()
+
+    const userFilter = wrapper.find('.work-diary-toolbar .dropdown-stub')
+    expect(userFilter.exists()).toBe(true)
 
     const statusDropdown = wrapper.find('select.status-dropdown')
     expect(statusDropdown.exists()).toBe(true)

--- a/server/src/config/permissions.js
+++ b/server/src/config/permissions.js
@@ -10,5 +10,9 @@ export const PERMISSIONS = Object.freeze({
   REVIEW_MANAGE: 'review:manage',
   TAG_MANAGE: 'tag:manage',
   ROLE_MANAGE: 'role:manage',
-  ANALYTICS_VIEW: 'analytics:view'
+  ANALYTICS_VIEW: 'analytics:view',
+  WORK_DIARY_READ_ALL: 'work-diary:read-all',
+  WORK_DIARY_READ_OWN: 'work-diary:read-own',
+  WORK_DIARY_REVIEW: 'work-diary:review',
+  WORK_DIARY_COMMENT: 'work-diary:comment'
 })

--- a/server/src/config/roles.js
+++ b/server/src/config/roles.js
@@ -1,8 +1,24 @@
+import { PERMISSIONS } from './permissions.js'
+
 /**
- * \u7cfb\u7d71\u89d2\u8272\u5e38\u6578\u5b9a\u7fa9
+ * 系統角色常數定義
  */
 export const ROLES = Object.freeze({
   EMPLOYEE: 'employee',
   MANAGER: 'manager',
   OUTSOURCE: 'outsource'
+})
+
+/**
+ * 角色預設權限
+ */
+export const ROLE_DEFAULT_PERMISSIONS = Object.freeze({
+  [ROLES.EMPLOYEE]: [PERMISSIONS.WORK_DIARY_READ_OWN],
+  [ROLES.MANAGER]: [
+    PERMISSIONS.WORK_DIARY_READ_ALL,
+    PERMISSIONS.WORK_DIARY_READ_OWN,
+    PERMISSIONS.WORK_DIARY_REVIEW,
+    PERMISSIONS.WORK_DIARY_COMMENT
+  ],
+  [ROLES.OUTSOURCE]: []
 })

--- a/server/src/controllers/notification.controller.js
+++ b/server/src/controllers/notification.controller.js
@@ -1,0 +1,33 @@
+import { listNotificationsByUser, markNotificationRead } from '../services/notification.service.js'
+
+export const getNotifications = async (req, res) => {
+  const limit = Math.min(parseInt(req.query.limit, 10) || 10, 50)
+  const notifications = await listNotificationsByUser(req.user._id, { limit })
+  res.json(
+    notifications.map((item) => ({
+      id: item._id,
+      type: item.type,
+      title: item.title,
+      message: item.message,
+      link: item.link,
+      payload: item.payload,
+      read: item.read,
+      createdAt: item.createdAt
+    }))
+  )
+}
+
+export const readNotification = async (req, res) => {
+  const updated = await markNotificationRead(req.params.id, req.user._id)
+  if (!updated) return res.status(404).json({ message: 'Notification not found' })
+  res.json({
+    id: updated._id,
+    type: updated.type,
+    title: updated.title,
+    message: updated.message,
+    link: updated.link,
+    payload: updated.payload,
+    read: updated.read,
+    createdAt: updated.createdAt
+  })
+}

--- a/server/src/controllers/workDiary.controller.js
+++ b/server/src/controllers/workDiary.controller.js
@@ -1,0 +1,248 @@
+import mongoose from 'mongoose'
+import WorkDiary, { WORK_DIARY_STATUS } from '../models/workDiary.model.js'
+import { PERMISSIONS } from '../config/permissions.js'
+import { includeManagers } from '../utils/includeManagers.js'
+import { createNotifications } from '../services/notification.service.js'
+import { t } from '../i18n/messages.js'
+
+const toDateRange = (value) => {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  const start = new Date(date)
+  start.setHours(0, 0, 0, 0)
+  const end = new Date(start)
+  end.setHours(23, 59, 59, 999)
+  return { start, end }
+}
+
+const formatDateString = (date) => {
+  if (!date) return ''
+  const d = typeof date === 'string' ? new Date(date) : date
+  if (Number.isNaN(d.getTime())) return ''
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+const hasPermission = (req, perm) =>
+  Array.isArray(req.user?.roleId?.permissions) &&
+  req.user.roleId.permissions.includes(perm)
+
+const ensureReadAccess = (req) => {
+  const canReadAll = hasPermission(req, PERMISSIONS.WORK_DIARY_READ_ALL)
+  const canReadOwn = hasPermission(req, PERMISSIONS.WORK_DIARY_READ_OWN)
+  if (!canReadAll && !canReadOwn) {
+    const err = new Error(t('PERMISSION_DENIED'))
+    err.status = 403
+    throw err
+  }
+  return { canReadAll, canReadOwn }
+}
+
+export const listWorkDiaries = async (req, res) => {
+  const { canReadAll } = ensureReadAccess(req)
+  const range = toDateRange(req.query.date)
+  const filter = {}
+  if (range) {
+    filter.date = { $gte: range.start, $lte: range.end }
+  }
+
+  if (canReadAll) {
+    if (req.query.userId && req.query.userId !== 'all') {
+      filter.owner = new mongoose.Types.ObjectId(req.query.userId)
+    }
+  } else {
+    filter.owner = req.user._id
+  }
+
+  const diaries = await WorkDiary.find(filter)
+    .populate('owner', 'name email')
+    .sort({ updatedAt: -1 })
+
+  res.json(
+    diaries.map((item) => ({
+      id: item._id,
+      title: item.title,
+      content: item.content,
+      summary: item.summary,
+      status: item.status,
+      supervisorComment: item.supervisorComment,
+      date: item.date,
+      author: item.owner,
+      images: item.images || [],
+      detailLoaded: true
+    }))
+  )
+}
+
+export const getWorkDiary = async (req, res) => {
+  const { canReadAll } = ensureReadAccess(req)
+  const diary = await WorkDiary.findById(req.params.id).populate('owner', 'name email')
+  if (!diary) return res.status(404).json({ message: t('NOTE_NOT_FOUND') })
+  if (!canReadAll && diary.owner._id.toString() !== req.user._id.toString()) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+  res.json({
+    id: diary._id,
+    title: diary.title,
+    content: diary.content,
+    summary: diary.summary,
+    status: diary.status,
+    supervisorComment: diary.supervisorComment,
+    date: diary.date,
+    author: diary.owner,
+    images: diary.images || [],
+    detailLoaded: true
+  })
+}
+
+const buildNotificationLink = (diary) => {
+  const date = formatDateString(diary.date)
+  const ownerId = diary.owner?._id?.toString?.() || diary.owner?.toString?.() || ''
+  return ownerId ? `/work-diaries/${date}/${ownerId}` : `/work-diaries/${date}`
+}
+
+export const updateWorkDiary = async (req, res) => {
+  const { canReadAll, canReadOwn } = ensureReadAccess(req)
+  const diary = await WorkDiary.findById(req.params.id).populate('owner', 'name email')
+  if (!diary) return res.status(404).json({ message: t('NOTE_NOT_FOUND') })
+
+  const ownerId = diary.owner?._id?.toString?.()
+  const currentUserId = req.user._id.toString()
+  const isOwner = ownerId === currentUserId
+  const canReview = hasPermission(req, PERMISSIONS.WORK_DIARY_REVIEW)
+  const canComment = hasPermission(req, PERMISSIONS.WORK_DIARY_COMMENT)
+
+  if (!isOwner && !canReview && !canComment) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+
+  if (!canReadAll && canReadOwn && !isOwner) {
+    return res.status(403).json({ message: t('PERMISSION_DENIED') })
+  }
+
+  const updates = {}
+  if ('title' in req.body && (isOwner || canReview)) updates.title = req.body.title
+  if ('content' in req.body && (isOwner || canReview)) updates.content = req.body.content
+  if ('summary' in req.body && (isOwner || canReview)) updates.summary = req.body.summary
+
+  const nextStatus = req.body.status
+  const statusAllowedForOwner =
+    isOwner &&
+    nextStatus &&
+    [WORK_DIARY_STATUS.DRAFT, WORK_DIARY_STATUS.SUBMITTED].includes(nextStatus)
+
+  if (nextStatus && (canReview || statusAllowedForOwner)) {
+    updates.status = nextStatus
+  }
+
+  if ('supervisorComment' in req.body && (canReview || canComment)) {
+    updates.supervisorComment = req.body.supervisorComment
+  }
+
+  const previousStatus = diary.status
+  const previousComment = diary.supervisorComment
+
+  diary.set(updates)
+  await diary.save()
+
+  const result = await WorkDiary.findById(diary._id).populate('owner', 'name email')
+
+  const notifications = []
+
+  if (
+    isOwner &&
+    updates.status === WORK_DIARY_STATUS.SUBMITTED &&
+    previousStatus !== WORK_DIARY_STATUS.SUBMITTED
+  ) {
+    const managerIds = await includeManagers([])
+    if (managerIds.length) {
+      await createNotifications(managerIds, {
+        type: 'work-diary:submitted',
+        title: `${diary.owner.name || '員工'} 提交 ${formatDateString(diary.date)} 日誌`,
+        message: `${diary.owner.name || '員工'} 已提交工作日誌，請進行審核。`,
+        link: buildNotificationLink(diary),
+        payload: { diaryId: diary._id.toString(), status: diary.status }
+      })
+    }
+  }
+
+  if (
+    !isOwner &&
+    (updates.status !== undefined || updates.supervisorComment !== undefined) &&
+    (previousStatus !== diary.status || previousComment !== diary.supervisorComment)
+  ) {
+    notifications.push({
+      type: 'work-diary:reviewed',
+      title: `${req.user.name || '主管'} 更新了您的日誌`,
+      message:
+        updates.status && updates.status !== previousStatus
+          ? `日誌狀態變更為 ${updates.status}`
+          : '主管已新增留言',
+      link: buildNotificationLink(diary),
+      payload: {
+        diaryId: diary._id.toString(),
+        status: diary.status,
+        supervisorComment: diary.supervisorComment
+      }
+    })
+  }
+
+  if (notifications.length) {
+    await createNotifications([ownerId], notifications[0])
+  }
+
+  res.json({
+    id: result._id,
+    title: result.title,
+    content: result.content,
+    summary: result.summary,
+    status: result.status,
+    supervisorComment: result.supervisorComment,
+    date: result.date,
+    author: result.owner,
+    images: result.images || [],
+    detailLoaded: true
+  })
+}
+
+export const createWorkDiary = async (req, res) => {
+  const { canReadAll, canReadOwn } = ensureReadAccess(req)
+  let owner = req.user._id
+  if (canReadAll && req.body.owner) {
+    owner = req.body.owner
+  } else if (!canReadOwn) {
+    const err = new Error(t('PERMISSION_DENIED'))
+    err.status = 403
+    throw err
+  }
+
+  const range = toDateRange(req.body.date)
+  const date = range ? range.start : new Date()
+
+  const diary = await WorkDiary.create({
+    title: req.body.title || '',
+    content: req.body.content || '',
+    summary: req.body.summary || '',
+    date,
+    status: req.body.status || WORK_DIARY_STATUS.DRAFT,
+    supervisorComment: req.body.supervisorComment || '',
+    owner
+  })
+
+  const populated = await diary.populate('owner', 'name email')
+  res.status(201).json({
+    id: populated._id,
+    title: populated.title,
+    content: populated.content,
+    summary: populated.summary,
+    status: populated.status,
+    supervisorComment: populated.supervisorComment,
+    date: populated.date,
+    author: populated.owner,
+    images: populated.images || [],
+    detailLoaded: true
+  })
+}

--- a/server/src/models/notification.model.js
+++ b/server/src/models/notification.model.js
@@ -1,0 +1,18 @@
+import mongoose from 'mongoose'
+
+const notificationSchema = new mongoose.Schema(
+  {
+    recipient: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    type: { type: String, required: true },
+    title: { type: String, required: true },
+    message: { type: String, default: '' },
+    link: { type: String, default: '' },
+    payload: { type: mongoose.Schema.Types.Mixed, default: {} },
+    read: { type: Boolean, default: false }
+  },
+  { timestamps: true }
+)
+
+notificationSchema.index({ recipient: 1, createdAt: -1 })
+
+export default mongoose.model('Notification', notificationSchema)

--- a/server/src/models/workDiary.model.js
+++ b/server/src/models/workDiary.model.js
@@ -1,0 +1,40 @@
+import mongoose from 'mongoose'
+
+export const WORK_DIARY_STATUS = Object.freeze({
+  DRAFT: 'draft',
+  SUBMITTED: 'submitted',
+  APPROVED: 'approved',
+  REVISION: 'revision'
+})
+
+const imageSchema = new mongoose.Schema(
+  {
+    id: { type: String },
+    path: { type: String },
+    name: { type: String },
+    url: { type: String }
+  },
+  { _id: false }
+)
+
+const workDiarySchema = new mongoose.Schema(
+  {
+    title: { type: String, default: '' },
+    content: { type: String, default: '' },
+    summary: { type: String, default: '' },
+    date: { type: Date, required: true },
+    status: {
+      type: String,
+      enum: Object.values(WORK_DIARY_STATUS),
+      default: WORK_DIARY_STATUS.DRAFT
+    },
+    supervisorComment: { type: String, default: '' },
+    owner: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    images: { type: [imageSchema], default: [] }
+  },
+  { timestamps: true }
+)
+
+workDiarySchema.index({ date: 1, owner: 1 })
+
+export default mongoose.model('WorkDiary', workDiarySchema)

--- a/server/src/routes/notification.routes.js
+++ b/server/src/routes/notification.routes.js
@@ -1,0 +1,13 @@
+import express from 'express'
+import asyncHandler from 'express-async-handler'
+import { protect } from '../middleware/auth.js'
+import { getNotifications, readNotification } from '../controllers/notification.controller.js'
+
+const router = express.Router()
+
+router.use(protect)
+
+router.route('/').get(asyncHandler(getNotifications))
+router.route('/:id/read').patch(asyncHandler(readNotification))
+
+export default router

--- a/server/src/routes/workDiary.routes.js
+++ b/server/src/routes/workDiary.routes.js
@@ -1,0 +1,25 @@
+import express from 'express'
+import asyncHandler from 'express-async-handler'
+import { protect } from '../middleware/auth.js'
+import {
+  listWorkDiaries,
+  getWorkDiary,
+  updateWorkDiary,
+  createWorkDiary
+} from '../controllers/workDiary.controller.js'
+
+const router = express.Router()
+
+router.use(protect)
+
+router
+  .route('/')
+  .get(asyncHandler(listWorkDiaries))
+  .post(asyncHandler(createWorkDiary))
+
+router
+  .route('/:id')
+  .get(asyncHandler(getWorkDiary))
+  .put(asyncHandler(updateWorkDiary))
+
+export default router

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -5,7 +5,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import User from '../models/user.model.js'
 import Role from '../models/role.model.js'
-import { ROLES } from '../config/roles.js'
+import { ROLES, ROLE_DEFAULT_PERMISSIONS } from '../config/roles.js'
 import { PERMISSIONS } from '../config/permissions.js'
 import { MENUS } from '../config/menus.js'
 
@@ -30,6 +30,7 @@ const seed = async () => {
     const roleDocs = await Role.insertMany([
       {
         name: ROLES.EMPLOYEE,
+        permissions: ROLE_DEFAULT_PERMISSIONS[ROLES.EMPLOYEE],
         menus: [
           MENUS.DASHBOARD,
           MENUS.ASSETS,
@@ -45,6 +46,7 @@ const seed = async () => {
       },
       {
         name: ROLES.OUTSOURCE,
+        permissions: ROLE_DEFAULT_PERMISSIONS[ROLES.OUTSOURCE],
         menus: [MENUS.ASSETS]
       }
     ])

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -89,6 +89,8 @@ import dashboardRoutes    from './routes/dashboard.routes.js'
 import departmentRoutes   from './routes/department.routes.js'
 import popularContentRoutes from './routes/popularContent.routes.js'
 import scriptIdeaRoutes   from './routes/scriptIdea.routes.js'
+import workDiaryRoutes    from './routes/workDiary.routes.js'
+import notificationRoutes from './routes/notification.routes.js'
 
 app.use('/api/auth',     authRoutes)
 app.use('/api/user',     userRoutes)
@@ -105,6 +107,8 @@ app.use('/api/clients/:clientId/platforms/:platformId/ad-daily', adDailyRoutes)
 app.use('/api/clients/:clientId/platforms/:platformId/weekly-notes', weeklyNoteRoutes)
 app.use('/api/clients/:clientId/popular-contents', popularContentRoutes)
 app.use('/api/clients/:clientId/script-ideas', scriptIdeaRoutes)
+app.use('/api/work-diaries', workDiaryRoutes)
+app.use('/api/notifications', notificationRoutes)
 app.use('/api/permissions', permissionsRoutes)
 app.use('/api/menus', menusRoutes)
 app.use('/api/review-stages', reviewStageRoutes)

--- a/server/src/services/notification.service.js
+++ b/server/src/services/notification.service.js
@@ -1,0 +1,31 @@
+import Notification from '../models/notification.model.js'
+
+export const createNotifications = async (recipients = [], data = {}) => {
+  const ids = Array.from(new Set((recipients || []).filter(Boolean)))
+  if (!ids.length) return []
+  const payload = ids.map((recipient) => ({
+    recipient,
+    type: data.type || 'general',
+    title: data.title || '通知',
+    message: data.message || '',
+    link: data.link || '',
+    payload: data.payload || {}
+  }))
+  return Notification.insertMany(payload)
+}
+
+export const listNotificationsByUser = async (userId, { limit = 10 } = {}) => {
+  if (!userId) return []
+  return Notification.find({ recipient: userId })
+    .sort({ createdAt: -1 })
+    .limit(limit)
+}
+
+export const markNotificationRead = async (id, userId) => {
+  if (!id || !userId) return null
+  return Notification.findOneAndUpdate(
+    { _id: id, recipient: userId },
+    { $set: { read: true } },
+    { new: true }
+  )
+}

--- a/server/tests/workDiary.test.js
+++ b/server/tests/workDiary.test.js
@@ -1,0 +1,155 @@
+import request from 'supertest'
+import express from 'express'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import authRoutes from '../src/routes/auth.routes.js'
+import workDiaryRoutes from '../src/routes/workDiary.routes.js'
+import notificationRoutes from '../src/routes/notification.routes.js'
+import Role from '../src/models/role.model.js'
+import User from '../src/models/user.model.js'
+import WorkDiary, { WORK_DIARY_STATUS } from '../src/models/workDiary.model.js'
+import Notification from '../src/models/notification.model.js'
+import { PERMISSIONS } from '../src/config/permissions.js'
+import { ROLES } from '../src/config/roles.js'
+import dotenv from 'dotenv'
+
+dotenv.config({ override: true })
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret'
+
+let mongo
+let app
+let employee
+let manager
+let employeeToken
+let managerToken
+let diary
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create()
+  await mongoose.connect(mongo.getUri())
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRoutes)
+  app.use('/api/work-diaries', workDiaryRoutes)
+  app.use('/api/notifications', notificationRoutes)
+
+  const employeeRole = await Role.create({
+    name: ROLES.EMPLOYEE,
+    permissions: [PERMISSIONS.WORK_DIARY_READ_OWN]
+  })
+
+  const managerRole = await Role.create({
+    name: ROLES.MANAGER,
+    permissions: [
+      PERMISSIONS.WORK_DIARY_READ_ALL,
+      PERMISSIONS.WORK_DIARY_READ_OWN,
+      PERMISSIONS.WORK_DIARY_REVIEW,
+      PERMISSIONS.WORK_DIARY_COMMENT
+    ]
+  })
+
+  employee = await User.create({
+    username: 'emp1',
+    password: 'pass1234',
+    email: 'emp1@example.com',
+    roleId: employeeRole._id
+  })
+
+  manager = await User.create({
+    username: 'manager1',
+    password: 'pass1234',
+    email: 'manager@example.com',
+    roleId: managerRole._id,
+    name: '主管'
+  })
+
+  const employeeLogin = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'emp1', password: 'pass1234' })
+    .expect(200)
+  employeeToken = employeeLogin.body.token
+
+  const managerLogin = await request(app)
+    .post('/api/auth/login')
+    .send({ username: 'manager1', password: 'pass1234' })
+    .expect(200)
+  managerToken = managerLogin.body.token
+
+  diary = await WorkDiary.create({
+    title: '日誌 A',
+    content: '內容 A',
+    owner: employee._id,
+    date: new Date('2024-05-01T00:00:00Z'),
+    status: WORK_DIARY_STATUS.DRAFT
+  })
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongo.stop()
+})
+
+beforeEach(async () => {
+  await Notification.deleteMany({})
+})
+
+describe('Work diary permissions', () => {
+  it('員工僅能讀取自身日誌', async () => {
+    const res = await request(app)
+      .get('/api/work-diaries')
+      .query({ date: '2024-05-01' })
+      .set('Authorization', `Bearer ${employeeToken}`)
+      .expect(200)
+
+    expect(res.body).toHaveLength(1)
+    expect(res.body[0].author._id).toBe(employee._id.toString())
+  })
+
+  it('主管可讀取指定成員日誌', async () => {
+    const res = await request(app)
+      .get('/api/work-diaries')
+      .query({ date: '2024-05-01', userId: employee._id.toString() })
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200)
+
+    expect(res.body).toHaveLength(1)
+    expect(res.body[0].author._id).toBe(employee._id.toString())
+  })
+})
+
+describe('Work diary notifications', () => {
+  it('員工提交日誌時通知主管', async () => {
+    await request(app)
+      .put(`/api/work-diaries/${diary._id}`)
+      .set('Authorization', `Bearer ${employeeToken}`)
+      .send({ status: WORK_DIARY_STATUS.SUBMITTED })
+      .expect(200)
+
+    const res = await request(app)
+      .get('/api/notifications')
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200)
+
+    expect(res.body).toHaveLength(1)
+    expect(res.body[0].type).toBe('work-diary:submitted')
+    expect(res.body[0].title).toContain('日誌')
+  })
+
+  it('主管審核或留言時通知員工', async () => {
+    await request(app)
+      .put(`/api/work-diaries/${diary._id}`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send({ status: WORK_DIARY_STATUS.APPROVED, supervisorComment: '辛苦了' })
+      .expect(200)
+
+    const res = await request(app)
+      .get('/api/notifications')
+      .set('Authorization', `Bearer ${employeeToken}`)
+      .expect(200)
+
+    expect(res.body).toHaveLength(1)
+    expect(res.body[0].type).toBe('work-diary:reviewed')
+    expect(res.body[0].message).toContain('日誌')
+  })
+})


### PR DESCRIPTION
## Summary
- 新增工作日誌相關權限常數與角色預設設定，並於種子資料同步設定
- 建立工作日誌 API 及通知服務，支援主管審核與員工提交流程並觸發通知
- 更新前端權限檢查、通知來源與工作日誌畫面邏輯，補上相關單元測試

## Testing
- `npm test` *(因無法安裝 server 套件導致 jest 缺失未能執行)*
- `npm --prefix client test -- --run src/views/WorkDiary.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68dbebf91c548329b8964c293a100e93