### PR TITLE
新增儀表板摘要分頁與前端切換介面

### DIFF
--- a/client/src/services/dashboard.js
+++ b/client/src/services/dashboard.js
@@ -6,3 +6,10 @@ export const fetchDailyData = (days, clientId, platformId) => {
   if (platformId) params.platformId = platformId
   return api.get('/dashboard/daily', { params }).then(r => r.data)
 }
+
+export const fetchDashboardSummary = ({ page, pageSize } = {}) => {
+  const params = {}
+  if (page) params.page = page
+  if (pageSize) params.pageSize = pageSize
+  return api.get('/dashboard/summary', { params }).then(r => r.data)
+}

--- a/client/src/views/Dashboard.test.js
+++ b/client/src/views/Dashboard.test.js
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+
+const fetchDashboardSummaryMock = vi.fn()
+const fetchProductStagesMock = vi.fn(() => Promise.resolve([]))
+const updateProductStageMock = vi.fn(() => Promise.resolve({}))
+const updateProductMock = vi.fn(() => Promise.resolve({}))
+
+vi.mock('../services/dashboard', () => ({
+  fetchDashboardSummary: fetchDashboardSummaryMock
+}));
+
+vi.mock('../services/products', () => ({
+  fetchProductStages: fetchProductStagesMock,
+  updateProductStage: updateProductStageMock,
+  updateProduct: updateProductMock
+}));
+
+const ButtonStub = defineComponent({
+  name: 'Button',
+  props: ['label', 'icon', 'iconPos', 'disabled'],
+  emits: ['click'],
+  setup(props, { emit, slots, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: ['button-stub', attrs.class].filter(Boolean).join(' '),
+          disabled: props.disabled ?? attrs.disabled ?? false,
+          onClick: (event) => {
+            if (props.disabled ?? attrs.disabled) return
+            emit('click', event)
+            attrs.onClick?.(event)
+          }
+        },
+        slots.default?.() || props.label || props.icon || 'button'
+      )
+  }
+})
+
+const CardStub = defineComponent({
+  name: 'Card',
+  setup(_, { slots }) {
+    return () =>
+      h('section', { class: 'card-stub' }, [slots.title?.(), slots.content?.(), slots.default?.()])
+  }
+})
+
+const DataTableStub = defineComponent({
+  name: 'DataTable',
+  props: ['value', 'paginator', 'rows', 'totalRecords', 'first', 'rowsPerPageOptions'],
+  emits: ['page'],
+  setup(props, { slots, emit }) {
+    return () =>
+      h('div', { class: 'datatable-stub' }, [
+        h(
+          'button',
+          {
+            class: 'datatable-page-trigger',
+            onClick: () => emit('page', { page: 1, rows: props.rows || 20 })
+          },
+          'page'
+        ),
+        slots.default?.()
+      ])
+  }
+})
+
+const ColumnStub = defineComponent({
+  name: 'Column',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'column-stub' }, slots.default?.())
+  }
+})
+
+const TagStub = defineComponent({
+  name: 'Tag',
+  props: ['value', 'severity'],
+  setup(props) {
+    return () => h('span', { class: `tag-stub ${props.severity || ''}` }, props.value)
+  }
+})
+
+const DialogStub = defineComponent({
+  name: 'Dialog',
+  props: ['visible'],
+  emits: ['update:visible'],
+  setup(props, { slots }) {
+    return () => (props.visible ? h('div', { class: 'dialog-stub' }, [slots.default?.(), slots.footer?.()]) : null)
+  }
+})
+
+const CheckboxStub = defineComponent({
+  name: 'Checkbox',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h('input', {
+        type: 'checkbox',
+        class: ['checkbox-stub', attrs.class].filter(Boolean).join(' '),
+        checked: props.modelValue,
+        onChange: (event) => emit('update:modelValue', event.target.checked)
+      })
+  }
+})
+
+const ProgressBarStub = defineComponent({
+  name: 'ProgressBar',
+  props: ['value'],
+  setup(props) {
+    return () => h('div', { class: 'progressbar-stub' }, `${props.value ?? 0}`)
+  }
+})
+
+const InputTextStub = defineComponent({
+  name: 'InputText',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('input', {
+        value: props.modelValue ?? '',
+        onInput: (event) => emit('update:modelValue', event.target.value)
+      })
+  }
+})
+
+const DropdownStub = defineComponent({
+  name: 'Dropdown',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('select', {
+        value: props.modelValue ?? '',
+        onChange: (event) => emit('update:modelValue', event.target.value)
+      })
+  }
+})
+
+const DatePickerStub = defineComponent({
+  name: 'DatePicker',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('input', {
+        type: 'date',
+        value: props.modelValue ?? '',
+        onInput: (event) => emit('update:modelValue', event.target.value)
+      })
+  }
+})
+
+const globalStubs = {
+  Button: ButtonStub,
+  Card: CardStub,
+  DataTable: DataTableStub,
+  Column: ColumnStub,
+  Tag: TagStub,
+  Dialog: DialogStub,
+  Checkbox: CheckboxStub,
+  ProgressBar: ProgressBarStub,
+  InputText: InputTextStub,
+  Dropdown: DropdownStub,
+  DatePicker: DatePickerStub
+}
+
+const mountDashboard = async () => {
+  const Dashboard = (await import('./Dashboard.vue')).default
+  const wrapper = mount(Dashboard, {
+    global: {
+      stubs: globalStubs,
+      directives: {
+        tooltip: () => {}
+      }
+    }
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('Dashboard 分頁摘要', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    fetchDashboardSummaryMock.mockReset()
+    fetchDashboardSummaryMock.mockResolvedValue({
+      recentAssets: [],
+      recentReviews: [],
+      recentProducts: {
+        items: [
+          { _id: 'p1', fileName: 'A.mp4', progress: { done: 0, total: 1 } }
+        ],
+        total: 25,
+        page: 1,
+        pageSize: 20
+      },
+      assetStats: {}
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('初始化時載入分頁資料', async () => {
+    const wrapper = await mountDashboard()
+    await flushPromises()
+
+    expect(fetchDashboardSummaryMock).toHaveBeenCalledWith({ page: 1, pageSize: 20 })
+
+    const dataTable = wrapper.findComponent(DataTableStub)
+    expect(dataTable.props('value')).toHaveLength(1)
+    expect(dataTable.props('totalRecords')).toBe(25)
+
+    wrapper.unmount()
+  })
+
+  it('切換分頁時重新載入資料', async () => {
+    fetchDashboardSummaryMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        recentAssets: [],
+        recentReviews: [],
+        recentProducts: {
+          items: Array.from({ length: 20 }, (_, index) => ({
+            _id: `p${index + 1}`,
+            fileName: `P${index + 1}`,
+            progress: { done: 0, total: 1 }
+          })),
+          total: 30,
+          page: 1,
+          pageSize: 20
+        },
+        assetStats: {}
+      })
+    )
+    fetchDashboardSummaryMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        recentAssets: [],
+        recentReviews: [],
+        recentProducts: {
+          items: [{ _id: 'p21', fileName: 'P21', progress: { done: 1, total: 1 } }],
+          total: 30,
+          page: 2,
+          pageSize: 20
+        },
+        assetStats: {}
+      })
+    )
+    
+    const wrapper = await mountDashboard()
+    await flushPromises()
+
+    const dataTable = wrapper.findComponent(DataTableStub)
+    await dataTable.vm.$emit('page', { page: 1, rows: 20 })
+    await flushPromises()
+
+    expect(fetchDashboardSummaryMock).toHaveBeenLastCalledWith({ page: 2, pageSize: 20 })
+
+    const updatedTable = wrapper.findComponent(DataTableStub)
+    expect(updatedTable.props('value')[0]._id).toBe('p21')
+
+    wrapper.unmount()
+  })
+})

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -65,10 +65,19 @@
           <template #content>
             <div v-if="!isMobile" class="table-container">
               <DataTable
