### PR TITLE
feat: 加入腳本創意權限驗證

### DIFF
--- a/client/src/permissionNames.js
+++ b/client/src/permissionNames.js
@@ -10,6 +10,8 @@ export const PERMISSION_NAMES = {
   'review:manage': '成品审查流程',
   'tag:manage': '标签管理',
   'role:manage': '角色权限设定',
+  'script-idea:read': '腳本創意檢視',
+  'script-idea:manage': '腳本創意管理',
   'analytics:view': '查看统计资料',
   'work-diary:manage:self': '管理個人工作日誌',
   'work-diary:read:all': '檢視所有工作日誌',

--- a/server/src/config/permissions.js
+++ b/server/src/config/permissions.js
@@ -10,6 +10,8 @@ export const PERMISSIONS = Object.freeze({
   REVIEW_MANAGE: 'review:manage',
   TAG_MANAGE: 'tag:manage',
   ROLE_MANAGE: 'role:manage',
+  SCRIPT_IDEA_READ: 'script-idea:read',
+  SCRIPT_IDEA_MANAGE: 'script-idea:manage',
   ANALYTICS_VIEW: 'analytics:view',
   WORK_DIARY_MANAGE_SELF: 'work-diary:manage:self',
   WORK_DIARY_READ_ALL: 'work-diary:read:all',

--- a/server/src/routes/scriptIdea.routes.js
+++ b/server/src/routes/scriptIdea.routes.js
@@ -1,9 +1,11 @@
 import { Router } from 'express'
 import { body } from 'express-validator'
 import { protect } from '../middleware/auth.js'
+import { requirePerm } from '../middleware/permission.js'
 import { upload } from '../middleware/upload.js'
 import { validate } from '../middleware/validate.js'
 import asyncHandler from '../utils/asyncHandler.js'
+import { PERMISSIONS } from '../config/permissions.js'
 import {
   listScriptIdeas,
   createScriptIdea,
@@ -16,10 +18,11 @@ const router = Router({ mergeParams: true })
 
 router.use(protect)
 
-router.get('/', asyncHandler(listScriptIdeas))
+router.get('/', requirePerm(PERMISSIONS.SCRIPT_IDEA_READ), asyncHandler(listScriptIdeas))
 
 router.post(
   '/',
+  requirePerm(PERMISSIONS.SCRIPT_IDEA_MANAGE),
   upload.single('video'),
   body('date').notEmpty().withMessage('腳本日期為必填').isISO8601().withMessage('腳本日期格式錯誤'),
   body('scriptCount').optional().isNumeric().withMessage('腳本數量需為數字'),
@@ -28,10 +31,15 @@ router.post(
   asyncHandler(createScriptIdea)
 )
 
-router.get('/:ideaId', asyncHandler(getScriptIdea))
+router.get(
+  '/:ideaId',
+  requirePerm(PERMISSIONS.SCRIPT_IDEA_READ),
+  asyncHandler(getScriptIdea)
+)
 
 router.put(
   '/:ideaId',
+  requirePerm(PERMISSIONS.SCRIPT_IDEA_MANAGE),
   upload.single('video'),
   body('date').optional().isISO8601().withMessage('腳本日期格式錯誤'),
   body('scriptCount').optional().isNumeric().withMessage('腳本數量需為數字'),
@@ -40,6 +48,10 @@ router.put(
   asyncHandler(updateScriptIdea)
 )
 
-router.delete('/:ideaId', asyncHandler(deleteScriptIdea))
+router.delete(
+  '/:ideaId',
+  requirePerm(PERMISSIONS.SCRIPT_IDEA_MANAGE),
+  asyncHandler(deleteScriptIdea)
+)
 
 export default router

--- a/server/src/scripts/seedUsers.js
+++ b/server/src/scripts/seedUsers.js
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'node:url'
 import User from '../models/user.model.js'
 import Role from '../models/role.model.js'
 import { ROLES, ROLE_DEFAULT_PERMISSIONS, ROLE_DEFAULT_MENUS } from '../config/roles.js'
+import { PERMISSIONS } from '../config/permissions.js'
+import { MENUS } from '../config/menus.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 dotenv.config({ path: path.resolve(__dirname, '../../.env') })


### PR DESCRIPTION
## Summary
- 新增腳本創意讀取與管理權限常數，並同步調整權限名稱與相關種子腳本
- 將腳本創意 API 路由套用對應權限驗證，補強測試涵蓋缺權限情境
- 更新前端權限顯示名稱以支援角色管理介面挑選新權限

## Testing
- npm test *(失敗，因專案缺少依賴無法安裝 Jest)*
- npm run test *(部分測試失敗，現有 AdData 測試用例未通過)*

------
https://chatgpt.com/codex/tasks/task_e_68dc45f270848329ae0c5fa2386004a9