### PR TITLE
新增素材刪除紀錄與自動清理排程

### DIFF
--- a/client/src/components/assets/AssetDeletionLogList.test.js
+++ b/client/src/components/assets/AssetDeletionLogList.test.js
@@ -1,0 +1,40 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import AssetDeletionLogList from './AssetDeletionLogList.vue'
+import { fetchAssetDeletionLogs } from '../../services/assets'
+
+vi.mock('../../services/assets', () => ({
+  fetchAssetDeletionLogs: vi.fn()
+}))
+
+describe('AssetDeletionLogList', () => {
+  beforeEach(() => {
+    fetchAssetDeletionLogs.mockReset()
+  })
+
+  it('renders deletion logs returned by API', async () => {
+    fetchAssetDeletionLogs.mockResolvedValue({
+      data: [
+        {
+          id: '1',
+          originalFilename: 'demo.mp4',
+          method: 'manual-single',
+          deletedAt: '2024-01-01T10:00:00.000Z',
+          deletedBy: { name: '管理員' }
+        }
+      ],
+      pagination: { total: 1, page: 1, limit: 10 }
+    })
+
+    const wrapper = mount(AssetDeletionLogList, {
+      props: { visible: true }
+    })
+
+    await flushPromises()
+
+    expect(fetchAssetDeletionLogs).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('demo.mp4')
+    expect(wrapper.text()).toContain('手動刪除')
+    expect(wrapper.text()).toContain('管理員')
+  })
+})