+                :key="refreshKey"
                 :value="recentProducts"
+                :lazy="true"
+                :paginator="true"
+                :rows="pagination.pageSize"
+                :totalRecords="pagination.total"
+                :first="firstProductRow"
+                :rowsPerPageOptions="[10, 20, 30, 50]"
                 responsiveLayout="scroll"
                 emptyMessage="尚無成品"
                 class="modern-table"
+                paginatorTemplate="FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown"
+                @page="onProductPage"
               >
                 <Column field="createdAt" header="上傳時間" style="min-width: 150px">
                   <template #body="{ data }">
@@ -159,6 +168,24 @@
                     />
                   </div>
                 </div>
+              </div>
+              <div class="mobile-pagination">
+                <Button
+                  label="上一頁"
+                  icon="pi pi-arrow-left"
+                  class="p-button-text"
+                  :disabled="!canPrevPage"
+                  @click="goToPreviousPage"
+                />
+                <span class="mobile-page-indicator">第 {{ pagination.page }} / {{ totalPages }} 頁</span>
+                <Button
+                  label="下一頁"
+                  icon="pi pi-arrow-right"
+                  iconPos="right"
+                  class="p-button-text"
+                  :disabled="!canNextPage"
+                  @click="goToNextPage"
+                />
               </div>
             </div>
           </template>
