### PR TITLE
新增工作日誌菜單選項

### DIFF
--- a/server/src/config/menus.js
+++ b/server/src/config/menus.js
@@ -9,5 +9,6 @@ export const MENUS = Object.freeze({
   POPULAR_DATA: 'popular-data',
   AD_DATA: 'ad-data',
   SCRIPT_IDEAS: 'script-ideas',
+  WORK_DIARIES: 'work-diaries',
   ACCOUNT: 'account'
 })

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -34,6 +34,7 @@ const seed = async () => {
           MENUS.DASHBOARD,
           MENUS.ASSETS,
           MENUS.PRODUCTS,
+          MENUS.WORK_DIARIES,
           MENUS.POPULAR_DATA,
           MENUS.ACCOUNT
         ]


### PR DESCRIPTION
## Summary
- 新增 WORK_DIARIES 菜單常數，讓菜單 API 可回傳工作日誌選項
- 更新預設角色種子資料，讓員工角色包含工作日誌菜單

## Testing
- `npm run test` *(失敗：環境缺少 jest 套件，無法於容器內安裝依賴)*

------
https://chatgpt.com/codex/tasks/task_e_68dc317ea85c8329827c9212b108fa8e