### PR TITLE
完善工作日誌內容欄位與序列化

### DIFF
--- a/client/src/views/WorkDiary.test.js
+++ b/client/src/views/WorkDiary.test.js
@@ -353,6 +353,48 @@ describe('WorkDiary.vue', () => {
     })
   })
 
+  it('缺少 content 欄位時會從 contentBlocks 推導顯示內容', async () => {
+    const user = {
+      token: 'token',
+      user: {
+        _id: 'emp1',
+        name: '一般員工',
+        permissions: ['work-diary:manage:self', 'work-diary:read:self'],
+        menus: ['work-diaries']
+      }
+    }
+
+    const diaries = [
+      {
+        id: 'd-block',
+        title: '日誌區塊',
+        status: 'submitted',
+        author: { _id: 'emp1', name: '一般員工' },
+        contentBlocks: [{ type: 'text', value: '摘要段落', order: 0 }]
+      }
+    ]
+
+    const detail = {
+      id: 'd-block',
+      title: '日誌區塊',
+      status: 'submitted',
+      images: [],
+      contentBlocks: [
+        { type: 'text', value: '第一段內容', order: 0 },
+        { type: 'text', value: '第二段內容', order: 1 }
+      ]
+    }
+
+    const { wrapper } = await mountWorkDiary({ user, diaries, detail })
+
+    const listPreview = wrapper.find('.list-item .item-preview')
+    expect(listPreview.text()).toContain('第一段內容')
+
+    const detailTextarea = wrapper.find('#diary-content')
+    expect(detailTextarea.element.value).toBe(`第一段內容
+第二段內容`)
+  })
+
   it('可以建立日誌並重新整理列表', async () => {
     const user = {
       token: 'token',


### PR DESCRIPTION
## Summary
- 建立與更新工作日誌時支援以 content 欄位建立預設 contentBlocks，並在序列化時回傳聚合後的 content 字串
- 改寫 appendSignedUrls 於回傳物件上補齊 content 與簽名圖片資料
- 前端 store 與頁面在缺少 content 時會從 contentBlocks 推導內容，確保列表與表單都有文字
- 新增後端與前端測試，驗證建立、更新後的內容可正確讀出並顯示

## Testing
- `npx vitest run src/views/WorkDiary.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e26762a4ac832986f85f2694a01df3