### PR TITLE
修正爆款客戶搜尋的空值處理

### DIFF
--- a/client/src/views/PopularData.test.js
+++ b/client/src/views/PopularData.test.js
@@ -136,6 +136,27 @@ describe('PopularData 客戶列表', () => {
     await wrapper.findAll('button')[0].trigger('click')
     expect(pushSpy).toHaveBeenCalledWith({ name: 'PopularDataPlatforms', params: { clientId: '2' } })
   })
+
+  it('含無名稱客戶時仍可載入並搜尋', async () => {
+    fetchClientsMock.mockResolvedValueOnce([
+      { _id: '1' },
+      { _id: '2', name: '晨曦品牌' }
+    ])
+
+    const router = await createTestRouter()
+    const wrapper = mount(PopularData, { global: { stubs: globalStubs, plugins: [router] } })
+    await flushPromises()
+
+    expect(wrapper.findAll('.card-stub').length).toBe(2)
+    expect(wrapper.text()).toContain('晨曦品牌')
+
+    const input = wrapper.find('input')
+    await input.setValue('晨曦')
+    await flushPromises()
+
+    expect(wrapper.findAll('.card-stub').length).toBe(1)
+    expect(wrapper.text()).toContain('晨曦品牌')
+  })
 })
 
 describe('PopularData 平台選擇', () => {

--- a/client/src/views/popular-data/PopularData.vue
+++ b/client/src/views/popular-data/PopularData.vue
@@ -47,7 +47,10 @@ const clients = ref([])
 const filteredClients = computed(() => {
   const k = keyword.value.trim().toLowerCase()
   if (!k) return clients.value
-  return clients.value.filter((client) => client.name?.toLowerCase().includes(k))
+  return clients.value.filter((client) => {
+    const name = (client?.name ?? '').toLowerCase()
+    return name.includes(k)
+  })
 })
 
 const loadClients = async () => {


### PR DESCRIPTION
## Summary
- ensure PopularData 搜尋時對缺少名稱的客戶以空字串處理避免錯誤
- 新增含無名稱客戶的搜尋測試案例

## Testing
- npm run test -- src/views/PopularData.test.js --run

------
https://chatgpt.com/codex/tasks/task_e_68dcc687f3608329af246480366b06cb