### PR TITLE
新增工作日誌圖片追加與刪除 API

### DIFF
--- a/client/src/services/workDiary.js
+++ b/client/src/services/workDiary.js
@@ -70,7 +70,7 @@ export const uploadWorkDiaryImages = (diaryId, files = []) => {
 
 export const removeWorkDiaryImage = (diaryId, imageId) =>
   api
-    .delete(`/work-diaries/${diaryId}/images/${imageId}`)
+    .delete(`/work-diaries/${diaryId}/images/${encodeURIComponent(imageId)}`)
     .then((res) => res.data)
 
 export default {

--- a/server/src/i18n/messages.js
+++ b/server/src/i18n/messages.js
@@ -43,6 +43,7 @@ export const languages = {
     DIARY_DUPLICATE: '當日工作日誌已存在',
     DIARY_EDIT_FORBIDDEN: '無權編輯此工作日誌',
     DIARY_REVIEW_FORBIDDEN: '無權審核此工作日誌',
+    DIARY_IMAGE_NOT_FOUND: '找不到指定圖片',
     UPDATED: '已更新',
     MOVED: '已移动',
     DELETED: '已删除'

--- a/server/src/routes/workDiary.routes.js
+++ b/server/src/routes/workDiary.routes.js
@@ -9,6 +9,8 @@ import {
   getWorkDiary,
   createWorkDiary,
   updateWorkDiary,
+  addWorkDiaryImages,
+  removeWorkDiaryImage,
   reviewWorkDiary
 } from '../controllers/workDiary.controller.js'
 
@@ -45,6 +47,19 @@ router
     upload.array('images'),
     asyncHandler(updateWorkDiary)
   )
+
+router.post(
+  '/:diaryId/images',
+  requirePerm(PERMISSIONS.WORK_DIARY_MANAGE_SELF),
+  upload.array('images'),
+  asyncHandler(addWorkDiaryImages)
+)
+
+router.delete(
+  '/:diaryId/images/:imageId',
+  requirePerm(PERMISSIONS.WORK_DIARY_MANAGE_SELF),
+  asyncHandler(removeWorkDiaryImage)
+)
 
 router.patch(
   '/:diaryId/review',


### PR DESCRIPTION
## Summary
- 新增工作日誌圖片追加與刪除控制器，沿用既有簽名網址流程
- 補上圖片上傳與刪除路由權限設定並回傳最新圖片列表
- 擴充工作日誌測試涵蓋圖片追加/刪除情境與 404 行為，並於前端刪除 API 編碼路徑參數

## Testing
- `npm test` *(因環境缺少 jest 套件無法執行)*

------
https://chatgpt.com/codex/tasks/task_e_68e271a77a508329833594d64975d1a8