### PR TITLE
調整腳本記錄日期格式並補上相關測試

### DIFF
--- a/client/src/utils/date.js
+++ b/client/src/utils/date.js
@@ -1,0 +1,16 @@
+export const formatDateOnly = (value) => {
+  if (!value) return ''
+
+  if (typeof value === 'string') {
+    const match = value.match(/^\d{4}-\d{2}-\d{2}/)
+    if (match) return match[0]
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}

--- a/client/src/utils/date.test.js
+++ b/client/src/utils/date.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { formatDateOnly } from './date'
+
+describe('formatDateOnly', () => {
+  it('可以將 Date 物件格式化為 yyyy-MM-dd', () => {
+    const result = formatDateOnly(new Date('2024-05-15T15:30:00Z'))
+    expect(result).toBe('2024-05-15')
+  })
+
+  it('可以處理字串輸入', () => {
+    const result = formatDateOnly('2024-01-01T00:00:00+08:00')
+    expect(result).toBe('2024-01-01')
+  })
+
+  it('遇到無效日期時回傳空字串', () => {
+    expect(formatDateOnly('invalid')).toBe('')
+    expect(formatDateOnly(null)).toBe('')
+  })
+})

--- a/client/src/views/script-ideas/ScriptIdeasRecords.vue
+++ b/client/src/views/script-ideas/ScriptIdeasRecords.vue
@@ -82,6 +82,7 @@ import {
   updateScriptIdea,
   SCRIPT_IDEA_STATUS
 } from '@/services/scriptIdeas'
+import { formatDateOnly } from '@/utils/date'
 
 const props = defineProps({
   clientId: {
@@ -142,7 +143,7 @@ const closeDialog = () => {
 }
 
 const buildPayload = () => ({
-  date: form.date ? form.date.toISOString() : '',
+  date: form.date ? formatDateOnly(form.date) : '',
   location: form.location,
   scriptCount: form.scriptCount,
   status: form.status


### PR DESCRIPTION
## Summary
- 新增 `formatDateOnly` 工具函式並在腳本記錄建立/編輯時使用，以避免傳送 UTC ISO 字串造成日期偏移
- 為腳本創意紀錄畫面導入新工具函式，確保提交資料與使用者選擇的日期一致
- 補上 `formatDateOnly` 的單元測試並執行腳本創意相關測試驗證流程

## Testing
- npm --prefix client test -- run src/utils/date.test.js src/views/script-ideas/ScriptIdeas.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc3afc30c483299d9415430cda2d56