--- a/client/src/components/assets/AssetDeletionLogList.vue
+++ b/client/src/components/assets/AssetDeletionLogList.vue
@@ -1,0 +1,275 @@
+<template>
+  <div v-if="visible" class="deletion-log-panel">
+    <p class="retention-hint">系統會自動保留素材刪除紀錄 {{ retentionDays }} 天，逾期素材將於離峰時段自動清除。</p>
+
+    <div class="filter-row">
+      <label>
+        開始日期
+        <input type="date" v-model="startDate" />
+      </label>
+      <label>
+        結束日期
+        <input type="date" v-model="endDate" />
+      </label>
+      <div class="filter-actions">
+        <button class="primary" type="button" @click="applyFilters" :disabled="loading">
+          套用
+        </button>
+        <button class="ghost" type="button" @click="resetFilters" :disabled="loading">
+          清除
+        </button>
+      </div>
+    </div>
+
+    <div v-if="loading" class="loading-state">正在取得刪除紀錄...</div>
+    <div v-else>
+      <table v-if="logs.length" class="log-table">
+        <thead>
+          <tr>
+            <th>刪除時間</th>
+            <th>原始檔名</th>
+            <th>執行方式</th>
+            <th>操作人員</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="item in logs" :key="item.id">
+            <td>{{ formatDate(item.deletedAt) }}</td>
+            <td class="filename">{{ item.originalFilename }}</td>
+            <td>{{ formatMethod(item.method) }}</td>
+            <td>{{ item.deletedBy?.name || '—' }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-else class="empty-state">目前沒有符合條件的刪除紀錄。</p>
+    </div>
+
+    <div v-if="totalPages > 1" class="pagination">
+      <button type="button" @click="changePage(currentPage - 1)" :disabled="currentPage === 1 || loading">
+        上一頁
+      </button>
+      <span>第 {{ currentPage }} / {{ totalPages }} 頁</span>
+      <button type="button" @click="changePage(currentPage + 1)" :disabled="currentPage === totalPages || loading">
+        下一頁
+      </button>
+    </div>
+
+    <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import { fetchAssetDeletionLogs } from '../../services/assets'
+
+const props = defineProps({
+  visible: {
+    type: Boolean,
+    default: false
+  },
+  retentionDays: {
+    type: Number,
+    default: 90
+  },
+  pageSize: {
+    type: Number,
+    default: 10
+  }
+})
+
+const startDate = ref('')
+const endDate = ref('')
+const currentPage = ref(1)
+const total = ref(0)
+const logs = ref([])
+const loading = ref(false)
+const errorMessage = ref('')
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / props.pageSize)))
+
+const buildParams = () => {
+  const params = { page: currentPage.value, limit: props.pageSize }
+  if (startDate.value) params.startDate = startDate.value
+  if (endDate.value) params.endDate = endDate.value
+  return params
+}
+
+const loadLogs = async () => {
+  if (!props.visible) return
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const response = await fetchAssetDeletionLogs(buildParams())
+    logs.value = Array.isArray(response.data) ? response.data : []
+    total.value = response.pagination?.total || 0
+  } catch (error) {
+    errorMessage.value = typeof error === 'string' ? error : '刪除紀錄取得失敗'
+    logs.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+const applyFilters = () => {
+  currentPage.value = 1
+  loadLogs()
+}
+
+const resetFilters = () => {
+  startDate.value = ''
+  endDate.value = ''
+  currentPage.value = 1
+  loadLogs()
+}
+
+const changePage = (page) => {
+  if (page < 1 || page > totalPages.value) return
+  currentPage.value = page
+  loadLogs()
+}
+
+const formatDate = (value) => {
+  if (!value) return '—'
+  return new Date(value).toLocaleString('zh-TW', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+const formatMethod = (method) => {
+  const map = {
+    'manual-single': '手動刪除',
+    'manual-bulk': '批次刪除',
+    scheduled: '排程清理'
+  }
+  return map[method] || method || '—'
+}
+
+watch(() => props.visible, (visible) => {
+  if (visible) {
+    loadLogs()
+  }
+})
+
+onMounted(() => {
+  if (props.visible) {
+    loadLogs()
+  }
+})
+</script>
+
+<style scoped>
+.deletion-log-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.retention-hint {
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.filter-row label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  color: #1e293b;
+}
+
+.filter-row input[type='date'] {
+  margin-top: 0.25rem;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.filter-actions button {
+  padding: 0.45rem 0.9rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border: none;
+}
+
+.filter-actions .primary {
+  background-color: #2563eb;
+  color: #fff;
+}
+
+.filter-actions .ghost {
+  background-color: transparent;
+  color: #2563eb;
+  border: 1px solid #2563eb;
+}
+
+.loading-state,
+.empty-state,
+.error-message {
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.error-message {
+  color: #dc2626;
+}
+
+.log-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.log-table th,
+.log-table td {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.log-table th {
+  background-color: #f1f5f9;
+  color: #1e293b;
+}
+
+.log-table .filename {
+  word-break: break-all;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+.pagination button {
+  padding: 0.3rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
+  background-color: white;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+</style>

--- a/client/src/services/assets.js
+++ b/client/src/services/assets.js
@@ -177,3 +177,6 @@ export const deleteAssetsBulk = ids =>
 
 export const getBatchDownloadProgress = id =>
   api.get(`/assets/batch-download/${id}`).then(res => res.data)
+
+export const fetchAssetDeletionLogs = (params = {}) =>
+  api.get('/assets/deletion-logs', { params }).then(res => res.data)

--- a/client/src/views/AssetLibrary.vue
+++ b/client/src/views/AssetLibrary.vue
@@ -19,6 +19,13 @@
             v-tooltip.bottom="'重新整理'"
           />
           <Button
+            icon="pi pi-history"
+            label="刪除紀錄"
+            class="action-btn secondary"
+            @click="openDeletionLogs"
+            v-tooltip.bottom="'查看自動與手動刪除紀錄'"
+          />
+          <Button
             icon="pi pi-upload"
             label="上傳素材"
             class="action-btn primary"
@@ -378,9 +385,9 @@
 
     <Dialog v-model:visible="previewVisible" :header="previewItem?.name" class="preview-dialog" :modal="true">
       <div class="preview-content">
-        <img 
-          v-if="isImage(previewItem)" 
-          :src="previewItem.url" 
+        <img
+          v-if="isImage(previewItem)"
+          :src="previewItem.url"
           class="preview-media" 
           alt="預覽圖片"
         />
@@ -397,6 +404,15 @@
         </div>
       </div>
     </Dialog>
+    <Dialog
+      v-model:visible="showDeletionLogs"
+      header="刪除紀錄"
+      class="log-dialog"
+      :modal="true"
+      :style="{ width: '60vw', maxWidth: '900px' }"
+    >
+      <AssetDeletionLogList :visible="showDeletionLogs" :retention-days="RETENTION_DAYS" />
+    </Dialog>
   </div>
 </template>
 
@@ -411,6 +427,7 @@ import { useUploadStore } from '../stores/upload'
 import { fetchUsers } from '../services/user'
 import { fetchTags } from '../services/tags'
 import { useProgressStore } from '../stores/progress'
+import AssetDeletionLogList from '../components/assets/AssetDeletionLogList.vue'
 
 import Toolbar from 'primevue/toolbar'
 import Button from 'primevue/button'
@@ -453,6 +470,8 @@ const previewItem = ref(null)
 const moveDialog = ref(false)
 const targetFolder = ref(null)
 const folderOptions = ref([])
+const showDeletionLogs = ref(false)
+const RETENTION_DAYS = 90
 
 const expandedItems = ref(new Set())
 const TRUNCATE_LENGTH = 60
@@ -515,6 +534,10 @@ const getItemIcon = (item) => {
 
 const triggerUpload = () => {
   fileUploadRef.value?.$el.querySelector('input[type="file"]')?.click()
+}
+
+const openDeletionLogs = () => {
+  showDeletionLogs.value = true
 }
 
 const focusFolderInput = () => {
@@ -1373,6 +1396,11 @@ watch(filterTags, () => loadData(currentFolder.value?._id), { deep: true })
 .preview-dialog {
   width: 90vw;
   max-width: 800px;
+}
+
+.log-dialog :deep(.p-dialog-content) {
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 .dialog-form {

--- a/server/src/controllers/asset.controller.js
+++ b/server/src/controllers/asset.controller.js
@@ -17,6 +17,8 @@ import { includeManagers } from '../utils/includeManagers.js'
 import { getCache, setCache, clearCacheByPrefix, delCache } from '../utils/cache.js'
 import { clearDashboardCache } from './dashboard.controller.js'
 import logger from '../config/logger.js'
+import AssetDeletionLog from '../models/assetDeletionLog.model.js'
+import { deleteAssetsByIds, DeletionMethod } from '../services/assetDeletion.service.js'
 
 const parseTags = (t) => {
   if (!t) return []
@@ -241,16 +243,15 @@ export const reviewAsset = async (req, res) => {
 }
 
 export const deleteAsset = async (req, res) => {
-  const asset = await Asset.findByIdAndDelete(req.params.id)
-  if (asset?.folderId) {
-    await Folder.updateOne({ _id: asset.folderId }, { $set: { updatedAt: new Date() } })
-    const parents = await getAncestorFolderIds(asset.folderId)
-  if (parents.length) {
-      await Folder.updateMany({ _id: { $in: parents } }, { $set: { updatedAt: new Date() } })
-    }
+  const result = await deleteAssetsByIds([req.params.id], {
+    method: DeletionMethod.MANUAL_SINGLE,
+    deletedBy: req.user?._id || null
+  })
+
+  if (!result.deletedCount) {
+    return res.status(404).json({ message: t('ASSET_NOT_FOUND') })
   }
-  await clearCacheByPrefix('assets:')
-  await clearDashboardCache()
+
   res.json({ message: t('ASSET_DELETED') })
 }
 
@@ -517,19 +518,68 @@ export const deleteAssets = async (req, res) => {
     return res.status(400).json({ message: t('PARAMS_ERROR') })
   }
 
-  const assets = await Asset.find({ _id: { $in: ids } })
-  await Asset.deleteMany({ _id: { $in: ids } })
+  const result = await deleteAssetsByIds(ids, {
+    method: DeletionMethod.MANUAL_BULK,
+    deletedBy: req.user?._id || null
+  })
 
-  const folderIds = [...new Set(assets.map(a => a.folderId).filter(Boolean).map(id => id.toString()))]
-  for (const id of folderIds) {
-    await Folder.updateOne({ _id: id }, { $set: { updatedAt: new Date() } })
-    const parents = await getAncestorFolderIds(id)
-    if (parents.length) {
-      await Folder.updateMany({ _id: { $in: parents } }, { $set: { updatedAt: new Date() } })
+  res.json({ message: t('DELETED'), deletedCount: result.deletedCount })
+}
+
+export const getAssetDeletionLogs = async (req, res) => {
+  const page = Math.max(parseInt(req.query.page, 10) || 1, 1)
+  const limit = Math.min(parseInt(req.query.limit, 10) || 20, 100)
+  const filter = {}
+
+  const parseDate = (value, endOfDay = false) => {
+    if (!value) return null
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return null
+    if (endOfDay) {
+      date.setHours(23, 59, 59, 999)
+    } else {
+      date.setHours(0, 0, 0, 0)
     }
+    return date
   }
 
-  await clearCacheByPrefix('assets:')
-  await clearDashboardCache()
-  res.json({ message: t('DELETED') })
+  const start = parseDate(req.query.startDate)
+  const end = parseDate(req.query.endDate, true)
+  if (start || end) {
+    filter.deletedAt = {}
+    if (start) filter.deletedAt.$gte = start
+    if (end) filter.deletedAt.$lte = end
+  }
+
+  if (req.query.method && Object.values(DeletionMethod).includes(req.query.method)) {
+    filter.method = req.query.method
+  }
+
+  const [logs, total] = await Promise.all([
+    AssetDeletionLog.find(filter)
+      .sort({ deletedAt: -1 })
+      .skip((page - 1) * limit)
+      .limit(limit)
+      .populate('deletedBy', 'username name'),
+    AssetDeletionLog.countDocuments(filter)
+  ])
+
+  res.json({
+    data: logs.map(log => ({
+      id: log._id,
+      assetId: log.assetId,
+      originalFilename: log.originalFilename,
+      deletedAt: log.deletedAt,
+      method: log.method,
+      deletedBy: log.deletedBy ? {
+        id: log.deletedBy._id,
+        name: log.deletedBy.name || log.deletedBy.username
+      } : null
+    })),
+    pagination: {
+      page,
+      limit,
+      total
+    }
+  })
 }

--- a/server/src/models/assetDeletionLog.model.js
+++ b/server/src/models/assetDeletionLog.model.js
@@ -1,0 +1,37 @@
+import mongoose from 'mongoose'
+
+const assetDeletionLogSchema = new mongoose.Schema(
+  {
+    assetId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Asset',
+      required: true
+    },
+    originalFilename: {
+      type: String,
+      required: true
+    },
+    method: {
+      type: String,
+      enum: ['manual-single', 'manual-bulk', 'scheduled'],
+      required: true
+    },
+    deletedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      default: null
+    },
+    deletedAt: {
+      type: Date,
+      default: Date.now
+    }
+  },
+  {
+    versionKey: false
+  }
+)
+
+assetDeletionLogSchema.index({ deletedAt: -1 })
+assetDeletionLogSchema.index({ assetId: 1 })
+
+export default mongoose.model('AssetDeletionLog', assetDeletionLogSchema)

--- a/server/src/routes/asset.routes.js
+++ b/server/src/routes/asset.routes.js
@@ -18,7 +18,8 @@ import {
   createAsset,
     batchDownload,
     getBatchDownloadProgress,
-    deleteAssets
+    deleteAssets,
+    getAssetDeletionLogs
 } from '../controllers/asset.controller.js'
 import {
   getAssetStages,
@@ -45,6 +46,12 @@ router.post('/', protect, requirePerm(PERMISSIONS.ASSET_CREATE), asyncHandler(cr
 router.post('/batch-download', protect, asyncHandler(batchDownload))
 router.get('/batch-download/:id', protect, asyncHandler(getBatchDownloadProgress))
 router.get('/', protect, requirePerm(PERMISSIONS.ASSET_READ), asyncHandler(getAssets))
+router.get(
+  '/deletion-logs',
+  protect,
+  requirePerm(PERMISSIONS.ASSET_READ),
+  asyncHandler(getAssetDeletionLogs)
+)
 router.post(
   '/:id/comment',
   protect,

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -20,6 +20,7 @@ import mongoose                    from 'mongoose'
 import connectDB                   from './config/db.js'
 import { notFound, errorHandler }  from './utils/handleError.js'
 import AdDaily                     from './models/adDaily.model.js'
+import { scheduleAssetCleanup }    from './services/assetCleanupScheduler.js'
 
 /* ────────────────────────── 0. Service-Account 還原 ───────────────────────── */
 const base64Key = process.env.GCS_KEY_JSON || process.env.GCP_SA_KEY
@@ -132,3 +133,5 @@ const PORT = process.env.PORT || 3000
 app.listen(PORT, () => {
   console.log(`🚀 Server running at http://localhost:${PORT}`)
 })
+
+scheduleAssetCleanup()

--- a/server/src/services/assetCleanupScheduler.js
+++ b/server/src/services/assetCleanupScheduler.js
@@ -1,0 +1,61 @@
+import logger from '../config/logger.js'
+import { deleteExpiredAssets, DeletionMethod } from './assetDeletion.service.js'
+
+const TARGET_HOUR = 3
+const TARGET_MINUTE = 30
+
+export const runAssetCleanup = async () => {
+  try {
+    const result = await deleteExpiredAssets({ days: 90, method: DeletionMethod.SCHEDULED })
+    logger.info(`Scheduled asset cleanup finished. Removed: ${result.deletedCount}`)
+    return result
+  } catch (error) {
+    logger.error('Scheduled asset cleanup failed', error)
+    throw error
+  }
+}
+
+const computeDelay = () => {
+  const now = new Date()
+  const next = new Date(now)
+  next.setHours(TARGET_HOUR, TARGET_MINUTE, 0, 0)
+  if (next <= now) {
+    next.setDate(next.getDate() + 1)
+  }
+  return next.getTime() - now.getTime()
+}
+
+const scheduleNextRun = () => {
+  const delay = computeDelay()
+  logger.info(`Next asset cleanup scheduled in ${Math.round(delay / 1000 / 60)} minutes.`)
+  return setTimeout(async () => {
+    await runAssetCleanup()
+    scheduleNextRun()
+  }, delay)
+}
+
+let timerRef = null
+
+export const scheduleAssetCleanup = () => {
+  if (process.env.NODE_ENV === 'test') {
+    return null
+  }
+  if (timerRef) {
+    clearTimeout(timerRef)
+  }
+  timerRef = scheduleNextRun()
+  return timerRef
+}
+
+export const cancelAssetCleanupSchedule = () => {
+  if (timerRef) {
+    clearTimeout(timerRef)
+    timerRef = null
+  }
+}
+
+export default {
+  scheduleAssetCleanup,
+  cancelAssetCleanupSchedule,
+  runAssetCleanup
+}

--- a/server/src/services/assetDeletion.service.js
+++ b/server/src/services/assetDeletion.service.js
@@ -1,0 +1,85 @@
+import Asset from '../models/asset.model.js'
+import AssetDeletionLog from '../models/assetDeletionLog.model.js'
+import Folder from '../models/folder.model.js'
+import { getAncestorFolderIds } from '../utils/folderTree.js'
+import { clearCacheByPrefix } from '../utils/cache.js'
+import { clearDashboardCache } from '../controllers/dashboard.controller.js'
+import logger from '../config/logger.js'
+
+const MANUAL_SINGLE = 'manual-single'
+const MANUAL_BULK = 'manual-bulk'
+const SCHEDULED = 'scheduled'
+
+const touchFolderHierarchy = async (folderId) => {
+  if (!folderId) return
+  await Folder.updateOne({ _id: folderId }, { $set: { updatedAt: new Date() } })
+  const parents = await getAncestorFolderIds(folderId)
+  if (parents.length) {
+    await Folder.updateMany({ _id: { $in: parents } }, { $set: { updatedAt: new Date() } })
+  }
+}
+
+const persistDeletionLogs = async (assets, method, deletedBy = null) => {
+  if (!assets.length) return
+  const now = new Date()
+  const docs = assets.map(asset => ({
+    assetId: asset._id,
+    originalFilename: asset.filename,
+    method,
+    deletedBy,
+    deletedAt: now
+  }))
+  await AssetDeletionLog.insertMany(docs, { ordered: false })
+}
+
+const deleteAssetDocuments = async (assets, { method, deletedBy } = {}) => {
+  if (!assets.length) return { deletedCount: 0, deletedIds: [] }
+
+  const deletedIds = []
+  for (const asset of assets) {
+    await Asset.deleteOne({ _id: asset._id })
+    await touchFolderHierarchy(asset.folderId)
+    deletedIds.push(asset._id.toString())
+  }
+
+  await persistDeletionLogs(assets, method, deletedBy)
+  await clearCacheByPrefix('assets:')
+  await clearDashboardCache()
+  logger.info(`Asset deletion completed by ${method}: ${deletedIds.length} item(s) removed.`)
+  return { deletedCount: deletedIds.length, deletedIds }
+}
+
+export const deleteAssetsByIds = async (ids, { method = MANUAL_SINGLE, deletedBy = null } = {}) => {
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return { deletedCount: 0, deletedIds: [] }
+  }
+  const assets = await Asset.find({ _id: { $in: ids } })
+  if (!assets.length) {
+    return { deletedCount: 0, deletedIds: [] }
+  }
+  return deleteAssetDocuments(assets, { method, deletedBy })
+}
+
+export const deleteExpiredAssets = async ({ days = 90, method = SCHEDULED } = {}) => {
+  const threshold = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+  const assets = await Asset.find({ createdAt: { $lt: threshold } })
+  if (!assets.length) {
+    logger.info('Asset cleanup job executed: no expired assets found.')
+    return { deletedCount: 0, deletedIds: [] }
+  }
+  const result = await deleteAssetDocuments(assets, { method, deletedBy: null })
+  logger.info(`Asset cleanup job removed ${result.deletedCount} asset(s) older than ${days} days.`)
+  return result
+}
+
+export const DeletionMethod = {
+  MANUAL_SINGLE,
+  MANUAL_BULK,
+  SCHEDULED
+}
+
+export default {
+  deleteAssetsByIds,
+  deleteExpiredAssets,
+  DeletionMethod
+}

--- a/server/tests/assetCleanupScheduler.test.js
+++ b/server/tests/assetCleanupScheduler.test.js
@@ -1,0 +1,46 @@
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import Asset from '../src/models/asset.model.js'
+import AssetDeletionLog from '../src/models/assetDeletionLog.model.js'
+import { runAssetCleanup } from '../src/services/assetCleanupScheduler.js'
+
+let mongo
+
+describe('asset cleanup scheduler', () => {
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test'
+    mongo = await MongoMemoryServer.create()
+    await mongoose.connect(mongo.getUri())
+  })
+
+  afterAll(async () => {
+    await mongoose.disconnect()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    await Asset.deleteMany({})
+    await AssetDeletionLog.deleteMany({})
+  })
+
+  it('removes assets older than 90 days and records logs', async () => {
+    const oldAsset = await Asset.create({ filename: 'old.mp4', path: '/tmp/old.mp4', type: 'raw' })
+    await Asset.updateOne(
+      { _id: oldAsset._id },
+      { createdAt: new Date(Date.now() - 100 * 24 * 60 * 60 * 1000) }
+    )
+    const recentAsset = await Asset.create({ filename: 'recent.mp4', path: '/tmp/recent.mp4', type: 'raw' })
+
+    const result = await runAssetCleanup()
+
+    const removed = await Asset.findById(oldAsset._id)
+    const remained = await Asset.findById(recentAsset._id)
+    const logs = await AssetDeletionLog.find({ assetId: oldAsset._id })
+
+    expect(result.deletedCount).toBe(1)
+    expect(removed).toBeNull()
+    expect(remained).not.toBeNull()
+    expect(logs).toHaveLength(1)
+    expect(logs[0].method).toBe('scheduled')
+  })
+})


### PR DESCRIPTION
## Summary
- 新增素材刪除紀錄資料模型與共用刪除服務，並更新素材刪除 API 與查詢端點。
- 建立每日排程於離峰時段清除 90 天前素材並同步寫入刪除紀錄。
- 前端加入刪除紀錄對話框與 API 封裝，並撰寫對應的 Vitest 測試。

## Testing
- ⚠️ `npm test --prefix server`（環境限制無法安裝必要套件，Jest 不存在）
- ❌ `npm test --prefix client`（現有 AdData 測試失敗與本次修改無關）
- ✅ `cd client && npx vitest run src/components/assets/AssetDeletionLogList.test.js`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d56239b3883299841275bb371ce20)