### PR TITLE
feat: 強化工作日誌權限設定與檢視體驗

### DIFF
--- a/client/src/stores/workDiary.js
+++ b/client/src/stores/workDiary.js
@@ -72,13 +72,31 @@ const normalizeDiaryItem = (item) => {
     item.supervisorComment !== undefined && item.supervisorComment !== null
       ? String(item.supervisorComment)
       : managerComment.text
+  const visibleTo = Array.isArray(item.visibleTo)
+    ? item.visibleTo
+        .map((viewer) => {
+          const viewerId = viewer?._id || viewer?.id || viewer
+          if (!viewerId) return null
+          if (typeof viewer === 'object') {
+            return {
+              ...viewer,
+              id: viewerId,
+              name: viewer.name || viewer.displayName || viewer.username || viewer.email || ''
+            }
+          }
+          return { id: viewerId }
+        })
+        .filter(Boolean)
+    : []
   return {
     ...item,
     id,
     content: derivedContent,
     detailLoaded,
     managerComment,
-    supervisorComment
+    supervisorComment,
+    visibleTo,
+    visibility: item.visibility || 'private'
   }
 }
 

--- a/server/src/models/role.model.js
+++ b/server/src/models/role.model.js
@@ -23,6 +23,12 @@ const roleSchema = new mongoose.Schema(
         message: 'Invalid menu'
       },
       default: []
+    },
+
+    workDiaryViewers: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'User',
+      default: []
     }
 
 


### PR DESCRIPTION
## Summary
- 新增角色層級的工作日誌可見者設定，後端強制保留指定可見名單並回傳詳細資訊
- 工作日誌頁面支援切換「顯示全部日誌」、顯示日曆日期與可見者多選，並補上使用者清單載入流程
- 角色管理介面可維護日誌可見者，並同步調整前端與測試覆蓋

## Testing
- npm --prefix client test -- WorkDiary

------
https://chatgpt.com/codex/tasks/task_e_68e4c2db57f4832999319307b12c0f77