### PR TITLE
調整主管留言欄位處理流程

### DIFF
--- a/client/src/stores/workDiary.js
+++ b/client/src/stores/workDiary.js
@@ -56,11 +56,29 @@ const normalizeDiaryItem = (item) => {
       : hasContentField
       ? Boolean(item.content)
       : false
+  const managerComment =
+    item.managerComment && typeof item.managerComment === 'object'
+      ? {
+          ...item.managerComment,
+          text:
+            item.managerComment.text !== undefined && item.managerComment.text !== null
+              ? String(item.managerComment.text)
+              : '',
+          commentedBy: item.managerComment.commentedBy ?? null,
+          commentedAt: item.managerComment.commentedAt ?? null
+        }
+      : { text: '', commentedBy: null, commentedAt: null }
+  const supervisorComment =
+    item.supervisorComment !== undefined && item.supervisorComment !== null
+      ? String(item.supervisorComment)
+      : managerComment.text
   return {
     ...item,
     id,
     content: derivedContent,
-    detailLoaded
+    detailLoaded,
+    managerComment,
+    supervisorComment
   }
 }
 

--- a/client/src/views/WorkDiary.test.js
+++ b/client/src/views/WorkDiary.test.js
@@ -235,7 +235,7 @@ const mountWorkDiary = async ({
     title: '日誌 A',
     content: '今日完成任務。',
     status: 'submitted',
-    supervisorComment: '請再補充銷售結果',
+    managerComment: { text: '請再補充銷售結果' },
     images: []
   }
 }) => {
@@ -349,7 +349,7 @@ describe('WorkDiary.vue', () => {
       title: '日誌 A',
       content: '今日完成任務。',
       status: 'approved',
-      supervisorComment: '辛苦了，保持品質。'
+      managerComment: { text: '辛苦了，保持品質。' }
     })
   })
 

--- a/client/src/views/WorkDiary.vue
+++ b/client/src/views/WorkDiary.vue
@@ -215,7 +215,7 @@
                   <label class="field-label" for="diary-supervisor">主管留言</label>
                   <Textarea
                     id="diary-supervisor"
-                    v-model="detailForm.supervisorComment"
+                    v-model="detailForm.managerCommentText"
                     autoResize
                     rows="5"
                     :readonly="!isSupervisor"
@@ -617,10 +617,12 @@ watch(
       return
     }
     const content = getDiaryContent(diary)
+    const commentText =
+      diary.managerComment?.text ?? diary.supervisorComment ?? ''
     detailForm.value = {
       title: diary.title || '',
       content,
-      supervisorComment: diary.supervisorComment || '',
+      managerCommentText: commentText,
       status: diary.status || WORK_DIARY_STATUS.DRAFT,
       images: Array.isArray(diary.images) ? [...diary.images] : []
     }
@@ -657,9 +659,11 @@ const handleSave = async () => {
     status: canChangeStatus.value
       ? detailForm.value.status
       : workDiaryStore.selectedDiary?.status,
-    supervisorComment: isSupervisor.value
-      ? detailForm.value.supervisorComment
-      : workDiaryStore.selectedDiary?.supervisorComment
+  }
+  if (isSupervisor.value) {
+    payload.managerComment = {
+      text: detailForm.value.managerCommentText ?? ''
+    }
   }
   try {
     await workDiaryStore.saveDiary(workDiaryStore.selectedDiaryId, payload)


### PR DESCRIPTION
## Summary
- 後端更新工作日誌時支援主管直接更新留言並統一回傳 managerComment/supervisorComment 欄位
- 前端工作日誌頁面與 store 調整為讀寫 managerComment.text 以帶入既有留言
- 補充後端與前端測試以涵蓋主管透過 PUT 更新留言的情境

## Testing
- npm --prefix client run test -- --run src/views/WorkDiary.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2733fcb1c832980c1bd1d70da8c8c