@@ -359,9 +386,9 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, nextTick } from 'vue'
-import api from '../services/api'
+import { ref, onMounted, onUnmounted, nextTick, reactive, computed } from 'vue'
 import { fetchProductStages, updateProductStage, updateProduct } from '../services/products'
+import { fetchDashboardSummary } from '../services/dashboard'
 
 import Card from 'primevue/card'
 import Button from 'primevue/button'
@@ -386,6 +413,20 @@ const stageList = ref([])
 let currentProductId = null
 let dashboardTimer = null
 const isMobile = ref(window.innerWidth <= 991)
+
+const pagination = reactive({
+  page: 1,
+  pageSize: 20,
+  total: 0
+})
+
+const firstProductRow = computed(() => (pagination.page - 1) * pagination.pageSize)
+const totalPages = computed(() => {
+  if (!pagination.total) return 1
+  return Math.max(Math.ceil(pagination.total / pagination.pageSize), 1)
+})
+const canPrevPage = computed(() => pagination.page > 1)
+const canNextPage = computed(() => pagination.page < totalPages.value)
 
 const handleResize = () => {
   isMobile.value = window.innerWidth <= 991
@@ -417,14 +458,45 @@ function saveLists() {
 }
 
 /* ===== API ===== */
-async function fetchDashboard() {
-  // recentProducts.value = null;
-  const { data } = await api.get('/dashboard/summary')
+async function fetchDashboard(page = pagination.page) {
+  const targetPage = Math.max(page, 1)
+  const data = await fetchDashboardSummary({ page: targetPage, pageSize: pagination.pageSize })
   recentAssets.value = structuredClone(data.recentAssets)
   recentReviews.value = structuredClone(data.recentReviews)
-  recentProducts.value = structuredClone(data.recentProducts) // 取得完整成品列表
+  const productPayload = data.recentProducts || { items: [], total: 0 }
+  recentProducts.value = structuredClone(productPayload.items || [])
+  pagination.total = productPayload.total ?? recentProducts.value.length
+  pagination.page = productPayload.page ?? targetPage
+  if (productPayload.pageSize) {
+    pagination.pageSize = productPayload.pageSize
+  }
+  if (!recentProducts.value.length && pagination.page > 1 && pagination.total) {
+    const finalPage = Math.max(Math.ceil(pagination.total / pagination.pageSize), 1)
+    if (finalPage !== pagination.page) {
+      await fetchDashboard(finalPage)
+      return
+    }
+  }
   assetStats.value = { ...data.assetStats }
   refreshKey.value++                         // 觸發 DataTable 重繪
+}
+
+function onProductPage(event) {
+  const nextPage = event.page + 1
+  const nextPageSize = event.rows
+  const sizeChanged = nextPageSize !== pagination.pageSize
+  pagination.pageSize = nextPageSize
+  if (nextPage !== pagination.page || sizeChanged) {
+    fetchDashboard(nextPage)
+  }
+}
+
+function goToPreviousPage() {
+  if (canPrevPage.value) fetchDashboard(pagination.page - 1)
+}
+
+function goToNextPage() {
+  if (canNextPage.value) fetchDashboard(pagination.page + 1)
 }
 
 /* ===== Stages Dialog ===== */
@@ -686,6 +758,19 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.mobile-pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.mobile-page-indicator {
+  font-weight: 600;
+  color: var(--text-color);
 }
 
 .mobile-card {

--- a/server/src/controllers/dashboard.controller.js
+++ b/server/src/controllers/dashboard.controller.js
@@ -5,9 +5,15 @@ import ReviewStage from '../models/reviewStage.model.js'
 import AdDaily from '../models/adDaily.model.js'
 import { getCache, setCache, clearCacheByPrefix } from '../utils/cache.js'
 import { t } from '../i18n/messages.js'
+import {
+  resolveSummaryPagination,
+  buildSummaryCacheKey,
+  buildProductAccessFilter
+} from '../services/dashboard.service.js'
 
 export const getSummary = async (req, res) => {
-  const cacheKey = `dashboard:${req.user._id}`
+  const { page, pageSize, skip, limit } = resolveSummaryPagination(req.query)
+  const cacheKey = buildSummaryCacheKey(req.user._id, page, pageSize)
   const cached = await getCache(cacheKey)
   if (cached) return res.json(cached)
 
@@ -51,26 +57,30 @@ export const getSummary = async (req, res) => {
     }))
 
   /* -------- 成品及進度 -------- */
-  const productDocs = await Asset.find({ type: 'edited' })
-    .sort({ createdAt: -1 })
-    .populate('uploadedBy', 'username name')
-    .lean()
-
-  const filteredProducts = productDocs.filter(p =>
-    !p.allowedUsers?.length || p.allowedUsers.some(id => id.equals(req.user._id))
-  )
+  const productFilter = buildProductAccessFilter(req.user._id)
+  const [totalProducts, productDocs] = await Promise.all([
+    Asset.countDocuments(productFilter),
+    Asset.find(productFilter)
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
+      .populate('uploadedBy', 'username name')
+      .lean()
+  ])
 
   const totalStages = await ReviewStage.countDocuments()
   const allStages = await ReviewStage.find().sort('order')
-  const ids = filteredProducts.map(p => p._id)
-  const progressRecords = await ReviewRecord.aggregate([
-    { $match: { assetId: { $in: ids }, completed: true } },
-    { $group: { _id: '$assetId', done: { $sum: 1 } } }
-  ])
+  const ids = productDocs.map(p => p._id)
+  const progressRecords = ids.length
+    ? await ReviewRecord.aggregate([
+        { $match: { assetId: { $in: ids }, completed: true } },
+        { $group: { _id: '$assetId', done: { $sum: 1 } } }
+      ])
+    : []
   const progressMap = {}
   progressRecords.forEach(r => { progressMap[r._id.toString()] = r.done })
 
-  const recentProducts = filteredProducts.map(p => {
+  const productItems = productDocs.map(p => {
     const done = progressMap[p._id.toString()] || 0
     const pendingStage = done < allStages.length ? allStages[done].name : null
     return {
@@ -110,6 +120,13 @@ export const getSummary = async (req, res) => {
   const assetStats = { rawTotal, editedTotal, pending, approved, rejected }
 
   /* -------- 統整 & 快取 -------- */
+  const recentProducts = {
+    items: productItems,
+    total: totalProducts,
+    page,
+    pageSize
+  }
+
   const result = { recentAssets, recentReviews, recentProducts, assetStats }
   await setCache(cacheKey, result, 60)   // 快取 60 秒
   res.json(result)

--- a/server/src/routes/dashboard.routes.js
+++ b/server/src/routes/dashboard.routes.js
@@ -2,10 +2,23 @@ import { Router } from 'express'
 import { protect } from '../middleware/auth.js'
 import { getSummary, getDaily } from '../controllers/dashboard.controller.js'
 import asyncHandler from '../utils/asyncHandler.js'
+import { query } from 'express-validator'
+import { validate } from '../middleware/validate.js'
 
 const router = Router()
 router.use(protect)
-router.get('/summary', asyncHandler(getSummary))
+router.get(
+  '/summary',
+  [
+    query('page').optional().isInt({ min: 1 }).withMessage('page 必須為正整數'),
+    query('pageSize')
+      .optional()
+      .isInt({ min: 1, max: 50 })
+      .withMessage('pageSize 必須介於 1 與 50 之間')
+  ],
+  validate,
+  asyncHandler(getSummary)
+)
 router.get('/daily', asyncHandler(getDaily))
 
 export default router

--- a/server/src/services/dashboard.service.js
+++ b/server/src/services/dashboard.service.js
@@ -1,0 +1,26 @@
+const DEFAULT_PAGE = 1
+const DEFAULT_PAGE_SIZE = 20
+const MAX_PAGE_SIZE = 50
+
+export const resolveSummaryPagination = (query = {}) => {
+  const page = Math.max(parseInt(query.page, 10) || DEFAULT_PAGE, 1)
+  const requestedPageSize = parseInt(query.pageSize, 10) || DEFAULT_PAGE_SIZE
+  const pageSize = Math.min(Math.max(requestedPageSize, 1), MAX_PAGE_SIZE)
+  const skip = (page - 1) * pageSize
+
+  return { page, pageSize, skip, limit: pageSize }
+}
+
+export const buildSummaryCacheKey = (userId, page, pageSize) =>
+  `dashboard:${userId}:p${page}:s${pageSize}`
+
+export const buildProductAccessFilter = (userId) => ({
+  type: 'edited',
+  $or: [
+    { allowedUsers: { $exists: false } },
+    { allowedUsers: { $eq: [] } },
+    { allowedUsers: null },
+    { allowedUsers: userId }
+  ]
+})
+

--- a/server/tests/dashboardAssetCache.test.js
+++ b/server/tests/dashboardAssetCache.test.js
@@ -77,7 +77,7 @@ test('summary updates after asset update', async () => {
     .get('/api/dashboard/summary')
     .set('Authorization', `Bearer ${token}`)
     .expect(200)
-  expect(first.body.recentProducts[0].finalChecked).toBe(false)
+  expect(first.body.recentProducts.items[0].finalChecked).toBe(false)
 
   await request(app)
     .put(`/api/assets/${id}`)
@@ -89,5 +89,37 @@ test('summary updates after asset update', async () => {
     .get('/api/dashboard/summary')
     .set('Authorization', `Bearer ${token}`)
     .expect(200)
-  expect(second.body.recentProducts[0].finalChecked).toBe(true)
+  expect(second.body.recentProducts.items[0].finalChecked).toBe(true)
+})
+
+test('summary pagination returns total count and respects page parameter', async () => {
+  const createPromises = []
+  for (let i = 0; i < 25; i++) {
+    createPromises.push(
+      request(app)
+        .post('/api/assets')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ filename: `paged-${i}.mp4`, path: `/tmp/paged-${i}.mp4`, type: 'edited' })
+        .expect(201)
+    )
+  }
+  await Promise.all(createPromises)
+
+  const page1 = await request(app)
+    .get('/api/dashboard/summary?page=1&pageSize=20')
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200)
+
+  expect(page1.body.recentProducts.total).toBeGreaterThanOrEqual(25)
+  expect(page1.body.recentProducts.items).toHaveLength(20)
+  expect(page1.body.recentProducts.page).toBe(1)
+
+  const page2 = await request(app)
+    .get('/api/dashboard/summary?page=2&pageSize=20')
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200)
+
+  expect(page2.body.recentProducts.page).toBe(2)
+  expect(page2.body.recentProducts.items.length).toBeGreaterThan(0)
+  expect(page2.body.recentProducts.items[0]._id).not.toBe(page1.body.recentProducts.items[0]._id)
 })

--- a/server/tests/dashboardSummaryProgress.test.js
+++ b/server/tests/dashboardSummaryProgress.test.js
@@ -57,8 +57,8 @@ test('summary reflects stage progress after update', async () => {
     .set('Authorization', `Bearer ${token}`)
     .expect(200)
 
-  expect(res1.body.recentProducts[0].progress.done).toBe(0)
-  expect(res1.body.recentProducts[0].pendingStage).toBe('S1')
+  expect(res1.body.recentProducts.items[0].progress.done).toBe(0)
+  expect(res1.body.recentProducts.items[0].pendingStage).toBe('S1')
 
   await request(app)
     .put(`/api/assets/${assetId}/stages/${stageId}`)
@@ -71,6 +71,6 @@ test('summary reflects stage progress after update', async () => {
     .set('Authorization', `Bearer ${token}`)
     .expect(200)
 
-  expect(res2.body.recentProducts[0].progress.done).toBe(1)
-  expect(res2.body.recentProducts[0].pendingStage).toBeNull()
+  expect(res2.body.recentProducts.items[0].progress.done).toBe(1)
+  expect(res2.body.recentProducts.items[0].pendingStage).toBeNull()
 })


### PR DESCRIPTION
## Summary
- 擴充儀表板摘要 API，新增分頁解析服務、驗證邏輯與快取鍵更新，確保僅抓取當前頁面資料
- 前端儀表板整合分頁狀態與 PrimeVue paginator／行動裝置切換按鈕，並透過服務層傳遞查詢參數
- 補齊後端與前端針對分頁流程的測試，包含 API 分頁驗證與 Vue 分頁互動模擬

## Testing
- npx vitest run src/views/Dashboard.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d561f03748329a5bc1ade87b09763)