### PR TITLE
Add multi-script support to script ideas

### DIFF
--- a/server/src/models/scriptIdea.model.js
+++ b/server/src/models/scriptIdea.model.js
@@ -12,6 +12,25 @@ const storyboardSceneSchema = new mongoose.Schema(
   { _id: false }
 )
 
+const scriptContentSchema = new mongoose.Schema(
+  {
+    title: { type: String, trim: true, default: '' },
+    paragraphs: {
+      type: [String],
+      default: [],
+      set: (value) => {
+        if (!Array.isArray(value)) return []
+        return value.map((item) => {
+          if (typeof item === 'string') return item
+          if (!item || typeof item !== 'object') return ''
+          return typeof item.text === 'string' ? item.text : ''
+        })
+      }
+    }
+  },
+  { _id: false }
+)
+
 const scriptIdeaSchema = new mongoose.Schema(
   {
     clientId: {
@@ -89,6 +108,10 @@ const scriptIdeaSchema = new mongoose.Schema(
       type: String,
       trim: true,
       default: ''
+    },
+    scripts: {
+      type: [scriptContentSchema],
+      default: []
     },
     storyboard: {
       type: [storyboardSceneSchema],

--- a/server/tests/scriptIdeas.routes.test.js
+++ b/server/tests/scriptIdeas.routes.test.js
@@ -110,12 +110,23 @@ describe('Script Ideas API', () => {
       .set('Authorization', `Bearer ${token}`)
       .field('date', '2024-02-01T00:00:00.000Z')
       .field('location', '台北')
-      .field('scriptCount', '3')
+      .field('scriptCount', '2')
+      .field(
+        'scripts',
+        JSON.stringify([
+          { title: '腳本 A', paragraphs: ['第一段', '第二段'] }
+        ])
+      )
       .field('status', 'pending')
       .expect(201)
 
     expect(res.body.location).toBe('台北')
-    expect(res.body.scriptCount).toBe(3)
+    expect(res.body.scriptCount).toBe(2)
+    expect(Array.isArray(res.body.scripts)).toBe(true)
+    expect(res.body.scripts).toHaveLength(2)
+    expect(res.body.scripts[0]).toMatchObject({ title: '腳本 A' })
+    expect(res.body.scripts[0].paragraphs).toEqual(['第一段', '第二段'])
+    expect(res.body.scripts[1]).toMatchObject({ title: '', paragraphs: [] })
     ideaId = res.body._id
   })
 
@@ -147,6 +158,13 @@ describe('Script Ideas API', () => {
       .set('Authorization', `Bearer ${token}`)
       .field('summaryScript', '更新後腳本')
       .field('headline', '更新後標題')
+      .field(
+        'scripts',
+        JSON.stringify([
+          { title: '腳本 A', paragraphs: ['第一段更新', '第二段更新'] },
+          { title: '腳本 B', paragraphs: ['B 段落'] }
+        ])
+      )
       .attach('video', videoPath)
       .expect(200)
 
@@ -155,6 +173,8 @@ describe('Script Ideas API', () => {
     expect(uploadFileMock).toHaveBeenCalled()
     expect(res.body.summaryScript).toBe('更新後腳本')
     expect(res.body.videoName).toBe('idea.mp4')
+    expect(res.body.scripts).toHaveLength(2)
+    expect(res.body.scripts[0].paragraphs).toEqual(['第一段更新', '第二段更新'])
   })
 
   it('取得腳本詳情時附帶簽署網址', async () => {
@@ -165,6 +185,7 @@ describe('Script Ideas API', () => {
 
     expect(getSignedUrlMock).toHaveBeenCalled()
     expect(res.body.videoUrl).toContain('https://signed.example.com/')
+    expect(res.body.scripts).toHaveLength(2)
   })
 
   it('移除影片並刪除腳本記錄', async () => {


### PR DESCRIPTION
## Summary
- add a dedicated scripts array schema to script ideas and normalize it through the controller
- update script idea endpoints to parse scripts payloads, align them with scriptCount, and keep cached responses consistent
- refresh the script ideas detail view and related tests to manage multiple scripts and verify multi-script scenarios on both client and server

## Testing
- cd server && npm run test *(fails: jest binary missing because server dependencies cannot be installed in the sandbox)*
- cd client && npm run test *(fails: existing AdData.vue tests still fail; ScriptIdeas suites pass within the run)*

------
https://chatgpt.com/codex/tasks/task_e_68f3527a39008329b571b72e5f8eef62