### PR TITLE
修正腳本創意客戶搜尋時的空名稱處理

### DIFF
--- a/client/src/views/script-ideas/ScriptIdeas.test.js
+++ b/client/src/views/script-ideas/ScriptIdeas.test.js
@@ -273,6 +273,32 @@ describe('ScriptIdeas 客戶列表', () => {
     await manageButton.trigger('click')
     expect(pushSpy).toHaveBeenCalledWith({ name: 'ScriptIdeasRecords', params: { clientId: 'c2' } })
   })
+
+  it('客戶缺少名稱時仍能顯示並支援搜尋', async () => {
+    fetchClientsMock.mockResolvedValueOnce([
+      { _id: 'c1', name: null },
+      { _id: 'c2', name: '晨曦品牌' }
+    ])
+
+    const router = await createTestRouter()
+    const wrapper = mount(ScriptIdeas, { global: { plugins: [router], stubs: globalStubs } })
+    await flushPromises()
+
+    const cards = wrapper.findAll('.card-stub')
+    expect(cards).toHaveLength(2)
+
+    const headings = wrapper.findAll('.card-stub h2')
+    expect(headings[0].text()).toBe('')
+    expect(headings[1].text()).toBe('晨曦品牌')
+
+    const searchInput = wrapper.find('input')
+    await searchInput.setValue('晨曦')
+    await flushPromises()
+
+    const filteredCards = wrapper.findAll('.card-stub')
+    expect(filteredCards).toHaveLength(1)
+    expect(wrapper.text()).toContain('晨曦品牌')
+  })
 })
 
 describe('ScriptIdeasRecords 管理腳本記錄', () => {

--- a/client/src/views/script-ideas/ScriptIdeas.vue
+++ b/client/src/views/script-ideas/ScriptIdeas.vue
@@ -56,7 +56,10 @@ const errorMessage = ref('')
 const filteredClients = computed(() => {
   const k = keyword.value.trim().toLowerCase()
   if (!k) return clients.value
-  return clients.value.filter((client) => client.name?.toLowerCase().includes(k))
+  return clients.value.filter((client) => {
+    const name = (client.name ?? '').toLowerCase()
+    return name.includes(k)
+  })
 })
 
 const goToRecords = (client) => {


### PR DESCRIPTION
## Summary
- 以空字串回填客戶名稱後再進行搜尋比對，避免空值拋錯
- 補上客戶缺少名稱時仍可顯示與搜尋的單元測試

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dcc4bb21d88329942afd7f568ff391