### PR TITLE
修復腳本創意頁面空白並新增除錯紀錄

### DIFF
--- a/client/src/views/script-ideas/ScriptIdeas.vue
+++ b/client/src/views/script-ideas/ScriptIdeas.vue
@@ -19,6 +19,13 @@
       <p>{{ errorMessage }}</p>
     </section>
 
+    <section v-else-if="loadError" class="load-error">
+      <i class="pi pi-exclamation-triangle"></i>
+      <h2>客戶載入失敗</h2>
+      <p>{{ errorMessage }}</p>
+      <Button label="重新嘗試" icon="pi pi-refresh" @click="loadClients" />
+    </section>
+
     <section v-else class="script-ideas__content">
       <p v-if="filteredClients.length === 0" class="empty">目前沒有符合條件的客戶</p>
       <div v-else class="client-grid">
@@ -51,6 +58,7 @@ const keyword = ref('')
 const clients = ref([])
 const loading = ref(true)
 const permissionError = ref(false)
+const loadError = ref(false)
 const errorMessage = ref('')
 
 const filteredClients = computed(() => {
@@ -69,16 +77,22 @@ const goToRecords = (client) => {
 const loadClients = async () => {
   loading.value = true
   permissionError.value = false
+  loadError.value = false
   errorMessage.value = ''
   try {
     clients.value = await fetchClients()
+    console.info('[ScriptIdeas] 已載入客戶列表', { count: clients.value.length })
   } catch (error) {
     if (error?.response?.status === 403) {
       permissionError.value = true
       errorMessage.value = '請聯絡管理者開啟腳本創意檢視權限。'
       clients.value = []
+      console.warn('[ScriptIdeas] 缺少腳本創意檢視權限', error)
     } else {
       toast.add({ severity: 'error', summary: '載入失敗', detail: '無法取得客戶列表', life: 3000 })
+      loadError.value = true
+      errorMessage.value = '暫時無法載入客戶，請稍後再試。'
+      console.error('[ScriptIdeas] 取得客戶列表失敗', error)
     }
   } finally {
     loading.value = false
@@ -195,6 +209,33 @@ onMounted(loadClients)
 }
 
 .permission-error p {
+  margin: 0;
+  max-width: 420px;
+}
+
+.load-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem 1.5rem;
+  text-align: center;
+  color: #6b7280;
+}
+
+.load-error i {
+  font-size: 2rem;
+  color: #f59e0b;
+}
+
+.load-error h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #111827;
+}
+
+.load-error p {
   margin: 0;
   max-width: 420px;
 }

--- a/client/src/views/script-ideas/ScriptIdeasDetail.vue
+++ b/client/src/views/script-ideas/ScriptIdeasDetail.vue
@@ -152,13 +152,20 @@ const loadDetail = async () => {
     removeVideo.value = false
     videoFiles.value = []
     videoFile.value = null
+    console.info('[ScriptIdeasDetail] 已載入腳本詳情', {
+      clientId: props.clientId,
+      ideaId: props.recordId,
+      hasVideo: Boolean(data?.videoUrl)
+    })
   } catch (error) {
     if (error?.response?.status === 403) {
       permissionError.value = true
       errorMessage.value = '請聯絡管理者開啟腳本創意檢視權限。'
       idea.value = null
+      console.warn('[ScriptIdeasDetail] 檢視腳本詳情權限不足', error)
     } else {
       toast.add({ severity: 'error', summary: '載入失敗', detail: '無法取得腳本詳情', life: 3000 })
+      console.error('[ScriptIdeasDetail] 載入腳本詳情失敗', error)
     }
   } finally {
     loading.value = false
@@ -195,13 +202,21 @@ const save = async () => {
     await updateScriptIdea(props.clientId, props.recordId, buildPayload())
     toast.add({ severity: 'success', summary: '已儲存', detail: '腳本詳情更新成功', life: 2500 })
     await loadDetail()
+    console.info('[ScriptIdeasDetail] 已儲存腳本詳情', {
+      clientId: props.clientId,
+      ideaId: props.recordId,
+      removeVideo: removeVideo.value,
+      hasNewVideo: Boolean(videoFile.value)
+    })
   } catch (error) {
     if (error?.response?.status === 403) {
       permissionError.value = true
       errorMessage.value = '請聯絡管理者開啟腳本創意檢視權限。'
       toast.add({ severity: 'warn', summary: '無權限', detail: '您沒有腳本創意的編輯權限', life: 3000 })
+      console.warn('[ScriptIdeasDetail] 儲存腳本詳情權限不足', error)
     } else {
       toast.add({ severity: 'error', summary: '儲存失敗', detail: '請稍後再試', life: 3000 })
+      console.error('[ScriptIdeasDetail] 儲存腳本詳情失敗', error)
     }
   } finally {
     saving.value = false

--- a/client/src/views/script-ideas/ScriptIdeasRecords.vue
+++ b/client/src/views/script-ideas/ScriptIdeasRecords.vue
@@ -171,9 +171,11 @@ const submitForm = async () => {
     if (isEditing.value) {
       await updateScriptIdea(props.clientId, editingId.value, buildPayload())
       toast.add({ severity: 'success', summary: '更新成功', detail: '腳本記錄已更新', life: 2500 })
+      console.info('[ScriptIdeasRecords] 已更新腳本記錄', { clientId: props.clientId, ideaId: editingId.value })
     } else {
       await createScriptIdea(props.clientId, buildPayload())
       toast.add({ severity: 'success', summary: '新增成功', detail: '已建立新的腳本記錄', life: 2500 })
+      console.info('[ScriptIdeasRecords] 已新增腳本記錄', { clientId: props.clientId })
     }
     dialogVisible.value = false
     await loadRecords()
@@ -182,8 +184,10 @@ const submitForm = async () => {
       permissionError.value = true
       errorMessage.value = '請聯絡管理者開啟腳本創意檢視權限。'
       toast.add({ severity: 'warn', summary: '無權限', detail: '您沒有腳本創意的編輯權限', life: 3000 })
+      console.warn('[ScriptIdeasRecords] 編輯腳本記錄權限不足', error)
     } else {
       toast.add({ severity: 'error', summary: '儲存失敗', detail: '請稍後再試', life: 3000 })
+      console.error('[ScriptIdeasRecords] 儲存腳本記錄失敗', error)
     }
   } finally {
     saving.value = false
@@ -196,13 +200,16 @@ const confirmDelete = async (record) => {
     await deleteScriptIdea(props.clientId, record._id)
     toast.add({ severity: 'success', summary: '刪除成功', detail: '腳本記錄已刪除', life: 2500 })
     await loadRecords()
+    console.info('[ScriptIdeasRecords] 已刪除腳本記錄', { clientId: props.clientId, ideaId: record._id })
   } catch (error) {
     if (error?.response?.status === 403) {
       permissionError.value = true
       errorMessage.value = '請聯絡管理者開啟腳本創意檢視權限。'
       toast.add({ severity: 'warn', summary: '無權限', detail: '您沒有腳本創意的刪除權限', life: 3000 })
+      console.warn('[ScriptIdeasRecords] 刪除腳本記錄權限不足', error)
     } else {
       toast.add({ severity: 'error', summary: '刪除失敗', detail: '請稍後再試', life: 3000 })
+      console.error('[ScriptIdeasRecords] 刪除腳本記錄失敗', error)
     }
   }
 }
@@ -248,13 +255,16 @@ const loadRecords = async () => {
   loading.value = true
   try {
     records.value = await listScriptIdeas(props.clientId)
+    console.info('[ScriptIdeasRecords] 已載入腳本記錄', { clientId: props.clientId, count: records.value.length })
   } catch (error) {
     if (error?.response?.status === 403) {
       permissionError.value = true
       errorMessage.value = '請聯絡管理者開啟腳本創意檢視權限。'
       records.value = []
+      console.warn('[ScriptIdeasRecords] 取得腳本記錄權限不足', error)
     } else {
       toast.add({ severity: 'error', summary: '載入失敗', detail: '無法取得腳本記錄', life: 3000 })
+      console.error('[ScriptIdeasRecords] 載入腳本記錄發生錯誤', error)
     }
   } finally {
     loading.value = false
@@ -264,11 +274,16 @@ const loadRecords = async () => {
 const loadClient = async () => {
   try {
     client.value = await getClient(props.clientId)
+    if (client.value) {
+      console.info('[ScriptIdeasRecords] 已取得客戶資訊', { clientId: props.clientId, name: client.value.name })
+    }
   } catch (error) {
     if (error?.response?.status === 403) {
       permissionError.value = true
       errorMessage.value = '請聯絡管理者開啟腳本創意檢視權限。'
+      console.warn('[ScriptIdeasRecords] 取得客戶資訊權限不足', error)
     }
+    console.error('[ScriptIdeasRecords] 取得客戶資訊失敗', error)
     client.value = null
   }
 }


### PR DESCRIPTION
## Summary
- 為腳本創意客戶列表加上載入失敗狀態、重新嘗試按鈕與 console 記錄，避免僅顯示空白頁面
- 在腳本記錄與詳情頁補強成功與錯誤的 console log，協助後續排查

## Testing
- npx vitest run src/views/script-ideas/ScriptIdeas.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4d7ff25d883298004e976fc9d26cd